### PR TITLE
Testing updates

### DIFF
--- a/openforcefield/tests/conftest.py
+++ b/openforcefield/tests/conftest.py
@@ -458,6 +458,7 @@ def dinitrogen():
     dinitrogen.partial_charges = charges
     return dinitrogen
 
+
 @pytest.fixture(scope="function")
 def cis_1_2_dichloroethene():
     """
@@ -479,5 +480,3 @@ def cis_1_2_dichloroethene():
     cis_dichloroethene.add_bond(1, 4, 1, False)
     cis_dichloroethene.add_bond(2, 5, 1, False)
     return cis_dichloroethene
-
-

--- a/openforcefield/tests/conftest.py
+++ b/openforcefield/tests/conftest.py
@@ -19,7 +19,9 @@ This adds the following command line options.
 
 import logging
 
+import numpy as np
 import pytest
+from simtk import unit
 
 logger = logging.getLogger(__name__)
 
@@ -141,3 +143,341 @@ def pytest_collection_modifyitems(config, items):
                     "reason", ""
                 )
                 item.add_marker(pytest.mark.xfail(reason=reason))
+
+
+@pytest.fixture(scope="function")
+def ethane():
+    """
+    An ethane Molecule created from a SMILES string
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    return Molecule.from_smiles("CC")
+
+
+@pytest.fixture(scope="function")
+def ethene():
+    """
+    An ethene Molecule created from a SMILES string
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    return Molecule.from_smiles("C=C")
+
+
+@pytest.fixture(scope="function")
+def propane():
+    """
+    A propane Molecule created from a SMILES string
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    return Molecule.from_smiles("CCC")
+
+
+@pytest.fixture(scope="function")
+def ethanol():
+    """
+    Creates an openforcefield.topology.Molecule representation of
+    ethanol without the use of a cheminformatics toolkit
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    # Create an ethanol molecule without using a toolkit
+
+    ethanol = Molecule()
+    ethanol.add_atom(6, 0, False)  # C0
+    ethanol.add_atom(6, 0, False)  # C1
+    ethanol.add_atom(8, 0, False)  # O2
+    ethanol.add_atom(1, 0, False)  # H3
+    ethanol.add_atom(1, 0, False)  # H4
+    ethanol.add_atom(1, 0, False)  # H5
+    ethanol.add_atom(1, 0, False)  # H6
+    ethanol.add_atom(1, 0, False)  # H7
+    ethanol.add_atom(1, 0, False)  # H8
+    ethanol.add_bond(0, 1, 1, False, fractional_bond_order=1.33)  # C0 - C1
+    ethanol.add_bond(1, 2, 1, False, fractional_bond_order=1.23)  # C1 - O2
+    ethanol.add_bond(0, 3, 1, False, fractional_bond_order=1)  # C0 - H3
+    ethanol.add_bond(0, 4, 1, False, fractional_bond_order=1)  # C0 - H4
+    ethanol.add_bond(0, 5, 1, False, fractional_bond_order=1)  # C0 - H5
+    ethanol.add_bond(1, 6, 1, False, fractional_bond_order=1)  # C1 - H6
+    ethanol.add_bond(1, 7, 1, False, fractional_bond_order=1)  # C1 - H7
+    ethanol.add_bond(2, 8, 1, False, fractional_bond_order=1)  # O2 - H8
+    charges = unit.Quantity(
+        np.array([-0.4, -0.3, -0.2, -0.1, 0.00001, 0.1, 0.2, 0.3, 0.4]),
+        unit.elementary_charge,
+    )
+    ethanol.partial_charges = charges
+
+    return ethanol
+
+
+@pytest.fixture(scope="function")
+def reversed_ethanol():
+    """
+    Creates an openforcefield.topology.Molecule representation of
+    ethanol without the use of a cheminformatics toolkit. This function
+    reverses the atom indexing of ethanol
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    # Create an ethanol molecule without using a toolkit
+    ethanol = Molecule()
+    ethanol.add_atom(1, 0, False)  # H0
+    ethanol.add_atom(1, 0, False)  # H1
+    ethanol.add_atom(1, 0, False)  # H2
+    ethanol.add_atom(1, 0, False)  # H3
+    ethanol.add_atom(1, 0, False)  # H4
+    ethanol.add_atom(1, 0, False)  # H5
+    ethanol.add_atom(8, 0, False)  # O6
+    ethanol.add_atom(6, 0, False)  # C7
+    ethanol.add_atom(6, 0, False)  # C8
+    ethanol.add_bond(8, 7, 1, False, fractional_bond_order=1.33)  # C8 - C7
+    ethanol.add_bond(7, 6, 1, False, fractional_bond_order=1.23)  # C7 - O6
+    ethanol.add_bond(8, 5, 1, False, fractional_bond_order=1)  # C8 - H5
+    ethanol.add_bond(8, 4, 1, False, fractional_bond_order=1)  # C8 - H4
+    ethanol.add_bond(8, 3, 1, False, fractional_bond_order=1)  # C8 - H3
+    ethanol.add_bond(7, 2, 1, False, fractional_bond_order=1)  # C7 - H2
+    ethanol.add_bond(7, 1, 1, False, fractional_bond_order=1)  # C7 - H1
+    ethanol.add_bond(6, 0, 1, False, fractional_bond_order=1)  # O6 - H0
+    charges = unit.Quantity(
+        np.array([0.4, 0.3, 0.2, 0.1, 0.00001, -0.1, -0.2, -0.3, -0.4]),
+        unit.elementary_charge,
+    )
+    ethanol.partial_charges = charges
+    return ethanol
+
+
+@pytest.fixture(scope="function")
+def benzene_no_aromatic():
+    """
+    Creates an openforcefield.topology.Molecule representation of benzene through the API with aromatic bonds
+    not defied, used to test the levels of isomorphic matching.
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    benzene = Molecule()
+    benzene.add_atom(6, 0, False)  # C0
+    benzene.add_atom(6, 0, False)  # C1
+    benzene.add_atom(6, 0, False)  # C2
+    benzene.add_atom(6, 0, False)  # C3
+    benzene.add_atom(6, 0, False)  # C4
+    benzene.add_atom(6, 0, False)  # C5
+    benzene.add_atom(1, 0, False)  # H6
+    benzene.add_atom(1, 0, False)  # H7
+    benzene.add_atom(1, 0, False)  # H8
+    benzene.add_atom(1, 0, False)  # H9
+    benzene.add_atom(1, 0, False)  # H10
+    benzene.add_atom(1, 0, False)  # H11
+    benzene.add_bond(0, 5, 1, False)  # C0 - C5
+    benzene.add_bond(0, 1, 1, False)  # C0 - C1
+    benzene.add_bond(1, 2, 1, False)  # C1 - C2
+    benzene.add_bond(2, 3, 1, False)  # C2 - C3
+    benzene.add_bond(3, 4, 1, False)  # C3 - C4
+    benzene.add_bond(4, 5, 1, False)  # C4 - C5
+    benzene.add_bond(0, 6, 1, False)  # C0 - H6
+    benzene.add_bond(1, 7, 1, False)  # C1 - C7
+    benzene.add_bond(2, 8, 1, False)  # C2 - C8
+    benzene.add_bond(3, 9, 1, False)  # C3 - C9
+    benzene.add_bond(4, 10, 1, False)  # C4 - C10
+    benzene.add_bond(5, 11, 1, False)  # C5 - C11
+    return benzene
+
+
+@pytest.fixture(scope="function")
+def acetaldehyde():
+    """
+    Creates an openforcefield.topology.Molecule representation of acetaldehyde through the API
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    acetaldehyde = Molecule()
+    acetaldehyde.add_atom(6, 0, False)  # C0
+    acetaldehyde.add_atom(6, 0, False)  # C1
+    acetaldehyde.add_atom(8, 0, False)  # O2
+    acetaldehyde.add_atom(1, 0, False)  # H3
+    acetaldehyde.add_atom(1, 0, False)  # H4
+    acetaldehyde.add_atom(1, 0, False)  # H5
+    acetaldehyde.add_atom(1, 0, False)  # H6
+    acetaldehyde.add_bond(0, 1, 1, False)  # C0 - C1
+    acetaldehyde.add_bond(1, 2, 2, False)  # C1 = O2
+    acetaldehyde.add_bond(0, 3, 1, False)  # C0 - H3
+    acetaldehyde.add_bond(0, 4, 1, False)  # C0 - H4
+    acetaldehyde.add_bond(0, 5, 1, False)  # C0 - H5
+    acetaldehyde.add_bond(1, 6, 1, False)  # C1 - H6
+    charges = unit.Quantity(
+        np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]), unit.elementary_charge
+    )
+    acetaldehyde.partial_charges = charges
+    return acetaldehyde
+
+
+@pytest.fixture(scope="function")
+def water():
+    """
+    Creates an openforcefield.topology.Molecule representation of water through the API
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    mol = Molecule()
+    mol.add_atom(1, 0, False)  # H1
+    mol.add_atom(8, 0, False)  # O
+    mol.add_atom(1, 0, False)  # H2
+    mol.add_bond(0, 1, 1, False)  # H1 - O
+    mol.add_bond(1, 2, 1, False)  # O - H2
+    charges = unit.Quantity(np.array([0.0, 0.0, 0.0]), unit.elementary_charge)
+    mol.partial_charges = charges
+    return mol
+
+
+@pytest.fixture(scope="function")
+def ammonia():
+    """
+    Creates an openforcefield.topology.Molecule representation of ammonia through the API
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    mol = Molecule()
+    mol.add_atom(1, 0, False)  # H1
+    mol.add_atom(7, 0, False)  # N
+    mol.add_atom(1, 0, False)  # H2
+    mol.add_atom(1, 0, False)  # H3
+    mol.add_bond(0, 1, 1, False)  # H1 - N
+    mol.add_bond(1, 2, 1, False)  # N - H2
+    mol.add_bond(1, 3, 1, False)  # N - H3
+    charges = unit.Quantity(np.array([0.0, 0.0, 0.0, 0.0]), unit.elementary_charge)
+    mol.partial_charges = charges
+    return mol
+
+
+@pytest.fixture(scope="function")
+def acetate():
+    """
+    Creates an openforcefield.topology.Molecule representation of
+    acetate without the use of a cheminformatics toolkit
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    # Create an acetate molecule without using a toolkit
+    acetate = Molecule()
+    acetate.add_atom(6, 0, False)  # C0
+    acetate.add_atom(6, 0, False)  # C1
+    acetate.add_atom(8, 0, False)  # O2
+    acetate.add_atom(8, -1, False)  # O3
+    acetate.add_atom(1, 0, False)  # H4
+    acetate.add_atom(1, 0, False)  # H5
+    acetate.add_atom(1, 0, False)  # H6
+    acetate.add_bond(0, 1, 1, False)  # C0 - C1
+    acetate.add_bond(1, 2, 2, False)  # C1 = O2
+    acetate.add_bond(1, 3, 1, False)  # C1 - O3[-1]
+    acetate.add_bond(0, 4, 1, False)  # C0 - H4
+    acetate.add_bond(0, 5, 1, False)  # C0 - H5
+    acetate.add_bond(0, 6, 1, False)  # C0 - H6
+    return acetate
+
+
+@pytest.fixture(scope="function")
+def cyclohexane():
+    """
+    Creates an openforcefield.topology.Molecule representation of
+    cyclohexane without the use of a cheminformatics toolkit
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    cyclohexane = Molecule()
+    cyclohexane.add_atom(6, 0, False)  # C0
+    cyclohexane.add_atom(6, 0, False)  # C1
+    cyclohexane.add_atom(6, 0, False)  # C2
+    cyclohexane.add_atom(6, 0, False)  # C3
+    cyclohexane.add_atom(6, 0, False)  # C4
+    cyclohexane.add_atom(6, 0, False)  # C5
+    cyclohexane.add_atom(1, 0, False)  # H6
+    cyclohexane.add_atom(1, 0, False)  # H7
+    cyclohexane.add_atom(1, 0, False)  # H8
+    cyclohexane.add_atom(1, 0, False)  # H9
+    cyclohexane.add_atom(1, 0, False)  # H10
+    cyclohexane.add_atom(1, 0, False)  # H11
+    cyclohexane.add_atom(1, 0, False)  # H12
+    cyclohexane.add_atom(1, 0, False)  # H13
+    cyclohexane.add_atom(1, 0, False)  # H14
+    cyclohexane.add_atom(1, 0, False)  # H15
+    cyclohexane.add_atom(1, 0, False)  # H16
+    cyclohexane.add_atom(1, 0, False)  # H17
+    cyclohexane.add_bond(0, 1, 1, False)  # C0 - C1
+    cyclohexane.add_bond(1, 2, 1, False)  # C1 - C2
+    cyclohexane.add_bond(2, 3, 1, False)  # C2 - C3
+    cyclohexane.add_bond(3, 4, 1, False)  # C3 - C4
+    cyclohexane.add_bond(4, 5, 1, False)  # C4 - C5
+    cyclohexane.add_bond(5, 0, 1, False)  # C5 - C0
+    cyclohexane.add_bond(0, 6, 1, False)  # C0 - H6
+    cyclohexane.add_bond(0, 7, 1, False)  # C0 - H7
+    cyclohexane.add_bond(1, 8, 1, False)  # C1 - H8
+    cyclohexane.add_bond(1, 9, 1, False)  # C1 - H9
+    cyclohexane.add_bond(2, 10, 1, False)  # C2 - H10
+    cyclohexane.add_bond(2, 11, 1, False)  # C2 - H11
+    cyclohexane.add_bond(3, 12, 1, False)  # C3 - H12
+    cyclohexane.add_bond(3, 13, 1, False)  # C3 - H13
+    cyclohexane.add_bond(4, 14, 1, False)  # C4 - H14
+    cyclohexane.add_bond(4, 15, 1, False)  # C4 - H15
+    cyclohexane.add_bond(5, 16, 1, False)  # C5 - H16
+    cyclohexane.add_bond(5, 17, 1, False)  # C5 - H17
+    return cyclohexane
+
+
+@pytest.fixture(scope="function")
+def dioxygen():
+    """
+    Creates an openforcefield.topology.Molecule representation of
+    dioxygen without the use of a cheminformatics toolkit
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    dioxygen = Molecule()
+    dioxygen.add_atom(8, 0, False)  # O0
+    dioxygen.add_atom(8, 0, False)  # O1
+    dioxygen.add_bond(0, 1, 2, False)  # O0 # O1
+    charges = unit.Quantity(np.array([0.0, 0.0]), unit.elementary_charge)
+    dioxygen.partial_charges = charges
+
+    return dioxygen
+
+
+@pytest.fixture(scope="function")
+def dinitrogen():
+    """
+    Creates an openforcefield.topology.Molecule representation of
+    dinitrogen without the use of a cheminformatics toolkit
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    dinitrogen = Molecule()
+    dinitrogen.add_atom(7, 0, False)  # N0
+    dinitrogen.add_atom(7, 0, False)  # N1
+    dinitrogen.add_bond(0, 1, 3, False)  # N0 - N1
+    charges = unit.Quantity(np.array([0.0, 0.0]), unit.elementary_charge)
+    dinitrogen.partial_charges = charges
+    return dinitrogen
+
+@pytest.fixture(scope="function")
+def cis_1_2_dichloroethene():
+    """
+    Creates an openforcefield.topology.Molecule representation of cis-1,2-dichloroethene
+    without the use of a cheminformatics toolkit.
+    """
+    from openforcefield.topology.molecule import Molecule
+
+    cis_dichloroethene = Molecule()
+    cis_dichloroethene.add_atom(17, 0, False)
+    cis_dichloroethene.add_atom(6, 0, False)
+    cis_dichloroethene.add_atom(6, 0, False)
+    cis_dichloroethene.add_atom(17, 0, False)
+    cis_dichloroethene.add_atom(1, 0, False)
+    cis_dichloroethene.add_atom(1, 0, False)
+    cis_dichloroethene.add_bond(0, 1, 1, False)
+    cis_dichloroethene.add_bond(1, 2, 2, False, "Z")
+    cis_dichloroethene.add_bond(2, 3, 1, False)
+    cis_dichloroethene.add_bond(1, 4, 1, False)
+    cis_dichloroethene.add_bond(2, 5, 1, False)
+    return cis_dichloroethene
+
+

