### PR TITLE
Expose ELF conformer selection through the Molecule API

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -12,6 +12,8 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 
 New features
 """"""""""""
+- `PR #832 <https://github.com/openforcefield/openforcefield/pull/832>`_: Expose ELF conformer selection through the
+  ``Molecule`` API via a new ``apply_elf_conformer_selection`` function.
 - `PR #831 <https://github.com/openforcefield/openforcefield/pull/831>`_: Expose ELF conformer selection through the
   OpenEye wrapper.
 - `PR #793 <https://github.com/openforcefield/openforcefield/pull/793>`_: Add an initial ELF conformer selection

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -2764,10 +2764,12 @@ class TestMolecule:
         """Test applying the ELF10 method."""
 
         if toolkit == "openeye":
+            pytest.importorskip("openeye")
             toolkit_registry = ToolkitRegistry(
                 toolkit_precedence=[OpenEyeToolkitWrapper]
             )
         elif toolkit == "rdkit":
+            pytest.importorskip("rdkit")
             toolkit_registry = ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper])
 
         molecule = Molecule.from_file(

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -2759,6 +2759,68 @@ class TestMolecule:
         recomputed_charges = molecule._partial_charges
         assert np.allclose(initial_charges, recomputed_charges, atol=0.002)
 
+    @pytest.mark.parametrize("toolkit", ["openeye", "rdkit"])
+    def test_apply_elf_conformer_selection(self, toolkit):
+        """Test applying the ELF10 method."""
+
+        if toolkit == "openeye":
+            toolkit_registry = ToolkitRegistry(
+                toolkit_precedence=[OpenEyeToolkitWrapper]
+            )
+        elif toolkit == "rdkit":
+            toolkit_registry = ToolkitRegistry(toolkit_precedence=[RDKitToolkitWrapper])
+
+        molecule = Molecule.from_file(
+            get_data_file_path(os.path.join("molecules", "z_3_hydroxy_propenal.sdf")),
+            "SDF",
+        )
+
+        initial_conformers = [
+            # Add a conformer with an internal H-bond.
+            np.array(
+                [
+                    [0.5477, 0.3297, -0.0621],
+                    [-0.1168, -0.7881, 0.2329],
+                    [-1.4803, -0.8771, 0.1667],
+                    [-0.2158, 1.5206, -0.4772],
+                    [-1.4382, 1.5111, -0.5580],
+                    [1.6274, 0.3962, -0.0089],
+                    [0.3388, -1.7170, 0.5467],
+                    [-1.8612, -0.0347, -0.1160],
+                    [0.3747, 2.4222, -0.7115],
+                ]
+            )
+            * unit.angstrom,
+            # Add a conformer without an internal H-bond.
+            np.array(
+                [
+                    [0.5477, 0.3297, -0.0621],
+                    [-0.1168, -0.7881, 0.2329],
+                    [-1.4803, -0.8771, 0.1667],
+                    [-0.2158, 1.5206, -0.4772],
+                    [0.3353, 2.5772, -0.7614],
+                    [1.6274, 0.3962, -0.0089],
+                    [0.3388, -1.7170, 0.5467],
+                    [-1.7743, -1.7634, 0.4166],
+                    [-1.3122, 1.4082, -0.5180],
+                ]
+            )
+            * unit.angstrom,
+        ]
+
+        molecule._conformers = [*initial_conformers]
+
+        # Apply ELF10
+        molecule.apply_elf_conformer_selection(toolkit_registry=toolkit_registry)
+        elf10_conformers = molecule.conformers
+
+        assert len(elf10_conformers) == 1
+
+        assert np.allclose(
+            elf10_conformers[0].value_in_unit(unit.angstrom),
+            initial_conformers[1].value_in_unit(unit.angstrom),
+        )
+
     @requires_openeye
     def test_assign_fractional_bond_orders(self):
         """Test assignment of fractional bond orders"""

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -2816,8 +2816,8 @@ class FrozenMolecule(Serializable):
 
         See Also
         --------
-        ``OpenEyeToolkitWrapper.apply_elf_conformer_selection``
-        ``RDKitToolkitWrapper.apply_elf_conformer_selection``
+        OpenEyeToolkitWrapper.apply_elf_conformer_selection
+        RDKitToolkitWrapper.apply_elf_conformer_selection
 
         Parameters
         ----------

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -37,6 +37,7 @@ import operator
 import warnings
 from collections import OrderedDict
 from copy import deepcopy
+from typing import Optional, Union
 
 import networkx as nx
 import numpy as np
@@ -2790,6 +2791,62 @@ class FrozenMolecule(Serializable):
                 "Invalid toolkit_registry passed to generate_conformers. Expected ToolkitRegistry or ToolkitWrapper. Got  {}".format(
                     type(toolkit_registry)
                 )
+            )
+
+    def apply_elf_conformer_selection(
+        self,
+        percentage: float = 2.0,
+        limit: int = 10,
+        toolkit_registry: Optional[
+            Union[ToolkitRegistry, ToolkitWrapper]
+        ] = GLOBAL_TOOLKIT_REGISTRY,
+        **kwargs,
+    ):
+        """Applies the `ELF method<https://docs.eyesopen.com/toolkits/python/quacpactk/
+        molchargetheory.html#elf-conformer-selection>`_ to select a set of diverse
+        conformers which have minimal electrostatically strongly interacting functional
+        groups from a molecules conformers.
+
+        Notes
+        -----
+        * The input molecule should have a large set of conformers already
+          generated to select the ELF conformers from.
+        * The selected conformers will be retained in the `conformers` list
+          while unselected conformers will be discarded.
+
+        See Also
+        --------
+        ``OpenEyeToolkitWrapper.apply_elf_conformer_selection``
+        ``RDKitToolkitWrapper.apply_elf_conformer_selection``
+
+        Parameters
+        ----------
+        toolkit_registry
+            The underlying toolkit to use to select the ELF conformers.
+        percentage
+            The percentage of conformers with the lowest electrostatic interaction
+            energies to greedily select from.
+        limit
+            The maximum number of conformers to select.
+        """
+        if isinstance(toolkit_registry, ToolkitRegistry):
+            toolkit_registry.call(
+                "apply_elf_conformer_selection",
+                molecule=self,
+                percentage=percentage,
+                limit=limit,
+                **kwargs,
+            )
+        elif isinstance(toolkit_registry, ToolkitWrapper):
+            toolkit = toolkit_registry
+            toolkit.apply_elf_conformer_selection(
+                self, molecule=self, percentage=percentage, limit=limit, **kwargs
+            )
+        else:
+            raise InvalidToolkitRegistryError(
+                f"Invalid toolkit_registry passed to apply_elf_conformer_selection."
+                f"Expected ToolkitRegistry or ToolkitWrapper. Got "
+                f"{type(toolkit_registry)}"
             )
 
     def compute_partial_charges_am1bcc(


### PR DESCRIPTION
## Description

This PR adds a new `apply_elf_conformer_selection` function to the Molecule API, exposing the new ELF functionality added in #793 and #831.

## TODOs

- [ ] Tag issue being addressed
- [X] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [X] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [X] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [X] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)

## Status

- [X] Ready to go