### PR TITLE
Expose ELF conformer selection through the OpenEye wrapper.

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -10,6 +10,13 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 0.9.1 - Current development
 ---------------------------
 
+New features
+""""""""""""
+- `PR #831 <https://github.com/openforcefield/openforcefield/pull/831>`_: Expose ELF conformer selection through the
+  OpenEye wrapper.
+- `PR #793 <https://github.com/openforcefield/openforcefield/pull/793>`_: Add an initial ELF conformer selection
+  implementation which uses RDKit.
+
 Behavior changed
 """"""""
 - `PR #802 <https://github.com/openforcefield/openforcefield/pull/802>`_: Fixes

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -1122,6 +1122,65 @@ class TestOpenEyeToolkitWrapper:
         )
         assert molecule2.n_conformers == 10
 
+    def test_apply_elf_conformer_selection(self):
+        """Test applying the ELF10 method."""
+
+        toolkit = OpenEyeToolkitWrapper()
+
+        molecule = Molecule.from_file(
+            get_data_file_path(os.path.join("molecules", "z_3_hydroxy_propenal.sdf")),
+            "SDF",
+        )
+
+        # Test that the simple case of no conformers does not yield an exception.
+        toolkit.apply_elf_conformer_selection(molecule)
+
+        initial_conformers = [
+            # Add a conformer with an internal H-bond.
+            np.array(
+                [
+                    [0.5477, 0.3297, -0.0621],
+                    [-0.1168, -0.7881, 0.2329],
+                    [-1.4803, -0.8771, 0.1667],
+                    [-0.2158, 1.5206, -0.4772],
+                    [-1.4382, 1.5111, -0.5580],
+                    [1.6274, 0.3962, -0.0089],
+                    [0.3388, -1.7170, 0.5467],
+                    [-1.8612, -0.0347, -0.1160],
+                    [0.3747, 2.4222, -0.7115],
+                ]
+            )
+            * unit.angstrom,
+            # Add a conformer without an internal H-bond.
+            np.array(
+                [
+                    [0.5477, 0.3297, -0.0621],
+                    [-0.1168, -0.7881, 0.2329],
+                    [-1.4803, -0.8771, 0.1667],
+                    [-0.2158, 1.5206, -0.4772],
+                    [0.3353, 2.5772, -0.7614],
+                    [1.6274, 0.3962, -0.0089],
+                    [0.3388, -1.7170, 0.5467],
+                    [-1.7743, -1.7634, 0.4166],
+                    [-1.3122, 1.4082, -0.5180],
+                ]
+            )
+            * unit.angstrom,
+        ]
+
+        molecule._conformers = [*initial_conformers]
+
+        # Apply ELF10
+        toolkit.apply_elf_conformer_selection(molecule)
+        elf10_conformers = molecule.conformers
+
+        assert len(elf10_conformers) == 1
+
+        assert np.allclose(
+            elf10_conformers[0].value_in_unit(unit.angstrom),
+            initial_conformers[1].value_in_unit(unit.angstrom),
+        )
+
     def test_assign_partial_charges_am1bcc(self):
         """Test OpenEyeToolkitWrapper assign_partial_charges() with am1bcc"""
         toolkit_registry = ToolkitRegistry(toolkit_precedence=[OpenEyeToolkitWrapper])

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -58,6 +58,7 @@ import importlib
 import inspect
 import itertools
 import logging
+import re
 import subprocess
 import tempfile
 from distutils.spawn import find_executable
@@ -2113,6 +2114,86 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         for conformer in molecule2._conformers:
             molecule._add_conformer(conformer)