--- a/openforcefield/tests/test_chemicalenvironment.py
+++ b/openforcefield/tests/test_chemicalenvironment.py
@@ -1,6 +1,15 @@
 import pytest
 
-from openforcefield.typing.chemistry import *
+from openforcefield.typing.chemistry import (
+    AngleChemicalEnvironment,
+    AtomChemicalEnvironment,
+    BondChemicalEnvironment,
+    ChemicalEnvironment,
+    ImproperChemicalEnvironment,
+    SMIRKSMismatchError,
+    SMIRKSParsingError,
+    TorsionChemicalEnvironment,
+)
 from openforcefield.utils.toolkits import OPENEYE_AVAILABLE
 
 # TODO: Evaluate which tests in this file should be moved to test_toolkits
@@ -178,7 +187,7 @@ class TestChemicalEnvironments:
         """
         for wrong_env in wrong_envs:
             with pytest.raises(SMIRKSMismatchError):
-                env = wrong_env(smirks)
+                wrong_env(smirks)
 
     @pytest.mark.parametrize("toolkit", toolkits)
     def test_wrong_smirks_error(self, toolkit):
@@ -187,11 +196,11 @@ class TestChemicalEnvironments:
         """
         smirks = "[*;:1]"
         with pytest.raises(SMIRKSParsingError):
-            env = ChemicalEnvironment(smirks, toolkit_registry=toolkit)
+            ChemicalEnvironment(smirks, toolkit_registry=toolkit)
 
     def test_embedded_atoms_smirks(self):
         """
         Check embedded atom parsing works
         """
         smirks = "[#1$(*-[#6](-[#7,#8,#9,#16,#17,#35])-[#7,#8,#9,#16,#17,#35]):1]~[$([#1]~[#6])]"
-        env = ChemicalEnvironment(smirks)
+        ChemicalEnvironment(smirks)

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -20,11 +20,10 @@ import os
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
-import numpy as np
-import pytest
 from numpy.testing import assert_almost_equal
-from simtk import openmm, unit
+from simtk import openmm
 
