### PR TITLE
Add missing @requires_openeye to a slowtest that uses mol2

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -778,6 +778,7 @@ class TestMolecule:
         compare_mols(ref_mol, nonstandard_inchi_mol)
 
     # TODO: Should there be an equivalent toolkit test and leave this as an integration test?
+    @requires_openeye
     @pytest.mark.slow
     def test_create_from_file(self):
         """Test standard constructor taking a filename or file-like object."""


### PR DESCRIPTION
The non-OpenEye runs in the cron job are failing because one of the slow tests, which reads a MOL2 file, was not decorated with `@requires_openeye`. This PR fixes that. I thought I covered all cases when testing #722 - I made an environment for each case - but I must have missed it.

Logs (may not be persistent) fail only on the `OpenEye=false` cases and only for this test. This only shows up on the cron job since `--runslow` is off for normal CI runs.

https://github.com/openforcefield/openff-toolkit/actions/runs/573256586

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