+
+    def apply_elf_conformer_selection(
+        self,
+        molecule: "Molecule",
+        percentage: float = 2.0,
+        limit: int = 10,
+    ):
+        """Applies the `ELF method<https://docs.eyesopen.com/toolkits/python/quacpactk/
+        molchargetheory.html#elf-conformer-selection>`_ to select a set of diverse
+        conformers which have minimal electrostatically strongly interacting functional
+        groups from a molecules conformers.
+
+        Notes
+        -----
+        * The input molecule should have a large set of conformers already
+          generated to select the ELF conformers from.
+        * The selected conformers will be retained in the `molecule.conformers` list
+          while unselected conformers will be discarded.
+
+        See Also
+        --------
+        ``RDKitToolkitWrapper.apply_elf_conformer_selection``
+
+        Parameters
+        ----------
+        molecule
+            The molecule which contains the set of conformers to select from.
+        percentage
+            The percentage of conformers with the lowest electrostatic interaction
+            energies to greedily select from.
+        limit
+            The maximum number of conformers to select.
+        """
+
+        from openeye import oechem, oequacpac
+
+        if molecule.n_conformers == 0:
+            return
+
+        oe_molecule = molecule.to_openeye()
+
+        # Select a subset of the OMEGA generated conformers using the ELF10 method.
+        charge_engine = oequacpac.OEELFCharges(
+            oequacpac.OEAM1Charges(), limit, percentage, True
+        )
+
+        output_stream = oechem.oeosstream()
+
+        oechem.OEThrow.SetOutputStream(output_stream)
+        oechem.OEThrow.Clear()
+
+        status = oequacpac.OEAssignCharges(oe_molecule, charge_engine)
+
+        oechem.OEThrow.SetOutputStream(oechem.oeerr)
+
+        output_string = output_stream.str().decode("UTF-8")
+        output_string = output_string.replace("Warning: ", "")
+        output_string = re.sub("^: +", "", output_string, flags=re.MULTILINE)
+        output_string = re.sub("\n$", "", output_string)
+
+        # Check to make sure the call to OE was succesful, and re-route any
+        # non-fatal warnings to the correct logger.
+        if not status:
+            raise RuntimeError("\n" + output_string)
+        elif len(output_string) > 0:
+            logger.warning(output_string)
+
+        # Extract and store the ELF conformers on the input molecule.
+        conformers = []
+
+        for oe_conformer in oe_molecule.GetConfs():
+
+            conformer = np.zeros((oe_molecule.NumAtoms(), 3))
+
+            for atom_index, coordinates in oe_conformer.GetCoords().items():
+                conformer[atom_index, :] = coordinates
+
+            conformers.append(conformer * unit.angstrom)
+
+        molecule._conformers = conformers
 
     def assign_partial_charges(
         self,

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -2156,16 +2156,18 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         oe_molecule = molecule.to_openeye()
 
         # Select a subset of the OMEGA generated conformers using the ELF10 method.
-        charge_engine = oequacpac.OEELFCharges(
-            oequacpac.OEAM1Charges(), limit, percentage, True
-        )
+        oe_elf_options = oequacpac.OEELFOptions()
+        oe_elf_options.SetElfLimit(limit)
+        oe_elf_options.SetPercent(percentage)
+
+        oe_elf = oequacpac.OEELF(oe_elf_options)
 
         output_stream = oechem.oeosstream()
 
         oechem.OEThrow.SetOutputStream(output_stream)
         oechem.OEThrow.Clear()
 
-        status = oequacpac.OEAssignCharges(oe_molecule, charge_engine)
+        status = oe_elf.Select(oe_molecule)
 
         oechem.OEThrow.SetOutputStream(oechem.oeerr)
 


### PR DESCRIPTION
## Description

This PR exposed a new `apply_elf_conformer_selection` function through the `OpenEyeToolkitWrapper` in keeping with the same functionality which was added to the RDKit wrapper (#793).

The new function employs the built-in OpenEye ELF methods to select a set of ELF conformers from an existing set stored on an input molecule.

## TODO

- [ ] Tag issue being addressed
- [X] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [X] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [X] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)

## Status

- [x] Ready to review
- [ ] Ready to go