+from openforcefield.tests.conftest import *
 from openforcefield.tests.utils import (
     requires_openeye,
     requires_openeye_mol2,
@@ -316,280 +315,6 @@ def round_charge(xml):
         chunk = '" sig'.join(chunksp)
         xmlsp[index] = chunk
     return ' q="'.join(xmlsp)
-
-
-def create_cis_1_2_dichloroethene():
-    """
-    Creates an openforcefield.topology.Molecule representation of cis-1,2-dichloroethene
-    without the use of a cheminformatics toolkit.
-    """
-
-    cis_dichloroethene = Molecule()
-    cis_dichloroethene.add_atom(17, 0, False)
-    cis_dichloroethene.add_atom(6, 0, False)
-    cis_dichloroethene.add_atom(6, 0, False)
-    cis_dichloroethene.add_atom(17, 0, False)
-    cis_dichloroethene.add_atom(1, 0, False)
-    cis_dichloroethene.add_atom(1, 0, False)
-    cis_dichloroethene.add_bond(0, 1, 1, False)
-    cis_dichloroethene.add_bond(1, 2, 2, False, "Z")
-    cis_dichloroethene.add_bond(2, 3, 1, False)
-    cis_dichloroethene.add_bond(1, 4, 1, False)
-    cis_dichloroethene.add_bond(2, 5, 1, False)
-    return cis_dichloroethene
-
-
-def create_ethanol():
-    """
-    Creates an openforcefield.topology.Molecule representation of
-    ethanol without the use of a cheminformatics toolkit
-    """
-    # Create an ethanol molecule without using a toolkit
-    ethanol = Molecule()
-    ethanol.add_atom(6, 0, False)  # C0
-    ethanol.add_atom(6, 0, False)  # C1
-    ethanol.add_atom(8, 0, False)  # O2
-    ethanol.add_atom(1, 0, False)  # H3
-    ethanol.add_atom(1, 0, False)  # H4
-    ethanol.add_atom(1, 0, False)  # H5
-    ethanol.add_atom(1, 0, False)  # H6
-    ethanol.add_atom(1, 0, False)  # H7
-    ethanol.add_atom(1, 0, False)  # H8
-    ethanol.add_bond(0, 1, 1, False, fractional_bond_order=1.33)  # C0 - C1
-    ethanol.add_bond(1, 2, 1, False, fractional_bond_order=1.23)  # C1 - O2
-    ethanol.add_bond(0, 3, 1, False, fractional_bond_order=1)  # C0 - H3
-    ethanol.add_bond(0, 4, 1, False, fractional_bond_order=1)  # C0 - H4
-    ethanol.add_bond(0, 5, 1, False, fractional_bond_order=1)  # C0 - H5
-    ethanol.add_bond(1, 6, 1, False, fractional_bond_order=1)  # C1 - H6
-    ethanol.add_bond(1, 7, 1, False, fractional_bond_order=1)  # C1 - H7
-    ethanol.add_bond(2, 8, 1, False, fractional_bond_order=1)  # O2 - H8
-    charges = unit.Quantity(
-        np.array([-0.4, -0.3, -0.2, -0.1, 0.00001, 0.1, 0.2, 0.3, 0.4]),
-        unit.elementary_charge,
-    )
-    ethanol.partial_charges = charges
-
-    return ethanol
-
-
-def create_reversed_ethanol():
-    """
-    Creates an openforcefield.topology.Molecule representation of
-    ethanol without the use of a cheminformatics toolkit. This function
-    reverses the atom indexing of create_ethanol
-    """
-    # Create an ethanol molecule without using a toolkit
-    ethanol = Molecule()
-    ethanol.add_atom(1, 0, False)  # H0
-    ethanol.add_atom(1, 0, False)  # H1
-    ethanol.add_atom(1, 0, False)  # H2
-    ethanol.add_atom(1, 0, False)  # H3
-    ethanol.add_atom(1, 0, False)  # H4
-    ethanol.add_atom(1, 0, False)  # H5
-    ethanol.add_atom(8, 0, False)  # O6
-    ethanol.add_atom(6, 0, False)  # C7
-    ethanol.add_atom(6, 0, False)  # C8
-    ethanol.add_bond(8, 7, 1, False, fractional_bond_order=1.33)  # C8 - C7
-    ethanol.add_bond(7, 6, 1, False, fractional_bond_order=1.23)  # C7 - O6
-    ethanol.add_bond(8, 5, 1, False, fractional_bond_order=1)  # C8 - H5
-    ethanol.add_bond(8, 4, 1, False, fractional_bond_order=1)  # C8 - H4
-    ethanol.add_bond(8, 3, 1, False, fractional_bond_order=1)  # C8 - H3
-    ethanol.add_bond(7, 2, 1, False, fractional_bond_order=1)  # C7 - H2
-    ethanol.add_bond(7, 1, 1, False, fractional_bond_order=1)  # C7 - H1
-    ethanol.add_bond(6, 0, 1, False, fractional_bond_order=1)  # O6 - H0
-    charges = unit.Quantity(
-        np.array([0.4, 0.3, 0.2, 0.1, 0.00001, -0.1, -0.2, -0.3, -0.4]),
-        unit.elementary_charge,
-    )
-    ethanol.partial_charges = charges
-    return ethanol
-
-
-def create_benzene_no_aromatic():
-    """
-    Creates an openforcefield.topology.Molecule representation of benzene through the API with aromatic bonds
-    not defied, used to test the levels of isomorphic matching.
-    """
-    benzene = Molecule()
-    benzene.add_atom(6, 0, False)  # C0
-    benzene.add_atom(6, 0, False)  # C1
-    benzene.add_atom(6, 0, False)  # C2
-    benzene.add_atom(6, 0, False)  # C3
-    benzene.add_atom(6, 0, False)  # C4
-    benzene.add_atom(6, 0, False)  # C5
-    benzene.add_atom(1, 0, False)  # H6
-    benzene.add_atom(1, 0, False)  # H7
-    benzene.add_atom(1, 0, False)  # H8
-    benzene.add_atom(1, 0, False)  # H9
-    benzene.add_atom(1, 0, False)  # H10
-    benzene.add_atom(1, 0, False)  # H11
-    benzene.add_bond(0, 5, 1, False)  # C0 - C5
-    benzene.add_bond(0, 1, 1, False)  # C0 - C1
-    benzene.add_bond(1, 2, 1, False)  # C1 - C2
-    benzene.add_bond(2, 3, 1, False)  # C2 - C3
-    benzene.add_bond(3, 4, 1, False)  # C3 - C4
-    benzene.add_bond(4, 5, 1, False)  # C4 - C5
-    benzene.add_bond(0, 6, 1, False)  # C0 - H6
-    benzene.add_bond(1, 7, 1, False)  # C1 - C7
-    benzene.add_bond(2, 8, 1, False)  # C2 - C8
-    benzene.add_bond(3, 9, 1, False)  # C3 - C9
-    benzene.add_bond(4, 10, 1, False)  # C4 - C10
-    benzene.add_bond(5, 11, 1, False)  # C5 - C11
-    return benzene
-
-
-def create_acetaldehyde():
-    """
-    Creates an openforcefield.topology.Molecule representation of acetaldehyde through the API
-    """
-    acetaldehyde = Molecule()
-    acetaldehyde.add_atom(6, 0, False)  # C0
-    acetaldehyde.add_atom(6, 0, False)  # C1
-    acetaldehyde.add_atom(8, 0, False)  # O2
-    acetaldehyde.add_atom(1, 0, False)  # H3
-    acetaldehyde.add_atom(1, 0, False)  # H4
-    acetaldehyde.add_atom(1, 0, False)  # H5
-    acetaldehyde.add_atom(1, 0, False)  # H6
-    acetaldehyde.add_bond(0, 1, 1, False)  # C0 - C1
-    acetaldehyde.add_bond(1, 2, 2, False)  # C1 = O2
-    acetaldehyde.add_bond(0, 3, 1, False)  # C0 - H3
-    acetaldehyde.add_bond(0, 4, 1, False)  # C0 - H4
-    acetaldehyde.add_bond(0, 5, 1, False)  # C0 - H5
-    acetaldehyde.add_bond(1, 6, 1, False)  # C1 - H6
-    charges = unit.Quantity(
-        np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]), unit.elementary_charge
-    )
-    acetaldehyde.partial_charges = charges
-    return acetaldehyde
-
-
-def create_water():
-    """
-    Creates an openforcefield.topology.Molecule representation of water through the API
-    """
-    mol = Molecule()
-    mol.add_atom(1, 0, False)  # H1
-    mol.add_atom(8, 0, False)  # O
-    mol.add_atom(1, 0, False)  # H2
-    mol.add_bond(0, 1, 1, False)  # H1 - O
-    mol.add_bond(1, 2, 1, False)  # O - H2
-    charges = unit.Quantity(np.array([0.0, 0.0, 0.0]), unit.elementary_charge)
-    mol.partial_charges = charges
-    return mol
-
-
-def create_ammonia():
-    """
-    Creates an openforcefield.topology.Molecule representation of ammonia through the API
-    """
-    mol = Molecule()
-    mol.add_atom(1, 0, False)  # H1
-    mol.add_atom(7, 0, False)  # N
-    mol.add_atom(1, 0, False)  # H2
-    mol.add_atom(1, 0, False)  # H3
-    mol.add_bond(0, 1, 1, False)  # H1 - N
-    mol.add_bond(1, 2, 1, False)  # N - H2
-    mol.add_bond(1, 3, 1, False)  # N - H3
-    charges = unit.Quantity(np.array([0.0, 0.0, 0.0, 0.0]), unit.elementary_charge)
-    mol.partial_charges = charges
-    return mol
-
-
-def create_acetate():
-    """
-    Creates an openforcefield.topology.Molecule representation of
-    acetate without the use of a cheminformatics toolkit
-    """
-    # Create an acetate molecule without using a toolkit
-    acetate = Molecule()
-    acetate.add_atom(6, 0, False)  # C0
-    acetate.add_atom(6, 0, False)  # C1
-    acetate.add_atom(8, 0, False)  # O2
-    acetate.add_atom(8, -1, False)  # O3
-    acetate.add_atom(1, 0, False)  # H4
-    acetate.add_atom(1, 0, False)  # H5
-    acetate.add_atom(1, 0, False)  # H6
-    acetate.add_bond(0, 1, 1, False)  # C0 - C1
-    acetate.add_bond(1, 2, 2, False)  # C1 = O2
-    acetate.add_bond(1, 3, 1, False)  # C1 - O3[-1]
-    acetate.add_bond(0, 4, 1, False)  # C0 - H4
-    acetate.add_bond(0, 5, 1, False)  # C0 - H5
-    acetate.add_bond(0, 6, 1, False)  # C0 - H6
-    return acetate
-
-
-def create_cyclohexane():
-    """
-    Creates an openforcefield.topology.Molecule representation of
-    cyclohexane without the use of a cheminformatics toolkit
-    """
-    cyclohexane = Molecule()
-    cyclohexane.add_atom(6, 0, False)  # C0
-    cyclohexane.add_atom(6, 0, False)  # C1
-    cyclohexane.add_atom(6, 0, False)  # C2
-    cyclohexane.add_atom(6, 0, False)  # C3
-    cyclohexane.add_atom(6, 0, False)  # C4
-    cyclohexane.add_atom(6, 0, False)  # C5
-    cyclohexane.add_atom(1, 0, False)  # H6
-    cyclohexane.add_atom(1, 0, False)  # H7
-    cyclohexane.add_atom(1, 0, False)  # H8
-    cyclohexane.add_atom(1, 0, False)  # H9
-    cyclohexane.add_atom(1, 0, False)  # H10
-    cyclohexane.add_atom(1, 0, False)  # H11
-    cyclohexane.add_atom(1, 0, False)  # H12
-    cyclohexane.add_atom(1, 0, False)  # H13
-    cyclohexane.add_atom(1, 0, False)  # H14
-    cyclohexane.add_atom(1, 0, False)  # H15
-    cyclohexane.add_atom(1, 0, False)  # H16
-    cyclohexane.add_atom(1, 0, False)  # H17
-    cyclohexane.add_bond(0, 1, 1, False)  # C0 - C1
-    cyclohexane.add_bond(1, 2, 1, False)  # C1 - C2
-    cyclohexane.add_bond(2, 3, 1, False)  # C2 - C3
-    cyclohexane.add_bond(3, 4, 1, False)  # C3 - C4
-    cyclohexane.add_bond(4, 5, 1, False)  # C4 - C5
-    cyclohexane.add_bond(5, 0, 1, False)  # C5 - C0
-    cyclohexane.add_bond(0, 6, 1, False)  # C0 - H6
-    cyclohexane.add_bond(0, 7, 1, False)  # C0 - H7
-    cyclohexane.add_bond(1, 8, 1, False)  # C1 - H8
-    cyclohexane.add_bond(1, 9, 1, False)  # C1 - H9
-    cyclohexane.add_bond(2, 10, 1, False)  # C2 - H10
-    cyclohexane.add_bond(2, 11, 1, False)  # C2 - H11
-    cyclohexane.add_bond(3, 12, 1, False)  # C3 - H12
-    cyclohexane.add_bond(3, 13, 1, False)  # C3 - H13
-    cyclohexane.add_bond(4, 14, 1, False)  # C4 - H14
-    cyclohexane.add_bond(4, 15, 1, False)  # C4 - H15
-    cyclohexane.add_bond(5, 16, 1, False)  # C5 - H16
-    cyclohexane.add_bond(5, 17, 1, False)  # C5 - H17
-    return cyclohexane
-
-
-def create_dioxygen():
-    """
-    Creates an openforcefield.topology.Molecule representation of
-    dioxygen without the use of a cheminformatics toolkit
-    """
-    dioxygen = Molecule()
-    dioxygen.add_atom(8, 0, False)  # O0
-    dioxygen.add_atom(8, 0, False)  # O1
-    dioxygen.add_bond(0, 1, 2, False)  # O0 # O1
-    charges = unit.Quantity(np.array([0.0, 0.0]), unit.elementary_charge)
-    dioxygen.partial_charges = charges
-
-    return dioxygen
-
-
-def create_dinitrogen():
-    """
-    Creates an openforcefield.topology.Molecule representation of
-    dinitrogen without the use of a cheminformatics toolkit
-    """
-    dinitrogen = Molecule()
-    dinitrogen.add_atom(7, 0, False)  # N0
-    dinitrogen.add_atom(7, 0, False)  # N1
-    dinitrogen.add_bond(0, 1, 3, False)  # N0 - N1
-    charges = unit.Quantity(np.array([0.0, 0.0]), unit.elementary_charge)
-    dinitrogen.partial_charges = charges
-    return dinitrogen
 
 
 nonbonded_resolution_matrix = [
@@ -1216,7 +941,7 @@ class TestForceField:
 
         forcefield = ForceField("test_forcefields/test_forcefield.offxml")
         pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
-        molecules = [create_ethanol()]
+        molecules = [ethanol]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
         omm_system = forcefield.create_openmm_system(
@@ -1253,7 +978,7 @@ class TestForceField:
         self,
         create_circular_handler_dependencies,
         toolkit_registry,
-        registry_description,
+        ethanol,
     ):
         """Test parameterizing ethanol, but failing because custom handler classes can not resolve
         which order to run in"""
@@ -1264,18 +989,18 @@ class TestForceField:
         forcefield = ForceField("test_forcefields/test_forcefield.offxml")
 
         pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
-        molecules = [create_ethanol()]
+        molecules = [ethanol]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         with pytest.raises(
             RuntimeError,
             match="Unable to resolve order in which to run ParameterHandlers. "
             "Dependencies do not form a directed acyclic graph",
-        ) as excinfo:
+        ):
             omm_system = forcefield.create_openmm_system(
                 topology, toolkit_registry=toolkit_registry
             )
 
