### PR TITLE
Switch element parsing from OpenMM to QCElemental

### DIFF
--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -1499,8 +1499,8 @@ class TestForceFieldConstraints:
         """Check that the bonds in the molecule is correctly constrained."""
         for constraint_idx in range(system.getNumConstraints()):
             atom1_idx, atom2_idx, distance = system.getConstraintParameters(constraint_idx)
-            atom_elements = {molecule.atoms[atom1_idx].element.symbol,
-                             molecule.atoms[atom2_idx].element.symbol}
+            atom_elements = {molecule.atoms[atom1_idx].symbol,
+                             molecule.atoms[atom2_idx].symbol}
             assert atom_elements == bond_elements
             assert np.isclose(distance/unit.angstrom, bond_length/unit.angstrom)
 
@@ -1779,7 +1779,7 @@ class TestForceFieldParameterAssignment:
 
         # Give each atom a unique name, otherwise OpenMM will complain
         for idx, atom in enumerate(molecule.atoms):
-            atom.name = f'{atom.element.symbol}{idx}'
+            atom.name = f'{atom.symbol}{idx}'
         positions = molecule.conformers[0]
 
         off_gbsas  = {'HCT': 'test_forcefields/GBSA_HCT-1.0.offxml',
@@ -1940,7 +1940,7 @@ class TestForceFieldParameterAssignment:
 
         # Give each atom a unique name, otherwise OpenMM will complain
         for idx, atom in enumerate(molecule.atoms):
-            atom.name = f'{atom.element.symbol}{idx}'
+            atom.name = f'{atom.symbol}{idx}'
 
         positions = np.concatenate((molecule.conformers[0], molecule.conformers[0] + (10 * unit.angstrom)))
         # Create OpenFF System with the current toolkit.

--- a/openforcefield/topology/topology.py
+++ b/openforcefield/topology/topology.py
@@ -2077,7 +2077,7 @@ class Topology(Serializable):
                     # Set atom name
                     oe_atom.SetName(openmm_at.name)
                     # Set Symbol
-                    oe_atom.SetType(openmm_at.element.symbol)
+                    oe_atom.SetType(openmm_at.symbol)
                     # Set Atom index
                     oe_res.SetSerialNumber(openmm_at.index + 1)
                     # Commit the changes

--- a/openforcefield/typing/engines/smirnoff/parameters.py
+++ b/openforcefield/typing/engines/smirnoff/parameters.py
@@ -1726,7 +1726,7 @@ class ParameterHandler(_ParameterAttributeHandler):
                 for atom_idx in unassigned_tuple:
                     topology_atom = topology.atom(atom_idx)
                     unassigned_topology_atoms.append(topology_atom)
-                    unassigned_str += f"({topology_atom.atom.name} {topology_atom.atom.element.symbol}), "
+                    unassigned_str += f"({topology_atom.atom.name} {topology_atom.atom.symbol}), "
                 unassigned_topology_atom_tuples.append(tuple(unassigned_topology_atoms))
             err_msg += ("{parameter_handler} was not able to find parameters for the following valence terms:\n"
                         "{unassigned_str}").format(parameter_handler=cls.__name__,

--- a/openforcefield/utils/toolkits.py
+++ b/openforcefield/utils/toolkits.py
@@ -3832,7 +3832,7 @@ class AmberToolsToolkitWrapper(ToolkitWrapper):
             subprocess.check_output(["sqm", "-i", "sqm.in", "-o", "sqm.out", "-O"])
             # Ensure that antechamber/sqm did not change the indexing by checking against
             # an ordered list of element symbols for this molecule
-            expected_elements = [at.element.symbol for at in molecule.atoms]
+            expected_elements = [at.symbol for at in molecule.atoms]
             bond_orders = self._get_fractional_bond_orders_from_sqm_out('sqm.out',
                                                                             validate_elements=expected_elements)
 


### PR DESCRIPTION
I'm not convinced this is a good feature but I'm pushing it in case others find it valuable. I'm inclined to build element parsing in the System object off of QCElemental instead of OpenMM since it is much more lightweight and narrow. I wanted to see if this would be a big change for the toolkit and it doesn't seem to be.

There isn't anything particularly wrong with OpenMM's element module (I don't think - correct me if I'm wrong) and I don't think there's a major new feature that's enabled by this. The above benefits aside, the main change here is better compatibility with a future pydantic/QCElemental refactor. A downside is that this would add QCElemental as a hard dependency while removing OpenMM is not going to happen anytime soon, if ever. 

I don't intend for this to be included in 0.7.0 and it would be fine if this hangs until we work on a refactor that this would actually help.

### TODO

- [ ] Maybe alias `element.symbol` to `symbol` with a `DeprecationWarning` since it is an API break, although minor.
- [ ] Figure out a `from_mass` lookup, which may require monkeypatching or changing QCElemental's `periodictable` module.
- [ ] Add `QCElemental` as a dependency in the conda recipe
- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openforcefield/tree/master/openforcefield/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openforcefield/tree/master/docs), if applicable
- [ ] Update [changelog](https://github.com/openforcefield/openforcefield/blob/master/docs/releasehistory.rst)