-    def test_parameterize_ethanol_missing_torsion(self):
+    def test_parameterize_ethanol_missing_torsion(self, ethanol):
         from simtk.openmm import app
 
         from openforcefield.typing.engines.smirnoff.parameters import (
@@ -1292,7 +1017,7 @@ class TestForceField:
 """
         )
         pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
-        molecules = [create_ethanol()]
+        molecules = [ethanol]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         with pytest.raises(
             UnassignedProperTorsionParameterException,
@@ -1305,7 +1030,10 @@ class TestForceField:
         "toolkit_registry,registry_description", toolkit_registries
     )
     def test_parameterize_1_cyclohexane_1_ethanol(
-        self, toolkit_registry, registry_description
+        self,
+        toolkit_registry,
+        ethanol,
+        cyclohexane,
     ):
         """Test parameterizing a periodic system of two distinct molecules"""
         from simtk.openmm import app
@@ -1314,10 +1042,8 @@ class TestForceField:
         pdbfile = app.PDBFile(
             get_data_file_path("systems/test_systems/1_cyclohexane_1_ethanol.pdb")
         )
-        # toolkit_wrapper = RDKitToolkitWrapper()
-        molecules = [create_ethanol(), create_cyclohexane()]
-        # molecules = [Molecule.from_file(get_data_file_path(name)) for name in ('molecules/ethanol.mol2',
-        #                                                                      'molecules/cyclohexane.mol2')]
+
+        molecules = [ethanol, cyclohexane]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
         omm_system = forcefield.create_openmm_system(topology)
@@ -1326,7 +1052,10 @@ class TestForceField:
         "toolkit_registry,registry_description", toolkit_registries
     )
     def test_parameterize_1_cyclohexane_1_ethanol_vacuum(
-        self, toolkit_registry, registry_description
+        self,
+        toolkit_registry,
+        ethanol,
+        cyclohexane,
     ):
         """Test parametrizing a nonperiodic system of two distinct molecules"""
         from simtk.openmm import app
@@ -1335,7 +1064,7 @@ class TestForceField:
         pdbfile = app.PDBFile(
             get_data_file_path("systems/test_systems/1_cyclohexane_1_ethanol.pdb")
         )
-        molecules = [create_ethanol(), create_cyclohexane()]
+        molecules = [ethanol, cyclohexane]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         topology.box_vectors = None
 
@@ -1550,10 +1279,10 @@ class TestForceField:
             )
 
     @pytest.mark.parametrize("mod_cuoff", [True, False])
-    def test_nonbonded_cutoff_no_box_vectors(self, mod_cuoff):
+    def test_nonbonded_cutoff_no_box_vectors(self, mod_cuoff, ethanol):
         """Ensure that the NonbondedForce objects use the cutoff specified in the
         ParameterHandler, not the OpenMM defaults"""
-        top = Topology.from_molecules(create_ethanol())
+        top = Topology.from_molecules(ethanol)
         assert top.box_vectors is None
         forcefield = ForceField("test_forcefields/test_forcefield.offxml")
 
@@ -1574,7 +1303,7 @@ class TestForceField:
         assert found_cutoff == vdw_cutoff == e_cutoff
 
     @pytest.mark.parametrize("inputs", nonbonded_resolution_matrix)
-    def test_nonbonded_method_resolution(self, inputs):
+    def test_nonbonded_method_resolution(self, inputs, ethanol):
         """Test predefined permutations of input options to ensure nonbonded handling is correctly resolved"""
         from simtk.openmm import app
 
@@ -1585,7 +1314,7 @@ class TestForceField:
         exception = inputs["exception"]
         exception_match = inputs["exception_match"]
 
-        molecules = [create_ethanol()]
+        molecules = [ethanol]
         forcefield = ForceField("test_forcefields/test_forcefield.offxml")
 
         pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
@@ -2069,7 +1798,7 @@ class TestForceFieldVirtualSites:
                 (+0.2 * charge_unit, None, None),
                 (-0.4 * charge_unit, 0.2 * sigma_unit, 0.2 * epsilon_unit),
             ),
-            "mol": create_dinitrogen(),
+            "mol": dinitrogen,
         }
     )
     bond_charge_parameters_args.append(opts)
@@ -2085,7 +1814,7 @@ class TestForceFieldVirtualSites:
                 (+0.1 * charge_unit, None, None),
                 (-0.2 * charge_unit, 0.1 * sigma_unit, 0.1 * epsilon_unit),
             ),
-            "mol": create_dioxygen(),
+            "mol": dioxygen,
         }
     )
     bond_charge_parameters_args.append(opts)
@@ -2101,7 +1830,7 @@ class TestForceFieldVirtualSites:
                 (-0.4 * charge_unit, 0.2 * sigma_unit, 0.2 * epsilon_unit),
                 (-0.4 * charge_unit, 0.2 * sigma_unit, 0.2 * epsilon_unit),
             ),
-            "mol": create_dinitrogen(),
+            "mol": dinitrogen,
         }
     )
     bond_charge_parameters_args.append(opts)
@@ -2121,7 +1850,7 @@ class TestForceFieldVirtualSites:
                 (-0.2 * charge_unit, 0.1 * sigma_unit, 0.1 * epsilon_unit),
                 (-0.4 * charge_unit, 0.2 * sigma_unit, 0.2 * epsilon_unit),
             ),
-            "mol": create_dinitrogen(),
+            "mol": dinitrogen,
         }
     )
     bond_charge_parameters_args.append(opts)
@@ -2140,7 +1869,7 @@ class TestForceFieldVirtualSites:
                 (+0.0 * charge_unit, None, None),
                 (-0.6 * charge_unit, 0.2 * sigma_unit, 0.2 * epsilon_unit),
             ),
-            "mol": create_acetaldehyde(),
+            "mol": acetaldehyde,
         }
     )
     monovalent_parameters_args.append(opts)
@@ -2161,7 +1890,7 @@ class TestForceFieldVirtualSites:
                 (-0.4820 * charge_unit, 3.12 * sigma_unit, 0.16 * epsilon_unit),
                 (-0.4820 * charge_unit, 3.12 * sigma_unit, 0.16 * epsilon_unit),
             ),
-            "mol": create_water(),
+            "mol": water,
         }
     )
     divalent_parameters_args.append(opts)
@@ -2181,7 +1910,7 @@ class TestForceFieldVirtualSites:
                 (+0.0000 * charge_unit, None, None),
                 (-1.0000 * charge_unit, 0.00 * sigma_unit, 0.00 * epsilon_unit),
             ),
-            "mol": create_ammonia(),
+            "mol": ammonia,
         }
     )
     trivalent_parameters_args.append(opts)
@@ -2259,7 +1988,7 @@ class TestForceFieldChargeAssignment:
     def test_charges_from_molecule(self, toolkit_registry, registry_description):
         """Test skipping charge generation and instead getting charges from the original Molecule"""
         # Create an ethanol molecule without using a toolkit
-        molecules = [create_ethanol()]
+        molecules = [ethanol]
 
         from simtk.openmm import NonbondedForce, app
 
@@ -2305,10 +2034,8 @@ class TestForceFieldChargeAssignment:
             q, sigma, epsilon = nonbondedForce2.getParticleParameters(particle_index)
             assert q == expected_charge
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
-    def test_nonintegral_charge_exception(self, toolkit_registry, registry_description):
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
+    def test_nonintegral_charge_exception(self, toolkit_registry, ethanol):
         """Test skipping charge generation and instead getting charges from the original Molecule"""
         from simtk.openmm import app
 
@@ -2316,8 +2043,6 @@ class TestForceFieldChargeAssignment:
             NonintegralMoleculeChargeException,
         )
 
-        # Create an ethanol molecule without using a toolkit
-        ethanol = create_ethanol()
         ethanol.partial_charges[0] = 1.0 * unit.elementary_charge
 
         file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
@@ -2343,16 +2068,12 @@ class TestForceFieldChargeAssignment:
             allow_nonintegral_charges=True,
         )
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
-    def test_some_charges_from_molecule(self, toolkit_registry, registry_description):
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
+    def test_some_charges_from_molecule(self, toolkit_registry, ethanol, cyclohexane):
         """
         Test creating an OpenMM system where some charges come from a Molecule, but others come from toolkit
         calculation
         """
-        ethanol = create_ethanol()
-        cyclohexane = create_cyclohexane()
         molecules = [ethanol, cyclohexane]
 
         from simtk.openmm import NonbondedForce, app
@@ -2417,7 +2138,9 @@ class TestForceFieldChargeAssignment:
         #       We should implement something like doctests for the XML snippets on the SMIRNOFF spec page.
         ff = ForceField(xml_spec_docs_charge_increment_model_xml)
 
-    def test_charge_increment_model_forward_and_reverse_ethanol(self):
+    def test_charge_increment_model_forward_and_reverse_ethanol(
+        self, ethanol, reversed_ethanol
+    ):
         """Test application of ChargeIncrements to the same molecule with different orderings in the topology"""
         test_charge_increment_model_ff = """
         <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
@@ -2430,7 +2153,7 @@ class TestForceFieldChargeAssignment:
         file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
         ff = ForceField(file_path, test_charge_increment_model_ff)
         del ff._parameter_handlers["ToolkitAM1BCC"]
-        top = Topology.from_molecules([create_ethanol(), create_reversed_ethanol()])
+        top = Topology.from_molecules([ethanol, reversed_ethanol])
         sys = ff.create_openmm_system(top)
         nonbonded_force = [
             force
@@ -2461,7 +2184,7 @@ class TestForceFieldChargeAssignment:
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
             assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
-    def test_charge_increment_model_one_less_ci_than_tagged_atom(self):
+    def test_charge_increment_model_one_less_ci_than_tagged_atom(self, ethanol):
         """
         Ensure that we support the behavior where a ChargeIncrement is initialized with one less chargeincrement value
         than tagged atom. We test this by making two equivalent (one with fully explicit CIs, the other with some
@@ -2491,7 +2214,7 @@ class TestForceFieldChargeAssignment:
         del ff1._parameter_handlers["ToolkitAM1BCC"]
         ff2 = ForceField(file_path, test_charge_increment_model_ff_no_missing_cis)
         del ff2._parameter_handlers["ToolkitAM1BCC"]
-        top = Topology.from_molecules([create_ethanol()])
+        top = Topology.from_molecules([ethanol])
         # Make a system from each FF
         sys1 = ff2.create_openmm_system(top)
         sys2 = ff2.create_openmm_system(top)
@@ -2525,7 +2248,7 @@ class TestForceFieldChargeAssignment:
             assert abs(charge1 - expected_charge) < 1.0e-6 * unit.elementary_charge
             assert charge1 == charge2
 
-    def test_charge_increment_model_invalid_number_of_cis(self):
+    def test_charge_increment_model_invalid_number_of_cis(self, ethanol):
         """
         Ensure that we support the behavior where a ChargeIncrement with an incorrect number of tagged atoms
         and chargeincrementX values riases an error
@@ -2549,7 +2272,7 @@ class TestForceFieldChargeAssignment:
 
         # Add ONE MORE chargeincrement parameter than there are tagged atoms and ensure an exception is raised
         cimh.parameters[0].charge_increment.append(0.01 * unit.elementary_charge)
-        top = Topology.from_molecules([create_ethanol()])
+        top = Topology.from_molecules([ethanol])
         with pytest.raises(
             SMIRNOFFSpecError,
             match="number of chargeincrements must be either the same",
@@ -2573,7 +2296,7 @@ class TestForceFieldChargeAssignment:
         ChargeIncrement elements"""
         ff = ForceField(xml_charge_increment_model_formal_charges)
 
-    def test_charge_increment_model_net_charge(self):
+    def test_charge_increment_model_net_charge(self, acetate):
         """Test application of charge increments on a molecule with a net charge"""
         from simtk import unit
 
@@ -2589,7 +2312,6 @@ class TestForceFieldChargeAssignment:
         ff = ForceField(file_path, test_charge_increment_model_ff)
         del ff._parameter_handlers["ToolkitAM1BCC"]
 
-        acetate = create_acetate()
         top = acetate.to_topology()
         sys = ff.create_openmm_system(top)
         nonbonded_force = [
@@ -2602,11 +2324,10 @@ class TestForceFieldChargeAssignment:
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
             assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
-    def test_charge_increment_model_deduplicate_symmetric_matches(self):
+    def test_charge_increment_model_deduplicate_symmetric_matches(self, ethanol):
         """Test that chargeincrementmodelhandler deduplicates symmetric matches"""
         from simtk import unit
 
-        ethanol = create_ethanol()
         top = ethanol.to_topology()
 
         # Test a charge increment that matches all C-H bonds at once
@@ -2711,7 +2432,9 @@ class TestForceFieldChargeAssignment:
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
             assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
-    def test_charge_increment_model_completely_overlapping_matches_override(self):
+    def test_charge_increment_model_completely_overlapping_matches_override(
+        self, ethanol
+    ):
         """Ensure that DIFFERENT chargeincrements override one another if they apply to the
         same atoms, regardless of order"""
         from simtk import unit
@@ -2728,7 +2451,6 @@ class TestForceFieldChargeAssignment:
         ff = ForceField(file_path, test_charge_increment_model_ff)
         del ff._parameter_handlers["ToolkitAM1BCC"]
 
-        ethanol = create_ethanol()
         top = ethanol.to_topology()
         sys = ff.create_openmm_system(top)
         nonbonded_force = [
@@ -2751,7 +2473,9 @@ class TestForceFieldChargeAssignment:
             charge, _, _ = nonbonded_force.getParticleParameters(idx)
             assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
-    def test_charge_increment_model_partially_overlapping_matches_both_apply(self):
+    def test_charge_increment_model_partially_overlapping_matches_both_apply(
+        self, ethanol
+    ):
         """Ensure that DIFFERENT chargeincrements BOTH get applied if they match
         a partially-overlapping set of atoms"""
         from simtk import unit
@@ -2768,7 +2492,6 @@ class TestForceFieldChargeAssignment:
         ff = ForceField(file_path, test_charge_increment_model_ff)
         del ff._parameter_handlers["ToolkitAM1BCC"]
 
-        ethanol = create_ethanol()
         top = ethanol.to_topology()
         sys = ff.create_openmm_system(top)
         nonbonded_force = [
@@ -2792,7 +2515,7 @@ class TestForceFieldChargeAssignment:
             assert abs(charge - expected_charge) < 1.0e-6 * unit.elementary_charge
 
     @pytest.mark.parametrize("inputs", partial_charge_method_resolution_matrix)
-    def test_partial_charge_resolution(self, inputs):
+    def test_partial_charge_resolution(self, inputs, ethanol):
         """Check that the proper partial charge methods are available, and that unavailable partial charge methods
         raise an exception.
         """
@@ -2803,7 +2526,7 @@ class TestForceFieldChargeAssignment:
         partial_charge_method = inputs["partial_charge_method"]
         expected_exception = inputs["exception"]
         expected_exception_match = inputs["exception_match"]
-        ethanol = create_ethanol()
+
         ethanol.generate_conformers()
         if expected_exception is None:
             ethanol.assign_partial_charges(
@@ -2926,7 +2649,7 @@ class TestForceFieldChargeAssignment:
         molecules = [
             Molecule.from_file(get_data_file_path("molecules/ethanol.sdf")),
             Molecule.from_file(get_data_file_path("molecules/ethanol_reordered.sdf")),
-            create_reversed_ethanol(),
+            reversed_ethanol,
         ]
         top = Topology.from_molecules(molecules)
         omm_system = ff.create_openmm_system(top)
@@ -3256,7 +2979,7 @@ class TestForceFieldChargeAssignment:
         with pytest.raises(
             UnassignedMoleculeChargeException,
             match="did not have charges assigned by any ParameterHandler",
-        ) as excinfo:
+        ):
             omm_system = ff.create_openmm_system(top)
 
         # If we do NOT delete the ToolkiAM1BCCHandler, then toluene should be assigned some nonzero partial charges.
@@ -3283,14 +3006,16 @@ class TestForceFieldChargeAssignment:
         ],
     )
     def test_charges_on_ref_mols_when_using_return_topology(
-        self, charge_method, additional_offxmls
+        self,
+        charge_method,
+        additional_offxmls,
+        acetate,
     ):
         """Ensure that charges are set on returned topology if the user specifies 'return_topology=True' in
         create_openmm_system"""
         # TODO: Should this test also cover multiple unique molecules?
         from simtk.openmm import NonbondedForce
 
-        mol = create_acetate()
         ff = ForceField("test_forcefields/test_forcefield.offxml", *additional_offxmls)
         charge_mols = []
         if charge_method == "charge_from_molecules":
@@ -3859,7 +3584,7 @@ class TestForceFieldParameterAssignment:
             off_omm_system, amber_omm_system, positions, by_force_type=False
         )
 
-    def test_tip5p_dimer_energy(self):
+    def test_tip5p_dimer_energy(self, water):
         """"""
 
         tip5p_offxml = """<?xml version="1.0" encoding="utf-8"?>
@@ -3903,7 +3628,10 @@ class TestForceFieldParameterAssignment:
 
         off_ff = ForceField("test_forcefields/test_forcefield.offxml", tip5p_offxml)
 
-        molecule1 = create_water()
+        # Make new molecules from fixture to ensure objects differ
+        molecule1 = Molecule(water)
+        molecule2 = Molecule(water)
+
         molecule1.atoms[0].name = "O"
         molecule1.atoms[1].name = "H1"
         molecule1.atoms[2].name = "H2"
@@ -3920,7 +3648,6 @@ class TestForceFieldParameterAssignment:
             * unit.angstrom
         )
 
-        molecule2 = create_water()
         molecule2.atoms[0].name = "O"
         molecule2.atoms[1].name = "H1"
         molecule2.atoms[2].name = "H2"
@@ -4202,13 +3929,13 @@ class TestForceFieldParameterAssignment:
         )
 
     @requires_openeye
-    def test_overwrite_bond_orders(self):
+    def test_overwrite_bond_orders(self, ethanol):
         """Test that previously-defined bond orders in the topology are overwritten"""
-        mol = create_ethanol()
+        mol = Molecule(ethanol)
         mol.assign_fractional_bond_orders(bond_order_model="am1-wiberg")
         top = Topology.from_molecules(mol)
 
-        mod_mol = create_ethanol()
+        mod_mol = Molecule(ethanol)
         mod_mol.assign_fractional_bond_orders(bond_order_model="am1-wiberg")
         # populate the mol with garbage bond orders
         for bond in mod_mol.bonds:
@@ -4260,8 +3987,8 @@ class TestForceFieldParameterAssignment:
             "central_atoms",
         ),
         [
-            (create_ethanol, 4.953856, 44375.504, 0.13770, (1, 2)),
-            (create_reversed_ethanol, 4.953856, 44375.504, 0.13770, (7, 6)),
+            (ethanol, 4.953856, 44375.504, 0.13770, (1, 2)),
+            (reversed_ethanol, 4.953856, 44375.504, 0.13770, (7, 6)),
         ],
     )
     def test_fractional_bondorder_from_molecule(
@@ -4338,8 +4065,8 @@ class TestForceFieldParameterAssignment:
         """Check that an error is thrown when essentially the same molecule is entered more than once
         for partial_bond_orders_from_molecules"""
 
-        mol = create_ethanol()
-        mol2 = create_reversed_ethanol()
+        mol = ethanol
+        mol2 = reversed_ethanol
 
         forcefield = ForceField("test_forcefields/test_forcefield.offxml", xml_ff_bo)
         topology = Topology.from_molecules([mol, mol2])
@@ -4353,7 +4080,7 @@ class TestForceFieldParameterAssignment:
 
     @pytest.mark.parametrize(
         ("get_molecule", "central_atoms"),
-        [(create_ethanol, (1, 2)), (create_reversed_ethanol, (7, 6))],
+        [(ethanol, (1, 2)), (reversed_ethanol, (7, 6))],
     )
     def test_fractional_bondorder_superseded_by_standard_torsion(
         self, get_molecule, central_atoms
@@ -4406,8 +4133,8 @@ class TestForceFieldParameterAssignment:
             "central_atoms",
         ),
         [
-            (create_ethanol, 4.953856, 42266.9635, 1.39991, (1, 2)),
-            (create_reversed_ethanol, 4.953856, 42266.9635, 1.39991, (7, 6)),
+            (ethanol, 4.953856, 42266.9635, 1.39991, (1, 2)),
+            (reversed_ethanol, 4.953856, 42266.9635, 1.39991, (7, 6)),
         ],
     )
     def test_fractional_bondorder_calculated_rdkit(
@@ -4517,8 +4244,8 @@ class TestForceFieldParameterAssignment:
             "central_atoms",
         ),
         [
-            (create_ethanol, 4.953856, 42208.540, 0.140054, (1, 2)),
-            (create_reversed_ethanol, 4.953856, 42208.540, 0.140054, (7, 6)),
+            (ethanol, 4.953856, 42208.540, 0.140054, (1, 2)),
+            (reversed_ethanol, 4.953856, 42208.540, 0.140054, (7, 6)),
         ],
     )
     def test_fractional_bondorder_calculated_openeye(
@@ -4613,12 +4340,11 @@ class TestForceFieldParameterAssignment:
                 length = params[-2]
                 assert_almost_equal(length / length.unit, bond_length_interpolated, 0)
 
-    def test_fractional_bondorder_invalid_interpolation_method(self):
+    def test_fractional_bondorder_invalid_interpolation_method(self, ethanol):
         """
         Ensure that requesting an invalid interpolation method leads to a
         FractionalBondOrderInterpolationMethodUnsupportedError
         """
-        mol = create_ethanol()
 
         forcefield = ForceField("test_forcefields/test_forcefield.offxml", xml_ff_bo)
         forcefield.get_parameter_handler(

--- a/openforcefield/tests/test_forcefield.py
+++ b/openforcefield/tests/test_forcefield.py
@@ -488,15 +488,12 @@ partial_charge_method_resolution_matrix = [
 toolkit_registries = []
 if OpenEyeToolkitWrapper.is_available():
     toolkit_registries.append(
-        (ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper]), "OE")
+        ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])
     )
 if RDKitToolkitWrapper.is_available() and AmberToolsToolkitWrapper.is_available():
     toolkit_registries.append(
-        (
-            ToolkitRegistry(
-                toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper]
-            ),
-            "RDKit+AmberTools",
+        ToolkitRegistry(
+            toolkit_precedence=[RDKitToolkitWrapper, AmberToolsToolkitWrapper]
         )
     )
 
@@ -933,10 +930,8 @@ class TestForceField:
 
         ff = ForceField(gbsa_ff_xml)
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
-    def test_parameterize_ethanol(self, toolkit_registry, registry_description):
+    @pytest.mark.parametrize("toolkit_registry,", toolkit_registries)
+    def test_parameterize_ethanol(self, toolkit_registry, ethanol):
         from simtk.openmm import app
 
         forcefield = ForceField("test_forcefields/test_forcefield.offxml")
@@ -944,9 +939,7 @@ class TestForceField:
         molecules = [ethanol]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
-        omm_system = forcefield.create_openmm_system(
-            topology, toolkit_registry=toolkit_registry
-        )
+        forcefield.create_openmm_system(topology, toolkit_registry=toolkit_registry)
 
     @pytest.fixture()
     def create_circular_handler_dependencies(self):
@@ -971,9 +964,7 @@ class TestForceField:
         BondHandler._DEPENDENCIES = orig_bh_depends
         AngleHandler._DEPENDENCIES = orig_ah_depends
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
     def test_parameterize_ethanol_handler_dependency_loop(
         self,
         create_circular_handler_dependencies,
@@ -1023,12 +1014,10 @@ class TestForceField:
             UnassignedProperTorsionParameterException,
             match="- Topology indices [(]5, 0, 1, 6[)]: "
             r"names and elements [(](H\d+)? H[)], [(](C\d+)? C[)], [(](C\d+)? C[)], [(](H\d+)? H[)],",
-        ) as excinfo:
-            omm_system = forcefield.create_openmm_system(topology)
+        ):
+            forcefield.create_openmm_system(topology)
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
     def test_parameterize_1_cyclohexane_1_ethanol(
         self,
         toolkit_registry,
@@ -1046,11 +1035,9 @@ class TestForceField:
         molecules = [ethanol, cyclohexane]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
-        omm_system = forcefield.create_openmm_system(topology)
+        forcefield.create_openmm_system(topology)
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
     def test_parameterize_1_cyclohexane_1_ethanol_vacuum(
         self,
         toolkit_registry,
@@ -1068,12 +1055,10 @@ class TestForceField:
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         topology.box_vectors = None
 
-        omm_system = forcefield.create_openmm_system(topology)
+        forcefield.create_openmm_system(topology)
 
     @pytest.mark.slow
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
     @pytest.mark.parametrize(
         "box",
         [
@@ -1083,9 +1068,7 @@ class TestForceField:
             "propane_methane_butanol_0.2_0.3_0.5.pdb",
         ],
     )
-    def test_parameterize_large_system(
-        self, toolkit_registry, registry_description, box
-    ):
+    def test_parameterize_large_system(self, toolkit_registry, box):
         """Test parameterizing a large system of several distinct molecules.
         This test is very slow, so it is only run if the --runslow option is provided to pytest.
         """
@@ -1254,12 +1237,8 @@ class TestForceField:
             topology, positions=pdbfile.getPositions()
         )
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
-    def test_pass_invalid_kwarg_to_create_openmm_system(
-        self, toolkit_registry, registry_description
-    ):
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
+    def test_pass_invalid_kwarg_to_create_openmm_system(self, toolkit_registry):
         """Test to ensure an exception is raised when an unrecognized kwarg is passed """
         from simtk.openmm import app
 
@@ -1915,52 +1894,36 @@ class TestForceFieldVirtualSites:
     )
     trivalent_parameters_args.append(opts)
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
     @pytest.mark.parametrize("args", bond_charge_parameters_args)
-    def test_bond_charge_virtual_site_parameters(
-        self, toolkit_registry, registry_description, args
-    ):
+    def test_bond_charge_virtual_site_parameters(self, toolkit_registry, args):
         """
         Test force fields with bond charge lone pair virtual sites
         """
 
         self._test_physical_parameters(toolkit_registry, *args.values())
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
     @pytest.mark.parametrize("args", monovalent_parameters_args)
-    def test_monovalent_virtual_site_parameters(
-        self, toolkit_registry, registry_description, args
-    ):
+    def test_monovalent_virtual_site_parameters(self, toolkit_registry, args):
         """
         Test force fields with monovalent charge lone pair virtual sites
         """
 
         self._test_physical_parameters(toolkit_registry, *args.values())
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
     @pytest.mark.parametrize("args", divalent_parameters_args)
-    def test_divalent_virtual_site_parameters(
-        self, toolkit_registry, registry_description, args
-    ):
+    def test_divalent_virtual_site_parameters(self, toolkit_registry, args):
         """
         Test force fields with divalent lone pair virtual sites
         """
 
         self._test_physical_parameters(toolkit_registry, *args.values())
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
     @pytest.mark.parametrize("args", trivalent_parameters_args)
-    def test_trivalent_charge_virtual_site(
-        self, toolkit_registry, registry_description, args
-    ):
+    def test_trivalent_charge_virtual_site(self, toolkit_registry, args):
         """
         Test force fields with trivalent lone pair virtual sites
         """
@@ -1982,10 +1945,8 @@ class TestForceFieldChargeAssignment:
             ("I-", -1 * unit.elementary_charge),
         )
 
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
-    def test_charges_from_molecule(self, toolkit_registry, registry_description):
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
+    def test_charges_from_molecule(self, toolkit_registry, ethanol):
         """Test skipping charge generation and instead getting charges from the original Molecule"""
         # Create an ethanol molecule without using a toolkit
         molecules = [ethanol]
@@ -3903,10 +3864,8 @@ class TestForceFieldParameterAssignment:
 
     @pytest.mark.slow
     @requires_openeye_mol2
-    @pytest.mark.parametrize(
-        "toolkit_registry,registry_description", toolkit_registries
-    )
-    def test_parameterize_protein(self, toolkit_registry, registry_description):
+    @pytest.mark.parametrize("toolkit_registry", toolkit_registries)
+    def test_parameterize_protein(self, toolkit_registry):
         """Test that ForceField assigns parameters correctly for a protein"""
 
         mol_path = get_data_file_path("proteins/T4-protein.mol2")

--- a/openforcefield/tests/test_links.py
+++ b/openforcefield/tests/test_links.py
@@ -58,5 +58,5 @@ def test_readme_links(readme_link):
             break
         except Exception as e:
             exception = e
-    if not (success):
+    if not success:
         raise exception

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -323,6 +323,7 @@ class TestMolecule:
 
     # Test serialization {to|from}_{dict|yaml|toml|json|bson|xml|messagepack|pickle}
 
+    @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_dict_serialization(self, molecule):
         """Test serialization of a molecule object to and from dict."""
@@ -332,6 +333,7 @@ class TestMolecule:
         assert molecule_copy.n_conformers == molecule.n_conformers
         assert np.allclose(molecule_copy.conformers[0], molecule.conformers[0])
 
+    @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_yaml_serialization(self, molecule):
         """Test serialization of a molecule object to and from YAML."""
@@ -341,6 +343,7 @@ class TestMolecule:
         assert molecule_copy.n_conformers == molecule.n_conformers
         assert np.allclose(molecule_copy.conformers[0], molecule.conformers[0])
 
+    @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_toml_serialization(self, molecule):
         """Test serialization of a molecule object to and from TOML."""
@@ -349,6 +352,7 @@ class TestMolecule:
         with pytest.raises(NotImplementedError):
             mol.to_toml()
 
+    @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_bson_serialization(self, molecule):
         """Test serialization of a molecule object to and from BSON."""
@@ -358,6 +362,7 @@ class TestMolecule:
         assert molecule_copy.n_conformers == molecule.n_conformers
         assert np.allclose(molecule_copy.conformers[0], molecule.conformers[0])
 
+    @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_json_serialization(self, molecule):
         """Test serialization of a molecule object to and from JSON."""
@@ -366,6 +371,7 @@ class TestMolecule:
         assert molecule_copy.n_conformers == molecule.n_conformers
         assert np.allclose(molecule_copy.conformers[0], molecule.conformers[0])
 
+    @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_xml_serialization(self, molecule):
         """Test serialization of a molecule object to and from XML."""
@@ -375,6 +381,7 @@ class TestMolecule:
         with pytest.raises(NotImplementedError):
             Molecule.from_xml(serialized)
 
+    @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_messagepack_serialization(self, molecule):
         """Test serialization of a molecule object to and from messagepack."""
@@ -384,6 +391,7 @@ class TestMolecule:
         assert molecule_copy.n_conformers == molecule.n_conformers
         assert np.allclose(molecule_copy.conformers[0], molecule.conformers[0])
 
+    @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_pickle_serialization(self, molecule):
         """Test round-trip pickling of a molecule object."""
@@ -393,6 +401,7 @@ class TestMolecule:
         assert molecule_copy.n_conformers == molecule.n_conformers
         assert np.allclose(molecule_copy.conformers[0], molecule.conformers[0])
 
+    @pytest.mark.serialization
     def test_serialization_no_conformers(self):
         """Test round-trip serialization when molecules have no conformers or partial charges."""
         mol = Molecule.from_smiles("CCO")
@@ -443,6 +452,7 @@ class TestMolecule:
         assert len(molecule.atoms) == 0
         assert len(molecule.bonds) == 0
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_create_copy(self, molecule):
         """Test copy constructor."""
@@ -454,6 +464,7 @@ class TestMolecule:
         molecule_copy.properties["aaa"] = "bbb"
         assert "aaa" not in molecule.properties
 
+    @pytest.mark.roundtrip
     @pytest.mark.parametrize("toolkit", [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_smiles(self, molecule, toolkit):
@@ -797,6 +808,7 @@ class TestMolecule:
             filename = get_data_file_path("molecules/zinc-subset-tripos.mol2.gz")
             molecule = Molecule(filename, allow_undefined_stereo=True)
 
+    @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_create_from_serialized(self, molecule):
         """Test standard constructor taking the output of __getstate__()."""
@@ -804,6 +816,7 @@ class TestMolecule:
         molecule_copy = Molecule(serialized_molecule)
         assert molecule == molecule_copy
 
+    @pytest.mark.roundtrip
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_dict(self, molecule):
         """Test that conversion/creation of a molecule to and from a dict is consistent."""
@@ -811,12 +824,14 @@ class TestMolecule:
         molecule_copy = Molecule.from_dict(serialized)
         assert molecule == molecule_copy
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_networkx(self, molecule):
         """Test conversion to NetworkX graph."""
         graph = molecule.to_networkx()
 
     @requires_rdkit
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_rdkit(self, molecule):
         """Test that conversion/creation of a molecule to and from an RDKit rdmol is consistent."""
@@ -902,6 +917,7 @@ class TestMolecule:
             cholesterol, Molecule.from_iupac(cholesterol_iupac)
         )
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_topology(self, molecule):
         """Test that conversion/creation of a molecule to and from a Topology is consistent."""
@@ -1001,6 +1017,7 @@ class TestMolecule:
                 for atom_coords in data[2:]:
                     assert atom_coords.split()[1:] == coords
 
+    @pytest.mark.serialization
     # TODO: Should there be an equivalent toolkit test and leave this as an integration test?
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     @pytest.mark.parametrize(
@@ -1049,6 +1066,7 @@ class TestMolecule:
             # NOTE: We can't read pdb files and expect chemical information to be preserved
 
     @requires_openeye
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_oemol(self, molecule):
         """Test that conversion/creation of a molecule to and from a OEMol is consistent."""

--- a/openforcefield/tests/test_molecule.py
+++ b/openforcefield/tests/test_molecule.py
@@ -32,7 +32,6 @@ import numpy as np
 import pytest
 from simtk import unit
 
-from openforcefield.tests.conftest import *
 from openforcefield.tests.utils import (
     has_pkg,
     requires_openeye,
@@ -320,8 +319,6 @@ class TestMolecule:
     """Test Molecule class."""
 
     # TODO: Test getstate/setstate
-
-    # Test serialization {to|from}_{dict|yaml|toml|json|bson|xml|messagepack|pickle}
 
     @pytest.mark.serialization
     @pytest.mark.parametrize("molecule", mini_drug_bank())
@@ -804,7 +801,7 @@ class TestMolecule:
 
         # Ensure that attempting to initialize a single Molecule from a file
         # containing multiple molecules raises a ValueError
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError):
             filename = get_data_file_path("molecules/zinc-subset-tripos.mol2.gz")
             molecule = Molecule(filename, allow_undefined_stereo=True)
 
@@ -1184,14 +1181,14 @@ class TestMolecule:
         # check a reference mapping between ethanol and ethanol_reverse matches that calculated
         ref_mapping = {0: 8, 1: 7, 2: 6, 3: 3, 4: 4, 5: 5, 6: 1, 7: 2, 8: 0}
         assert (
-            Molecule.are_isomorphic(ethanol, ethanol_reverse, return_atom_map=True)[1]
+            Molecule.are_isomorphic(ethanol, reversed_ethanol, return_atom_map=True)[1]
             == ref_mapping
         )
         # check matching with nx.Graph atomic numbers and connectivity only
         assert (
             Molecule.are_isomorphic(
                 ethanol,
-                ethanol_reverse.to_networkx(),
+                reversed_ethanol.to_networkx(),
                 aromatic_matching=False,
                 formal_charge_matching=False,
                 bond_order_matching=False,
@@ -1201,7 +1198,7 @@ class TestMolecule:
             is True
         )
         # check matching with nx.Graph with full matching
-        assert ethanol.is_isomorphic_with(ethanol_reverse.to_networkx()) is True
+        assert ethanol.is_isomorphic_with(reversed_ethanol.to_networkx()) is True
         # check matching with a TopologyMolecule class
         from openforcefield.topology.topology import Topology, TopologyMolecule
 
@@ -1428,7 +1425,7 @@ class TestMolecule:
 
         # check all of the properties match as well, torsions and impropers will be in a different order
         # due to the bonds being out of order
-        assert_molecules_match_after_remap(new_ethanol, ethanol_reverse)
+        assert_molecules_match_after_remap(new_ethanol, reversed_ethanol)
 
         # test round trip (double remapping a molecule)
         new_ethanol = ethanol.remap(mapping, current_to_new=True)
@@ -2111,7 +2108,7 @@ class TestMolecule:
             ),
             unit.angstrom,
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_conformer(conf_missing_z)
 
         conf_too_few_atoms = unit.Quantity(
@@ -2125,7 +2122,7 @@ class TestMolecule:
             ),
             unit.angstrom,
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_conformer(conf_too_few_atoms)
 
         # Add a conformer with too many coordinates
@@ -2142,12 +2139,12 @@ class TestMolecule:
             ),
             unit.angstrom,
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_conformer(conf_too_many_atoms)
 
         # Add a conformer with no coordinates
         conf_no_coordinates = unit.Quantity(np.array([]), unit.angstrom)
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_conformer(conf_no_coordinates)
 
         # Add a conforer with units of nanometers
@@ -2180,7 +2177,7 @@ class TestMolecule:
             ),
             unit.joule,
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_conformer(conf_nonsense_units)
 
         # Add a conformer with no units
@@ -2193,7 +2190,7 @@ class TestMolecule:
                 [13.0, 14.0, 15],
             ]
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_conformer(conf_unitless)
 
     @pytest.mark.parametrize("molecule", mini_drug_bank())
@@ -2217,7 +2214,7 @@ class TestMolecule:
                 fractional_bond_order=bond.fractional_bond_order,
             )
         # Try to add the final bond twice, which should raise an Exception
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule_copy.add_bond(
                 bond.atom1_index,
                 bond.atom2_index,
@@ -2260,13 +2257,13 @@ class TestMolecule:
         atoms = (atom1, atom2)
 
         # Try to feed in unitless sigma
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_bond_charge_virtual_site(
                 atoms, distance, epsilon=epsilon, sigma=sigma_unitless, replace=True
             )
 
         # Try to feed in unitless rmin_half
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_bond_charge_virtual_site(
                 atoms,
                 distance,
@@ -2276,7 +2273,7 @@ class TestMolecule:
             )
 
         # Try to feed in unitless epsilon
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_bond_charge_virtual_site(
                 atoms,
                 distance,
@@ -2287,7 +2284,7 @@ class TestMolecule:
             )
 
         # Try to feed in unitless charges
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_bond_charge_virtual_site(
                 atoms,
                 distance,
@@ -2296,7 +2293,7 @@ class TestMolecule:
             )
 
         # We shouldn't be able to give both rmin_half and sigma VdW parameters.
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_bond_charge_virtual_site(
                 [atom1, atom2],
                 distance,
@@ -2319,7 +2316,7 @@ class TestMolecule:
         # TODO: Test the @property getters for sigma, epsilon, and rmin_half
 
         # We should have to give as many charge increments as atoms (len(charge_increments)) = 4
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.add_bond_charge_virtual_site(
                 atoms, distance, charge_increments=[0.0], replace=True
             )
@@ -2380,7 +2377,7 @@ class TestMolecule:
         distance = distance_unitless * unit.angstrom
 
         # Try to feed in a unitless distance
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(AssertionError):
             vsite1_index = molecule.add_bond_charge_virtual_site(
                 [atom1, atom2], distance_unitless
             )
@@ -2444,7 +2441,7 @@ class TestMolecule:
         atoms = (atom1, atom2, atom3)
 
         # Try passing in a unitless distance
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(AssertionError):
             vsite1_index = molecule.add_monovalent_lone_pair_virtual_site(
                 atoms,
                 distance_unitless,
@@ -2454,7 +2451,7 @@ class TestMolecule:
             )
 
         # Try passing in a unitless out_of_plane_angle
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(AssertionError):
             vsite1_index = molecule.add_monovalent_lone_pair_virtual_site(
                 atoms,
                 distance,
@@ -2464,7 +2461,7 @@ class TestMolecule:
             )
 
         # Try passing in a unitless in_plane_angle
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(AssertionError):
             vsite1_index = molecule.add_monovalent_lone_pair_virtual_site(
                 atoms,
                 distance,
@@ -2474,7 +2471,7 @@ class TestMolecule:
             )
 
         # Try giving two atoms
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(AssertionError):
             vsite1_index = molecule.add_monovalent_lone_pair_virtual_site(
                 [atom1, atom2],
                 distance,
@@ -2512,7 +2509,7 @@ class TestMolecule:
         )
 
         # test giving too few atoms
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(AssertionError):
             vsite1_index = molecule.add_divalent_lone_pair_virtual_site(
                 [atom1, atom2],
                 distance,
@@ -2541,7 +2538,7 @@ class TestMolecule:
             replace=False,
         )
         # Test for assertion when giving too few atoms
-        with pytest.raises(AssertionError) as excinfo:
+        with pytest.raises(AssertionError):
             vsite1_index = molecule.add_trivalent_lone_pair_virtual_site(
                 [atom1, atom2, atom3],
                 distance,
@@ -2753,9 +2750,6 @@ class TestMolecule:
     @requires_openeye
     def test_assign_fractional_bond_orders(self):
         """Test assignment of fractional bond orders"""
-        # TODO: Test only one molecule for speed?
-        # TODO: Do we need to deepcopy each molecule, or is setUp called separately for each test method?
-
         # Do not modify the original molecules.
         molecules = copy.deepcopy(mini_drug_bank())
 

--- a/openforcefield/tests/test_parameters.py
+++ b/openforcefield/tests/test_parameters.py
@@ -295,7 +295,7 @@ class TestInterpolation:
         k_bondorder = {
             2: 1.8 * unit.kilocalorie_per_mole,
         }
-        with pytest.raises(NotEnoughPointsForInterpolationError) as excinfo:
+        with pytest.raises(NotEnoughPointsForInterpolationError):
             k = _linear_inter_or_extrapolate(k_bondorder, 1)
 
     @pytest.mark.parametrize(
@@ -623,7 +623,7 @@ class TestParameterHandler:
         # Generate a SMIRNOFFSpecError by not providing a section version
         with pytest.raises(
             SMIRNOFFSpecError, match="Missing version while trying to construct"
-        ) as excinfo:
+        ):
             ph = ParameterHandler()
         # Successfully create ParameterHandler by skipping version check
         ph = ParameterHandler(skip_version_check=True)
@@ -639,7 +639,7 @@ class TestParameterHandler:
             SMIRNOFFVersionError,
             match="SMIRNOFF offxml file was written with version 1000.0, "
             "but this version of ForceField only supports version",
-        ) as excinfo:
+        ):
             ph = ParameterHandler(version="1000.0")
 
         # Generate a SMIRNOFFSpecError by providing a value lower than the min supported
@@ -647,7 +647,7 @@ class TestParameterHandler:
             SMIRNOFFVersionError,
             match="SMIRNOFF offxml file was written with version 0.1, "
             "but this version of ForceField only supports version",
-        ) as excinfo:
+        ):
             ph = ParameterHandler(version="0.1")
 
     def test_supported_version_range(self):
@@ -659,13 +659,13 @@ class TestParameterHandler:
             _MIN_SUPPORTED_SECTION_VERSION = 0.3
             _MAX_SUPPORTED_SECTION_VERSION = 2
 
-        with pytest.raises(SMIRNOFFVersionError) as excinfo:
+        with pytest.raises(SMIRNOFFVersionError):
             my_ph = MyPHSubclass(version=0.1)
         my_ph = MyPHSubclass(version=0.3)
         my_ph = MyPHSubclass(version=1)
         my_ph = MyPHSubclass(version="1.9")
         my_ph = MyPHSubclass(version=2.0)
-        with pytest.raises(SMIRNOFFVersionError) as excinfo:
+        with pytest.raises(SMIRNOFFVersionError):
             my_ph = MyPHSubclass(version=2.1)
 
     def test_write_same_version_as_was_set(self):
@@ -826,7 +826,7 @@ class TestParameterList:
             parameters.index("[#2:1]")
 
         p4 = ParameterType(smirks="[#2:1]")
-        with pytest.raises(ValueError, match="is not in list") as excinfo:
+        with pytest.raises(ValueError, match="is not in list"):
             parameters.index(p4)
 
     def test_contains(self):
@@ -1982,7 +1982,7 @@ class TestVirtualSiteHandler:
         with pytest.raises(
             SMIRNOFFSpecError,
             match="TrivalentLonePair virtual site defined with match attribute set to all_permutations. Only supported value is 'once'.",
-        ) as excinfo:
+        ):
             vs = VirtualSiteHandler.VirtualSiteTrivalentLonePairType(**invalid_kwargs)
 
 
@@ -2009,7 +2009,7 @@ class TestLibraryChargeHandler:
         with pytest.raises(
             SMIRNOFFSpecError,
             match="initialized with unequal number of tagged atoms and charges",
-        ) as excinfo:
+        ):
             lc_type = LibraryChargeHandler.LibraryChargeType(
                 smirks="[#6:1]-[#7:2]",
                 charge1=0.05 * unit.elementary_charge,
@@ -2020,7 +2020,7 @@ class TestLibraryChargeHandler:
         with pytest.raises(
             SMIRNOFFSpecError,
             match="initialized with unequal number of tagged atoms and charges",
-        ) as excinfo:
+        ):
             lc_type = LibraryChargeHandler.LibraryChargeType(
                 smirks="[#6:1]-[#7:2]-[#6]",
                 charge1=0.05 * unit.elementary_charge,
@@ -2031,7 +2031,7 @@ class TestLibraryChargeHandler:
         with pytest.raises(
             SMIRNOFFSpecError,
             match="initialized with unequal number of tagged atoms and charges",
-        ) as excinfo:
+        ):
             lc_type = LibraryChargeHandler.LibraryChargeType(
                 smirks="[#6:1]-[#7:2]-[#6]", charge1=0.05 * unit.elementary_charge
             )
@@ -2058,11 +2058,11 @@ class TestChargeIncrementModelHandler:
         handler = ChargeIncrementModelHandler(
             skip_version_check=True, number_of_conformers="0"
         )
-        with pytest.raises(TypeError) as excinfo:
+        with pytest.raises(TypeError):
             handler = ChargeIncrementModelHandler(
                 skip_version_check=True, number_of_conformers=None
             )
-        with pytest.raises(SMIRNOFFSpecError) as excinfo:
+        with pytest.raises(SMIRNOFFSpecError):
             handler = ChargeIncrementModelHandler(
                 skip_version_check=True, n_conformers=[10]
             )
@@ -2085,7 +2085,7 @@ class TestChargeIncrementModelHandler:
         assert handler.number_of_conformers == 2
         handler.number_of_conformers = "3"
         assert handler.number_of_conformers == 3
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError):
             handler.number_of_conformers = "string that can't be cast to int"
 
     def test_charge_increment_model_handlers_are_compatible(self):
@@ -2097,7 +2097,7 @@ class TestChargeIncrementModelHandler:
         handler3 = ChargeIncrementModelHandler(
             skip_version_check=True, number_of_conformers="9"
         )
-        with pytest.raises(IncompatibleParameterError) as excinfo:
+        with pytest.raises(IncompatibleParameterError):
             handler1.check_handler_compatibility(handler3)
 
     def test_charge_increment_type_wrong_num_increments(self):
@@ -2118,7 +2118,7 @@ class TestChargeIncrementModelHandler:
         with pytest.raises(
             SMIRNOFFSpecError,
             match="an invalid combination of tagged atoms and charge increments",
-        ) as excinfo:
+        ):
             ci_type = ChargeIncrementModelHandler.ChargeIncrementType(
                 smirks="[#6:1]-[#7:2]",
                 charge_increment1=0.05 * unit.elementary_charge,
@@ -2129,7 +2129,7 @@ class TestChargeIncrementModelHandler:
         with pytest.raises(
             SMIRNOFFSpecError,
             match="an invalid combination of tagged atoms and charge increments",
-        ) as excinfo:
+        ):
             ci_type = ChargeIncrementModelHandler.ChargeIncrementType(
                 smirks="[#6:1]-[#7:2]-[#6]",
                 charge_increment1=0.05 * unit.elementary_charge,
@@ -2183,17 +2183,17 @@ class TestGBSAHandler:
         gbsa_handler.gb_model = "OBC2"
         gbsa_handler.gb_model = "HCT"
         gbsa_handler.gb_model = "OBC1"
-        with pytest.raises(SMIRNOFFSpecError) as excinfo:
+        with pytest.raises(SMIRNOFFSpecError):
             gbsa_handler.gb_model = "Something invalid"
 
         gbsa_handler.solvent_dielectric = 50.0
         gbsa_handler.solvent_dielectric = "50.0"
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError):
             gbsa_handler.solvent_dielectric = "string that can not be cast to float"
 
         gbsa_handler.solute_dielectric = 2.5
         gbsa_handler.solute_dielectric = "3.5"
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(ValueError):
             gbsa_handler.solute_dielectric = "string that can not be cast to float"
 
         gbsa_handler.sa_model = "ACE"
@@ -2202,19 +2202,19 @@ class TestGBSAHandler:
         gbsa_handler.sa_model = None
         gbsa_handler.sa_model = "None"
 
-        with pytest.raises(TypeError) as excinfo:
+        with pytest.raises(TypeError):
             gbsa_handler.sa_model = "Invalid SA option"
 
         gbsa_handler.surface_area_penalty = (
             1.23 * unit.kilocalorie / unit.mole / unit.nanometer ** 2
         )
-        with pytest.raises(IncompatibleUnitError) as excinfo:
+        with pytest.raises(IncompatibleUnitError):
             gbsa_handler.surface_area_penalty = (
                 1.23 * unit.degree / unit.mole / unit.nanometer ** 2
             )
 
         gbsa_handler.solvent_radius = 300 * unit.femtometer
-        with pytest.raises(IncompatibleUnitError) as excinfo:
+        with pytest.raises(IncompatibleUnitError):
             gbsa_handler.solvent_radius = 3000 * unit.radian
 
     def test_gbsahandlers_are_compatible(self):
@@ -2235,7 +2235,7 @@ class TestGBSAHandler:
         )
         with pytest.raises(
             IncompatibleParameterError, match="Difference between 'solvent_radius' "
-        ) as excinfo:
+        ):
             gbsa_handler_1.check_handler_compatibility(gbsa_handler_3)
 
 

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -20,13 +20,6 @@ import pytest
 from numpy.testing import assert_almost_equal
 from simtk import unit
 
-from openforcefield.tests.test_forcefield import (
-    create_acetaldehyde,
-    create_acetate,
-    create_cyclohexane,
-    create_ethanol,
-    create_reversed_ethanol,
-)
 from openforcefield.tests.utils import (
     requires_ambertools,
     requires_openeye,
@@ -559,7 +552,7 @@ class TestOpenEyeToolkitWrapper:
         with pytest.raises(
             ValueError,
             match="but OpenEye Toolkit interpreted SMILES 'C#C' as having implicit hydrogen",
-        ) as excinfo:
+        ):
             offmol = Molecule.from_smiles(
                 smiles_impl,
                 toolkit_registry=toolkit_wrapper,
@@ -834,7 +827,7 @@ class TestOpenEyeToolkitWrapper:
                 charge_line_found = True
 
         # Make sure that a charge line was ever found
-        assert charge_line_found == True
+        assert charge_line_found
 
         # Make sure that the charges found were correct
         assert_almost_equal(
@@ -1196,7 +1189,7 @@ class TestOpenEyeToolkitWrapper:
         # which means it will only ever return ValueError
         with pytest.raises(
             ValueError, match="is not available from OpenEyeToolkitWrapper"
-        ) as excinfo:
+        ):
             molecule.assign_partial_charges(
                 toolkit_registry=toolkit_registry,
                 partial_charge_method="NotARealChargeMethod",
@@ -1206,7 +1199,7 @@ class TestOpenEyeToolkitWrapper:
         with pytest.raises(
             ChargeMethodUnavailableError,
             match="is not available from OpenEyeToolkitWrapper",
-        ) as excinfo:
+        ):
             OETKW = OpenEyeToolkitWrapper()
             OETKW.assign_partial_charges(
                 molecule=molecule, partial_charge_method="NotARealChargeMethod"
@@ -1291,7 +1284,7 @@ class TestOpenEyeToolkitWrapper:
         molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
 
         # For now, I'm just testing AM1-BCC (will test more when the SMIRNOFF spec for other charges is finalized)
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(Exception):
             molecule.compute_partial_charges_am1bcc(toolkit_registry=toolkit_wrapper)
             assert "Unable to assign charges" in str(excinfo)
             assert "OE Error: " in str(excinfo)
@@ -1413,7 +1406,7 @@ class TestOpenEyeToolkitWrapper:
             "Bond order model 'not a real bond order model' is not supported by "
             "OpenEyeToolkitWrapper. Supported models are ([[]'am1-wiberg', 'pm3-wiberg'[]])"
         )
-        with pytest.raises(ValueError, match=expected_error) as excinfo:
+        with pytest.raises(ValueError, match=expected_error):
             molecule.assign_fractional_bond_orders(
                 toolkit_registry=toolkit_wrapper,
                 bond_order_model="not a real bond order model",
@@ -1492,7 +1485,6 @@ class TestOpenEyeToolkitWrapper:
         assert bonds == []
 
         # test  molecules that should have no rotatable bonds
-        cyclohexane = cyclohexane
         bonds = cyclohexane.find_rotatable_bonds()
         assert bonds == []
 
@@ -1588,8 +1580,8 @@ class TestRDKitToolkitWrapper:
         with pytest.raises(
             ValueError,
             match="but RDKit toolkit interpreted SMILES 'C#C' as having implicit hydrogen",
-        ) as excinfo:
-            offmol = Molecule.from_smiles(
+        ):
+            Molecule.from_smiles(
                 smiles_impl,
                 toolkit_registry=toolkit_wrapper,
                 hydrogens_are_explicit=True,
@@ -2283,7 +2275,6 @@ class TestRDKitToolkitWrapper:
         assert bonds == []
 
         # test  molecules that should have no rotatable bonds
-        cyclohexane = cyclohexane
         bonds = cyclohexane.find_rotatable_bonds()
         assert bonds == []
 
@@ -2535,7 +2526,7 @@ class TestAmberToolsToolkitWrapper:
         # was thrown inside them, so we just check for a ValueError here
         with pytest.raises(
             ValueError, match="is not available from AmberToolsToolkitWrapper"
-        ) as excinfo:
+        ):
             molecule.assign_partial_charges(
                 toolkit_registry=toolkit_registry,
                 partial_charge_method="NotARealChargeMethod",
@@ -2545,7 +2536,7 @@ class TestAmberToolsToolkitWrapper:
         with pytest.raises(
             ChargeMethodUnavailableError,
             match="is not available from AmberToolsToolkitWrapper",
-        ) as excinfo:
+        ):
             ATTKW = AmberToolsToolkitWrapper()
             ATTKW.assign_partial_charges(
                 molecule=molecule, partial_charge_method="NotARealChargeMethod"
@@ -2740,7 +2731,7 @@ class TestAmberToolsToolkitWrapper:
             "Bond order model 'not a real charge model' is not supported by "
             "AmberToolsToolkitWrapper. Supported models are ([[]'am1-wiberg'[]])"
         )
-        with pytest.raises(ValueError, match=expected_error) as excinfo:
+        with pytest.raises(ValueError, match=expected_error):
             molecule.assign_fractional_bond_orders(
                 toolkit_registry=AmberToolsToolkitWrapper(),
                 bond_order_model="not a real charge model",
@@ -2826,7 +2817,7 @@ class TestBuiltInToolkitWrapper:
         # was thrown inside them, so we just check for a ValueError here
         with pytest.raises(
             ValueError, match="is not supported by the Built-in toolkit"
-        ) as excinfo:
+        ):
             molecule.assign_partial_charges(
                 toolkit_registry=toolkit_registry,
                 partial_charge_method="NotARealChargeMethod",
@@ -2836,7 +2827,7 @@ class TestBuiltInToolkitWrapper:
         with pytest.raises(
             ChargeMethodUnavailableError,
             match="is not supported by the Built-in toolkit",
-        ) as excinfo:
+        ):
             BITKW = BuiltInToolkitWrapper()
             BITKW.assign_partial_charges(
                 molecule=molecule, partial_charge_method="NotARealChargeMethod"
@@ -3320,7 +3311,7 @@ class TestToolkitRegistry:
             toolkit_registry.deregister_toolkit(RDKitToolkitWrapper)
 
     def deregister_from_global_registry(self):
-        # TODO: Update this, or move into a separate TestClass, pending GLOBAL_TOOLKIT_REGISTRY rewor
+        # TODO: Update this, or move into a separate TestClass, pending GLOBAL_TOOLKIT_REGISTRY rework
         # See issue #493
         # Whatever the first tookit it, de-register it and verify it's de-registered
 

--- a/openforcefield/tests/test_toolkits.py
+++ b/openforcefield/tests/test_toolkits.py
@@ -584,6 +584,7 @@ class TestOpenEyeToolkitWrapper:
         )
         assert offmol.n_atoms == 4
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", get_mini_drug_bank(OpenEyeToolkitWrapper))
     def test_to_inchi(self, molecule):
         """Test conversion to standard and non-standard InChI"""
@@ -592,6 +593,7 @@ class TestOpenEyeToolkitWrapper:
         inchi = molecule.to_inchi(toolkit_registry=toolkit)
         non_standard = molecule.to_inchi(True, toolkit_registry=toolkit)
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", get_mini_drug_bank(OpenEyeToolkitWrapper))
     def test_to_inchikey(self, molecule):
         """Test the conversion to standard and non-standard InChIKey"""
@@ -608,6 +610,7 @@ class TestOpenEyeToolkitWrapper:
         with pytest.raises(RuntimeError):
             mol = Molecule.from_inchi(inchi, toolkit_registry=toolkit)
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", get_mini_drug_bank(OpenEyeToolkitWrapper))
     def test_non_standard_inchi_round_trip(self, molecule):
         """Test if a molecule can survive an InChi round trip test in some cases the standard InChI
@@ -640,6 +643,7 @@ class TestOpenEyeToolkitWrapper:
                     mol2, bond_order_matching=False, toolkit_registry=toolkit
                 )
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize(
         "molecule",
         get_mini_drug_bank(
@@ -1609,6 +1613,7 @@ class TestRDKitToolkitWrapper:
         )
         assert offmol.n_atoms == 4
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", get_mini_drug_bank(RDKitToolkitWrapper))
     def test_to_inchi(self, molecule):
         """Test conversion to standard and non-standard InChI"""
@@ -1617,6 +1622,7 @@ class TestRDKitToolkitWrapper:
         inchi = molecule.to_inchi(toolkit_registry=toolkit)
         non_standard = molecule.to_inchi(fixed_hydrogens=True, toolkit_registry=toolkit)
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", get_mini_drug_bank(RDKitToolkitWrapper))
     def test_to_inchikey(self, molecule):
         """Test the conversion to standard and non-standard InChIKey"""
@@ -1691,6 +1697,7 @@ class TestRDKitToolkitWrapper:
 
         compare_mols(ref_mol, nonstandard_inchi_mol)
 
+    @pytest.mark.roundrip
     @pytest.mark.parametrize("molecule", get_mini_drug_bank(RDKitToolkitWrapper))
     def test_non_standard_inchi_round_trip(self, molecule):
         """Test if a molecule can survive an InChi round trip test in some cases the standard InChI

--- a/openforcefield/tests/test_topology.py
+++ b/openforcefield/tests/test_topology.py
@@ -17,7 +17,6 @@ import numpy as np
 import pytest
 from simtk import unit
 
-from openforcefield.tests.conftest import *
 from openforcefield.tests.utils import (
     get_data_file_path,
     requires_openeye,
@@ -757,8 +756,6 @@ class TestTopology:
         """
         from tempfile import NamedTemporaryFile
 
-        from simtk.unit import nanometer
-
         from openforcefield.topology import Molecule, Topology
 
         topology = Topology()
@@ -782,7 +779,7 @@ class TestTopology:
         count = 1
         coord = None
         with NamedTemporaryFile(suffix=".pdb") as iofile:
-            positions_nanometer = positions_angstrom.in_units_of(nanometer)
+            positions_nanometer = positions_angstrom.in_units_of(unit.nanometer)
             topology.to_file(iofile.name, positions_nanometer)
             data = open(iofile.name).readlines()
             for line in data:


### PR DESCRIPTION
This PR is another pass through the test suite, fixing a handful of that are non-critical but non-negligible

- [x] Update `unittest` code in `test_topology.py`
- [x] Convert `create_molecule` functions to fixtures
  - [ ] Find a way to force these through `@pytest.mark.parametrize` (maybe by re-using molecules with something other than fixtures?)
- [ ] Load MiniDrugBank molecules from a common source (discovered in a recent PR, one which I can't dig up at the moment)
- [x] Add marks for turning on/off some categories of tests (#712) i.e. `pytest -m "not serialization"` will skip tests marked as such
- [x] Remove ` as excinfo` pattern when `excinfo` not used