### PR TITLE
Resolve warnings emitted by Sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,12 +63,12 @@ autodoc_default_options = {
 # Disable NumPy style attributes/methods expecting every method to have its own docs page
 numpydoc_class_members_toctree = False
 
-_python_doc_base = 'http://docs.python.org/3.6'
+_python_doc_base = 'https://docs.python.org/3.6'
 intersphinx_mapping = {
     _python_doc_base: None,
-    'http://docs.scipy.org/doc/numpy': None,
-    'http://docs.scipy.org/doc/scipy/reference': None,
-    'http://scikit-learn.org/stable': None
+    'https://numpy.org/doc/stable': None,
+    'https://docs.scipy.org/doc/scipy/reference': None,
+    'https://scikit-learn.org/stable': None
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -55,7 +55,7 @@ Open Force Field Toolkit Concepts
 
 ``OFF Topology``
   An object that efficiently holds many OFF ``Molecule`` objects.
-  The atom indexing in a ``Topology`` may differ from those of the underlying ``Molecule``s
+  The atom indexing in a ``Topology`` may differ from those of the underlying ``Molecule``\ s
 
 ``OFF TopologyMolecule``
   The efficient data structures that make up an OFF Topology.
@@ -137,7 +137,7 @@ ParameterHandler
           ParameterHandler versions allow us to evolve ParameterHandler behavior in a controlled, recorded way.
           Force field development is experimental by nature, and it is unlikely that the initial choice of header attributes is suitable for all use cases.
           Recording the "versions" of a SMIRNOFF spec tag allows us to encode the default behavior and API of a specific generation of ParameterHandlers, while allowing the safe addition of new attributes and behaviors.
-    - Each ParameterHandler-derived class MAY implement:
+    Each ParameterHandler-derived class MAY implement:
         - ``known_kwargs``: Keyword arguments passed to ``ForceField.create_openmm_system`` are validated against the ``known_kwargs`` lists of each ParameterHandler that the ForceField owns.
           If present, these kwargs and their values will be passed on to the ParameterHandler.
         - ``to_dict``: converts the ParameterHandler to a hierarchical dict compliant with the SMIRNOFF specification.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 Open Force Field Toolkit
-=======================
+========================
 
 A modern, extensible library for molecular mechanics force field science from the `Open Force Field Initiative <http://openforcefield.org>`_
 

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -26,21 +26,30 @@ New features
   :py:meth:`TopologyMolecule.amber_impropers <openff.toolkit.topology.TopologyMolecule.amber_impropers>`,
   :py:meth:`Topology.smirnoff_impropers <openff.toolkit.topology.Topology.smirnoff_impropers>`, and
   :py:meth:`Topology.amber_impropers <openff.toolkit.topology.Topology.amber_impropers>`.
+- `PR #847 <https://github.com/openforcefield/openforcefield/pull/847>`_: Instances of
+  :py:class:`ParameterAttribute <openff.toolkit.typing.engines.smirnoff.parameters.ParameterAttribute>`
+  documentation can now specify their docstrings with the optional ``docstring`` argument to the
+  ``__init__()`` method.
 
 Behavior changed
-""""""""
-- `PR #802 <https://github.com/openforcefield/openff-toolkit/pull/802>`_: Fixes
-  `Issue #408 <https://github.com/openforcefield/openff-toolkit/issues/408>`_. The 1-4 scaling
+""""""""""""""""
+- `PR #802 <https://github.com/openforcefield/openforcefield/pull/802>`_: Fixes
+  `Issue #408 <https://github.com/openforcefield/openforcefield/issues/408>`_. The 1-4 scaling
   factor for electrostatic interactions is now properly set by the value specified in the force
   field. Previously it fell back to a default value of 0.83333. The toolkit may now produce
   slightly different energies as a result of this change.
 
-Bugfixes
-""""""""
-- `PR #838 <https://github.com/openforcefield/openff-toolkit/pull/838>`_: Corrects spacing of "forcefield" to "force
-  field" throughout documentation. Fixes `Issue #112 <https://github.com/openforcefield/openff-toolkit/issues/112>`_.
+Improved documentation and warnings
+"""""""""""""""""""""""""""""""""""
+- `PR #838 <https://github.com/openforcefield/openforcefield/pull/838>`_: Corrects spacing of "forcefield" to "force
+  field" throughout documentation. Fixes `Issue #112 <https://github.com/openforcefield/openforcefield/issues/112>`_.
 - `PR #846 <https://github.com/openforcefield/openff-toolkit/pull/846>`_: Corrects dead links throughout release history.
-  Fixes `Issue #112 <https://github.com/openforcefield/openff-toolkit/issues/835>`_.
+  Fixes `Issue #835 <https://github.com/openforcefield/openff-toolkit/issues/835>`_.
+- `PR #847 <https://github.com/openforcefield/openforcefield/pull/847>`_: Documentation now compiles
+  with far fewer warnings, and in many cases more correctly. Additionally, :py:class:`ParameterAttribute
+  <openff.toolkit.typing.engines.smirnoff.parameters.ParameterAttribute>` documentation no longer
+  appears incorrectly in classes where it is used. Fixes `Issue #397
+  <https://github.com/openforcefield/openforcefield/issues/397>`_.
 
 0.9.0 - Namespace Migration
 ---------------------------
@@ -95,7 +104,7 @@ New features
 
 Bugfixes
 """"""""
-- `PR #786 <https://github.com/openforcefield/openff-toolkit/pull/xyz>`_: Fixes `Issue #785
+- `PR #786 <https://github.com/openforcefield/openff-toolkit/pull/786>`_: Fixes `Issue #785
   <https://github.com/openforcefield/openff-toolkit/issues/785>`_ where RDKitToolkitWrapper would
   sometimes expect stereochemistry to be defined for non-stereogenic bonds when loading from
   SDF.
@@ -318,7 +327,7 @@ API-breaking changes
   - :py:meth:`Molecule.add_monovalent_lone_pair_virtual_site <openff.toolkit.topology.Molecule.add_monovalent_lone_pair_virtual_site>`
   - :py:meth:`Molecule.add_divalent_lone_pair_virtual_site <openff.toolkit.topology.Molecule.add_divalent_lone_pair_virtual_site>`
   - :py:meth:`Molecule.add_trivalent_lone_pair_virtual_site <openff.toolkit.topology.Molecule.add_trivalent_lone_pair_virtual_site>`
-  now only accept a list of atoms, not a list of integers, to define to parent atoms
+    now only accept a list of atoms, not a list of integers, to define to parent atoms
 
 - `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Removes
   :py:meth:`VirtualParticle.molecule_particle_index <openff.toolkit.topology.VirtualParticle.molecule_particle_index>`
@@ -754,9 +763,11 @@ New features
   and :py:meth:`Molecule.from_pdb_and_smiles <openff.toolkit.topology.Molecule.from_pdb_and_smiles>`
   and :py:meth:`Molecule.canonical_order_atoms <openff.toolkit.topology.Molecule.canonical_order_atoms>`
   and :py:meth:`Molecule.remap <openff.toolkit.topology.Molecule.remap>`
-      .. note::
-         The to_qcschema method accepts an extras dictionary which is passed into the validated qcelemental.models.Molecule
-         object.
+
+    .. note::
+       The to_qcschema method accepts an extras dictionary which is passed into the validated qcelemental.models.Molecule
+       object.
+
 - `PR #506 <https://github.com/openforcefield/openff-toolkit/pull/506>`_:
   The :py:class:`Molecule <openff.toolkit.topology.Molecule>` class adds
   :py:meth:`Molecule.find_rotatable_bonds <openff.toolkit.topology.Molecule.find_rotatable_bonds>`
@@ -764,11 +775,13 @@ New features
   Adds :py:meth:`Molecule.to_inchi <openff.toolkit.topology.Molecule.to_inchi>`
   and :py:meth:`Molecule.to_inchikey <openff.toolkit.topology.Molecule.to_inchikey>`
   and :py:meth:`Molecule.from_inchi <openff.toolkit.topology.Molecule.from_inchi>`
-      .. warning::
-         InChI was not designed as an molecule interchange format and using it as one is not recommended. Many round trip
-         tests will fail when using this format due to a loss of information. We have also added support for fixed
-         hydrogen layer nonstandard InChI which can help in the case of tautomers, but overall creating molecules from InChI should be
-         avoided.
+
+    .. warning::
+       InChI was not designed as an molecule interchange format and using it as one is not recommended. Many round trip
+       tests will fail when using this format due to a loss of information. We have also added support for fixed
+       hydrogen layer nonstandard InChI which can help in the case of tautomers, but overall creating molecules from InChI should be
+       avoided.
+
 - `PR #529 <https://github.com/openforcefield/openff-toolkit/pull/529>`_: Adds the ability to write out to XYZ files via
   :py:meth:`Molecule.to_file <openff.toolkit.topology.Molecule.to_file>` Both single frame and multiframe XYZ files are supported.
   Note reading from XYZ files will not be supported due to the lack of connectivity information.
@@ -776,10 +789,12 @@ New features
   :py:meth:`Molecule.to_smiles <openff.toolkit.topology.Molecule.to_smiles>` to allow for the creation of cmiles
   identifiers through combinations of isomeric, explicit hydrogen and mapped smiles, the default settings will return
   isomeric explicit hydrogen smiles as expected.
+
         .. warning::
            Atom maps can be supplied to the properties dictionary to modify which atoms have their map index included,
            if no map is supplied all atoms will be mapped in the order they appear in the
            :py:class:`Molecule <openff.toolkit.topology.Molecule>`.
+
 - `PR #563 <https://github.com/openforcefield/openff-toolkit/pull/563>`_:
   Adds ``test_forcefields/ion_charges.offxml``, giving ``LibraryCharges`` for monatomic ions.
 - `PR #543 <https://github.com/openforcefield/openff-toolkit/pull/543>`_:
@@ -787,8 +802,10 @@ New features
   states. These are :py:meth:`Molecule.enumerate_tautomers <openff.toolkit.topology.Molecule.enumerate_tautomers>`,
   :py:meth:`Molecule.enumerate_stereoisomers <openff.toolkit.topology.Molecule.enumerate_stereoisomers>`,
   :py:meth:`Molecule.enumerate_protomers <openff.toolkit.topology.Molecule.enumerate_protomers>`
+
       .. warning::
          Enumerate protomers is currently only available through the OpenEye toolkit.
+
 - `PR #573 <https://github.com/openforcefield/openff-toolkit/pull/573>`_:
   Adds ``quacpac`` error output to ``quacpac`` failure in ``Molecule.compute_partial_charges_am1bcc``.
 - `PR #560 <https://github.com/openforcefield/openff-toolkit/issues/560>`_: Added visualization method to the the Molecule class.
@@ -1083,8 +1100,8 @@ New features
   :py:class:`ForceFields <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
   and
   :py:class:`ParameterHandlers <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>`.
-  Note that, while XML representations of ``ForceField``s are stable and conform to the SMIRNOFF
-  specification, the pickled ``ForceField``s that this functionality enables are not guaranteed
+  Note that, while XML representations of ``ForceField``\ s are stable and conform to the SMIRNOFF
+  specification, the pickled ``ForceField``\ s that this functionality enables are not guaranteed
   to be compatible with future toolkit versions.
 
 Improved documentation and warnings
@@ -1422,7 +1439,7 @@ New features
 """"""""""""
 
 * Major overhaul, resulting in the creation of the `SMIRNOFF 0.2 specification <https://open-forcefield-toolkit.readthedocs.io/en/master/smirnoff.html>`_ and its XML representation
-* Updated API and infrastructure for reference SMIRNOFF :class:`ForceField` implementation
+* Updated API and infrastructure for reference SMIRNOFF :class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>` implementation
 * Implementation of modular :class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>` classes which process the topology to add all necessary forces to the system.
 * Implementation of modular :class:`ParameterIOHandler <openff.toolkit.typing.engines.smirnoff.io.ParameterIOHandler>` classes for reading/writing different serialized SMIRNOFF force field representations
 * Introduction of :class:`Molecule <openff.toolkit.topology.Molecule>` and :class:`Topology <openff.toolkit.topology.Topology>` classes for representing molecules and biomolecular systems

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -12,14 +12,14 @@ Releases follow the ``major.minor.micro`` scheme recommended by `PEP440 <https:/
 
 New features
 """"""""""""
-- `PR #832 <https://github.com/openforcefield/openforcefield/pull/832>`_: Expose ELF conformer selection through the
+- `PR #832 <https://github.com/openforcefield/openff-toolkit/pull/832>`_: Expose ELF conformer selection through the
   ``Molecule`` API via a new ``apply_elf_conformer_selection`` function.
-- `PR #831 <https://github.com/openforcefield/openforcefield/pull/831>`_: Expose ELF conformer selection through the
+- `PR #831 <https://github.com/openforcefield/openff-toolkit/pull/831>`_: Expose ELF conformer selection through the
   OpenEye wrapper.
-- `PR #793 <https://github.com/openforcefield/openforcefield/pull/793>`_: Add an initial ELF conformer selection
+- `PR #793 <https://github.com/openforcefield/openff-toolkit/pull/793>`_: Add an initial ELF conformer selection
   implementation which uses RDKit.
-- `PR #799 <https://github.com/openforcefield/openforcefield/pull/799>`_: Closes
-  `Issue #746 <https://github.com/openforcefield/openforcefield/issues/746>`_ by adding
+- `PR #799 <https://github.com/openforcefield/openff-toolkit/pull/799>`_: Closes
+  `Issue #746 <https://github.com/openforcefield/openff-toolkit/issues/746>`_ by adding
   :py:meth:`Molecule.smirnoff_impropers <openff.toolkit.topology.FrozenMolecule.smirnoff_impropers>`,
   :py:meth:`Molecule.amber_impropers <openff.toolkit.topology.FrozenMolecule.amber_impropers>`,
   :py:meth:`TopologyMolecule.smirnoff_impropers <openff.toolkit.topology.TopologyMolecule.smirnoff_impropers>`,
@@ -29,16 +29,18 @@ New features
 
 Behavior changed
 """"""""
-- `PR #802 <https://github.com/openforcefield/openforcefield/pull/802>`_: Fixes
-  `Issue #408 <https://github.com/openforcefield/openforcefield/issues/408>`_. The 1-4 scaling
+- `PR #802 <https://github.com/openforcefield/openff-toolkit/pull/802>`_: Fixes
+  `Issue #408 <https://github.com/openforcefield/openff-toolkit/issues/408>`_. The 1-4 scaling
   factor for electrostatic interactions is now properly set by the value specified in the force
   field. Previously it fell back to a default value of 0.83333. The toolkit may now produce
   slightly different energies as a result of this change.
 
 Bugfixes
 """"""""
-- `PR #838 <https://github.com/openforcefield/openforcefield/pull/838>`_: Corrects spacing of "forcefield" to "force
-  field" throughout documentation. Fixes `Issue #112 <https://github.com/openforcefield/openforcefield/issues/112>`_.
+- `PR #838 <https://github.com/openforcefield/openff-toolkit/pull/838>`_: Corrects spacing of "forcefield" to "force
+  field" throughout documentation. Fixes `Issue #112 <https://github.com/openforcefield/openff-toolkit/issues/112>`_.
+- `PR #846 <https://github.com/openforcefield/openff-toolkit/pull/846>`_: Corrects dead links throughout release history.
+  Fixes `Issue #112 <https://github.com/openforcefield/openff-toolkit/issues/835>`_.
 
 0.9.0 - Namespace Migration
 ---------------------------
@@ -52,7 +54,7 @@ From version ``0.9.0`` onwards the toolkit will need to be imported as ``import 
 
 API-breaking changes
 """"""""""""""""""""
-- `PR #803 <https://github.com/openforcefield/openforcefield/pull/803>`_: Migrates ``openforcefield``
+- `PR #803 <https://github.com/openforcefield/openff-toolkit/pull/803>`_: Migrates ``openforcefield``
   imports to ``openff.toolkit``.
 
 0.8.3 - Major bugfix release
@@ -71,41 +73,41 @@ choose to install the ``openff-toolkit`` package once released which will contai
 
 Bugfixes
 """"""""
-- `PR #808 <https://github.com/openforcefield/openforcefield/pull/808>`_: Fixes
-  `Issue #807 <https://github.com/openforcefield/openforcefield/issues/807>`_,
+- `PR #808 <https://github.com/openforcefield/openff-toolkit/pull/808>`_: Fixes
+  `Issue #807 <https://github.com/openforcefield/openff-toolkit/issues/807>`_,
   which tracks a major bug in the interconversion between a vdW ``sigma``
   and ``rmin_half`` parameter.
 
 
 New features
 """"""""""""
-- `PR #794 <https://github.com/openforcefield/openforcefield/pull/794>`_: Adds a decorator
+- `PR #794 <https://github.com/openforcefield/openff-toolkit/pull/794>`_: Adds a decorator
   ``@requires_package`` that denotes a function requires an optional dependency.
-- `PR #805 <https://github.com/openforcefield/openforcefield/pull/805>`_: Adds a deprecation warning for the up-coming
+- `PR #805 <https://github.com/openforcefield/openff-toolkit/pull/805>`_: Adds a deprecation warning for the up-coming
   release of the ``openff-toolkit`` package and its import breaking changes.
 
 0.8.2 - Bugfix release
 ----------------------
 
 **WARNING: This release was later found to contain a major bug,**
-`Issue #807 <https://github.com/openforcefield/openforcefield/issues/807>`_,
+`Issue #807 <https://github.com/openforcefield/openff-toolkit/issues/807>`_,
 **and produces incorrect energies.**
 
 Bugfixes
 """"""""
-- `PR #786 <https://github.com/openforcefield/openforcefield/pull/xyz>`_: Fixes `Issue #785
-  <https://github.com/openforcefield/openforcefield/issues/785>`_ where RDKitToolkitWrapper would
+- `PR #786 <https://github.com/openforcefield/openff-toolkit/pull/xyz>`_: Fixes `Issue #785
+  <https://github.com/openforcefield/openff-toolkit/issues/785>`_ where RDKitToolkitWrapper would
   sometimes expect stereochemistry to be defined for non-stereogenic bonds when loading from
   SDF.
-- `PR #786 <https://github.com/openforcefield/openforcefield/pull/786>`_: Fixes an issue where
-  using the :py:class:`Molecule <openforcefield.topology.Molecule>` copy constructor
+- `PR #786 <https://github.com/openforcefield/openff-toolkit/pull/786>`_: Fixes an issue where
+  using the :py:class:`Molecule <openff.toolkit.topology.Molecule>` copy constructor
   (``newmol = Molecule(oldmol)``) would result
   in the copy sharing the same ``.properties`` dict as the original (as in, changes to the
   ``.properties`` dict of the copy would be reflected in the original).
-- `PR #789 <https://github.com/openforcefield/openforcefield/pull/789>`_: Fixes a regression noted in
-  `Issue #788 <https://github.com/openforcefield/openforcefield/issues/788>`_
+- `PR #789 <https://github.com/openforcefield/openff-toolkit/pull/789>`_: Fixes a regression noted in
+  `Issue #788 <https://github.com/openforcefield/openff-toolkit/issues/788>`_
   where creating
-  :py:class:`vdWHandler.vdWType <openforcefield.typing.engines.smirnoff.parameters.vdWHandler.vdWType>`
+  :py:class:`vdWHandler.vdWType <openff.toolkit.typing.engines.smirnoff.parameters.vdWHandler.vdWType>`
   or setting ``sigma`` or ``rmin_half`` using Quantities represented as strings resulted in an error.
 
 
@@ -113,70 +115,68 @@ Bugfixes
 ----------------------------------------
 
 **WARNING: This release was later found to contain a major bug,**
-`Issue #807 <https://github.com/openforcefield/openforcefield/issues/807>`_,
+`Issue #807 <https://github.com/openforcefield/openff-toolkit/issues/807>`_,
 **and produces incorrect energies.**
 
 API-breaking changes
 """"""""""""""""""""
-- `PR #757 <https://github.com/openforcefield/openforcefield/pull/757>`_: Renames
+- `PR #757 <https://github.com/openforcefield/openff-toolkit/pull/757>`_: Renames
   ``test_forcefields/smirnoff99Frosst.offxml`` to ``test_forcefields/test_forcefield.offxml``
   to avoid confusion with any of the ACTUAL released FFs in the
   `smirnoff99Frosst line <https://github.com/openforcefield/smirnoff99Frosst/>`_
-- `PR #751 <https://github.com/openforcefield/openforcefield/pull/751>`_: Removes the
+- `PR #751 <https://github.com/openforcefield/openff-toolkit/pull/751>`_: Removes the
   optional ``oetools=("oechem", "oequacpac", "oeiupac", "oeomega")`` keyword argument from
-  :py:meth:`OpenEyeToolkitWrapper.is_available <openforcefield.utils.toolkits.OpenEyeToolkitWrapper.is_available>`, as
+  :py:meth:`OpenEyeToolkitWrapper.is_available <openff.toolkit.utils.toolkits.OpenEyeToolkitWrapper.is_available>`, as
   there are no special behaviors that are accessed in the case of partially-licensed OpenEye backends. The
   new behavior of this method is the same as if the default value above is always provided.
 
 Behavior Changed
 """"""""""""""""
-- `PR #583 <https://github.com/openforcefield/openforcefield/pull/583>`_: Methods
-  such as :py:meth:`Molecule.from_rdkit <openforcefield.topology.Molecule.from_rdkit>`
-  and :py:meth:`Molecule.from_openeye <openforcefield.topology.Molecule.from_openeye>`,
-  which delegate their internal logic to :py:class:`ToolkitRegistry <openforcefield.utils.toolkits.ToolkitRegistry>`
+- `PR #583 <https://github.com/openforcefield/openff-toolkit/pull/583>`_: Methods
+  such as :py:meth:`Molecule.from_rdkit <openff.toolkit.topology.Molecule.from_rdkit>`
+  and :py:meth:`Molecule.from_openeye <openff.toolkit.topology.Molecule.from_openeye>`,
+  which delegate their internal logic to :py:class:`ToolkitRegistry <openff.toolkit.utils.toolkits.ToolkitRegistry>`
   functions, now guarantee that they will return an object of the correct type when being called on ``Molecule``-derived classes. Previously,
-  running these constructors using subclasses of :py:class:`FrozenMolecule <openforcefield.topology.Molecule>`
+  running these constructors using subclasses of :py:class:`FrozenMolecule <openff.toolkit.topology.Molecule>`
   would not return an instance of that subclass, but rather just an instance of a
-  :py:class:`Molecule <openforcefield.topology.Molecule>`.
-- `PR #753 <https://github.com/openforcefield/openforcefield/pull/753>`_: ``ParameterLookupError``
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>`.
+- `PR #753 <https://github.com/openforcefield/openff-toolkit/pull/753>`_: ``ParameterLookupError``
   is now raised when passing to
-  :py:meth:`ParameterList.index <openforcefield.typing.engines.smirnoff.parameters.ParameterList>`
+  :py:meth:`ParameterList.index <openff.toolkit.typing.engines.smirnoff.parameters.ParameterList>`
   a SMIRKS pattern not found in the parameter list.
 
 New features
 """"""""""""
-- `PR #751 <https://github.com/openforcefield/openforcefield/pull/751>`_: Adds
-  :py:class:`LicenseError <openforcefield.utils.toolkits.LicenseError>`, a subclass of
-  :py:class:`ToolkitUnavailableException <openforcefield.utils.toolkits.ToolkitUnavailableException>`
-  which is raised when attempting to add a cheminformatics
-  :py:class:`ToolkitWrapper <openforcefield.utils.toolkits.ToolkitWrapper>` for a toolkit that
-  is installed but unlicensed.
-- `PR #678 <https://github.com/openforcefield/openforcefield/pull/678>`_: Adds
-  :py:meth:`ForceField.deregister_parameter_handler <openforcefield.typing.engines.smirnoff.forcefield.ForceField.deregister_parameter_handler>`.
-- `PR #730 <https://github.com/openforcefield/openforcefield/pull/730>`_: Adds
-  :py:class:`Topology.is_periodic <openforcefield.topology.Topology>`.
-- `PR #753 <https://github.com/openforcefield/openforcefield/pull/753>`_: Adds
-  :py:meth:`ParameterHandler.__getitem__ <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.__getitem__>`
-  to look up individual :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>`
+- `PR #751 <https://github.com/openforcefield/openff-toolkit/pull/751>`_: Adds
+  ``LicenseError``, a subclass of ``ToolkitUnavailableException`` which is raised when attempting to 
+  add a cheminformatics :py:class:`ToolkitWrapper <openff.toolkit.utils.toolkits.ToolkitWrapper>` for 
+  a toolkit that is installed but unlicensed.
+- `PR #678 <https://github.com/openforcefield/openff-toolkit/pull/678>`_: Adds
+  :py:meth:`ForceField.deregister_parameter_handler <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.deregister_parameter_handler>`.
+- `PR #730 <https://github.com/openforcefield/openff-toolkit/pull/730>`_: Adds
+  :py:class:`Topology.is_periodic <openff.toolkit.topology.Topology>`.
+- `PR #753 <https://github.com/openforcefield/openff-toolkit/pull/753>`_: Adds
+  :py:meth:`ParameterHandler.__getitem__ <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>`
+  to look up individual :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>`
   objects.
 
 Bugfixes
 """"""""
-- `PR #745 <https://github.com/openforcefield/openforcefield/pull/745>`_: Fixes bug when
+- `PR #745 <https://github.com/openforcefield/openff-toolkit/pull/745>`_: Fixes bug when
   serializing molecule with conformers to JSON.
-- `PR #750 <https://github.com/openforcefield/openforcefield/pull/750>`_: Fixes a bug causing either
+- `PR #750 <https://github.com/openforcefield/openff-toolkit/pull/750>`_: Fixes a bug causing either
   ``sigma`` or ``rmin_half`` to sometimes be missing on
-  :py:class:`vdWHandler.vdWType <openforcefield.typing.engines.smirnoff.parameters.vdWHandler.vdWType>`
+  :py:class:`vdWHandler.vdWType <openff.toolkit.typing.engines.smirnoff.parameters.vdWHandler.vdWType>`
   objects.
-- `PR #756 <https://github.com/openforcefield/openforcefield/pull/756>`_: Fixes bug when running
-  :py:meth:`vdWHandler.create_force <openforcefield.typing.engines.smirnoff.parameters.vdWHandler.create_force>`
+- `PR #756 <https://github.com/openforcefield/openff-toolkit/pull/756>`_: Fixes bug when running
+  :py:meth:`vdWHandler.create_force <openff.toolkit.typing.engines.smirnoff.parameters.vdWHandler>`
   using a ``vdWHandler`` that was initialized using the API.
-- `PR #776 <https://github.com/openforcefield/openforcefield/pull/776>`_: Fixes a bug in which
-  the :py:meth:`Topology.from_openmm <openforcefield.topology.Topology.from_openmm>` and
-  :py:meth:`Topology.from_mdtraj <openforcefield.topology.Topology.from_mdtraj>` methods would
+- `PR #776 <https://github.com/openforcefield/openff-toolkit/pull/776>`_: Fixes a bug in which
+  the :py:meth:`Topology.from_openmm <openff.toolkit.topology.Topology.from_openmm>` and
+  :py:meth:`Topology.from_mdtraj <openff.toolkit.topology.Topology.from_mdtraj>` methods would
   dangerously allow ``unique_molecules=None``.
-- `PR #777 <https://github.com/openforcefield/openforcefield/pull/777>`_:
-  :py:class:`RDKitToolkitWrapper <openforcefield.utils.toolkits.RDKitToolkitWrapper>`
+- `PR #777 <https://github.com/openforcefield/openff-toolkit/pull/777>`_:
+  :py:class:`RDKitToolkitWrapper <openff.toolkit.utils.toolkits.RDKitToolkitWrapper>`
   now outputs the full warning message when ``allow_undefined_stereo=True`` (previously the
   description of which stereo was undefined was squelched)
 
@@ -184,14 +184,14 @@ Bugfixes
 0.8.0 - Virtual Sites
 ---------------------
 
-This release implements the SMIRNOFF virtual site specification. The implementation enables support for models using off-site charges, including 4- and 5-point water models, in addition to lone pair modeling on various functional groups. The primary focus was on the ability to parameterize a system using virtual sites, and generating an OpenMM system with all virtual sites present and ready for evaluation. Support for formats other than OpenMM has not be implemented in this release, but may come with the appearance of the OpenFF system object. In addition to implementing the specification, the toolkit :py:class:`Molecule <openforcefield.topology.Molecule>` objects now allow the creation and manipulation of virtual sites.
+This release implements the SMIRNOFF virtual site specification. The implementation enables support for models using off-site charges, including 4- and 5-point water models, in addition to lone pair modeling on various functional groups. The primary focus was on the ability to parameterize a system using virtual sites, and generating an OpenMM system with all virtual sites present and ready for evaluation. Support for formats other than OpenMM has not be implemented in this release, but may come with the appearance of the OpenFF system object. In addition to implementing the specification, the toolkit :py:class:`Molecule <openff.toolkit.topology.Molecule>` objects now allow the creation and manipulation of virtual sites.
 
 **Major Feature: Support for the SMIRNOFF VirtualSite tag**
 
 Virtual sites can be added to a System in two ways:
 
 * `SMIRNOFF Force Fields can contain a VirtualSites tag <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#virtualsites-virtual-sites-for-off-atom-charges>`_ , specifying the addition of virtual sites according to SMARTS-based rules.
-* Virtual sites can be added to a :py:class:`Molecule <openforcefield.topology.Molecule>`, and these will appear in the final OpenMM system if a virtual site handler is present in the :py:class:`ForceField <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`.
+* Virtual sites can be added to a :py:class:`Molecule <openff.toolkit.topology.Molecule>`, and these will appear in the final OpenMM system if a virtual site handler is present in the :py:class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`.
 
 Virtual sites are the first parameters which directly depend on 3D conformation, where the position of the virtual sites are based on vectors defined on the atoms that were matched during parameterization. Because of this, a virtual site matching the triplet of atoms 1-2-3 will define a point that is different from a triplet matching 3-2-1. This is similar to defining "right-handed" and "left-handed" coordinate systems. This subtlety interplays with two major concepts in force field development:
 
@@ -222,7 +222,7 @@ The following cases exemplify our reasoning in implementing this behavior, and s
 
 * Formaldehyde, ``H2C=O``, with ``MonovalentLonePair`` virtual site(s) on the oxygen, with the aim of modeling both lone pairs. This one is subtle, since ``[#1:3]-[#6X3:2]=[#8X1:1]`` matches two unique groups of atoms (``1-3-4`` and ``2-3-4``). It is important to note in this situation that ``match="all_permutations"`` behaves exactly the same as ``match="once"``. Due to the anchoring hydrogens (``1`` and ``2``) being symmetric but opposite about the bond between ``3`` and ``4``, a single parameter does correctly place both lone pairs. A standing issue here is that the default exclusion policy (``parents``) will allow these two virtual sites to interact since they have different indexed atoms (parents), causing the energy to be different than the non-virtual site parameterization. In the future, the ``exclusion_policy="local"`` will account for this, and make virtual sites that share at least one "parent" atom not interact with each other. As a special note: when applying a ``MonovalentLonePair`` to a completely symmetric molecule, e.g. water, ``all_permutations`` can come into play, but this will apply two particles (one for each hydrogen).
 
-Finally, the toolkit handles the organization of atoms and virtual sites in a specific manner. Virtual sites are expected to be added *after all molecules in the topology are present*. This is because the Open Force Field Toolkit organizes a topology by placing all atoms first, then all virtual sites last. This differs from the OpenMM Modeller object, for example, which interleaves the order of atoms and virtual sites in such a way that all particles of a molecule are contiguous. In addition, due to the fact that a virtual site may contain multiple particles coupled to single parameters, the toolkit makes a distinction between a virtual *site*, and a virtual *particle*. A virtual site may represent multiple virtual particles, so the total number of particles cannot be directly determined by simply summing the number of atoms and virtual sites in a molecule. This is taken into account, however, and the :py:class:`Molecule <openforcefield.topology.Molecule>` and :py:class:`Topology <openforcefield.topology.Topology>` classes now implement ``particle`` iterators.
+Finally, the toolkit handles the organization of atoms and virtual sites in a specific manner. Virtual sites are expected to be added *after all molecules in the topology are present*. This is because the Open Force Field Toolkit organizes a topology by placing all atoms first, then all virtual sites last. This differs from the OpenMM Modeller object, for example, which interleaves the order of atoms and virtual sites in such a way that all particles of a molecule are contiguous. In addition, due to the fact that a virtual site may contain multiple particles coupled to single parameters, the toolkit makes a distinction between a virtual *site*, and a virtual *particle*. A virtual site may represent multiple virtual particles, so the total number of particles cannot be directly determined by simply summing the number of atoms and virtual sites in a molecule. This is taken into account, however, and the :py:class:`Molecule <openff.toolkit.topology.Molecule>` and :py:class:`Topology <openff.toolkit.topology.Topology>` classes now implement ``particle`` iterators.
 
 
 **Minor Feature: Support for the 0.4 ChargeIncrementModel tag**
@@ -241,107 +241,107 @@ More details and examples of this change are available in `The ChargeIncrementMo
 
 New features
 """"""""""""
-- `PR #726 <https://github.com/openforcefield/openforcefield/pull/726>`_: Adds support for the 0.4
+- `PR #726 <https://github.com/openforcefield/openff-toolkit/pull/726>`_: Adds support for the 0.4
   ChargeIncrementModel spec, allowing for the specification of one fewer ``charge_increment`` values
   than there are tagged atoms in the ``smirks``, and automatically assigning the final atom an offsetting charge.
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Adds support for the ``VirtualSites`` tag in the SMIRNOFF specification
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Adds support for the ``VirtualSites`` tag in the SMIRNOFF specification
 
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Adds ``replace`` and ``all_permutations`` kwarg to
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Adds ``replace`` and ``all_permutations`` kwarg to
 
-  - :py:meth:`Molecule.add_bond_charge_virtual_site <openforcefield.topology.Molecule.add_bond_charge_virtual_site>`
-  - :py:meth:`Molecule.add_monovalent_lone_pair_virtual_site <openforcefield.topology.Molecule.add_monovalent_lone_pair_virtual_site>`
-  - :py:meth:`Molecule.add_divalent_lone_pair_virtual_site <openforcefield.topology.Molecule.add_divalent_lone_pair_virtual_site>`
-  - :py:meth:`Molecule.add_trivalent_lone_pair_virtual_site <openforcefield.topology.Molecule.add_trivalent_lone_pair_virtual_site>`
+  - :py:meth:`Molecule.add_bond_charge_virtual_site <openff.toolkit.topology.Molecule.add_bond_charge_virtual_site>`
+  - :py:meth:`Molecule.add_monovalent_lone_pair_virtual_site <openff.toolkit.topology.Molecule.add_monovalent_lone_pair_virtual_site>`
+  - :py:meth:`Molecule.add_divalent_lone_pair_virtual_site <openff.toolkit.topology.Molecule.add_divalent_lone_pair_virtual_site>`
+  - :py:meth:`Molecule.add_trivalent_lone_pair_virtual_site <openff.toolkit.topology.Molecule.add_trivalent_lone_pair_virtual_site>`
 
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Adds ``orientations`` to
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Adds ``orientations`` to
 
-  - :py:class:`BondChargeVirtualSite <openforcefield.topology.BondChargeVirtualSite>`
-  - :py:class:`MonovalentLonePairVirtualSite <openforcefield.topology.MonovalentLonePairVirtualSite>`
-  - :py:class:`DivalentLonePairVirtualSite <openforcefield.topology.DivalentLonePairVirtualSite>`
-  - :py:class:`TrivalentLonePairVirtualSite <openforcefield.topology.TrivalentLonePairVirtualSite>`
+  - :py:class:`BondChargeVirtualSite <openff.toolkit.topology.BondChargeVirtualSite>`
+  - :py:class:`MonovalentLonePairVirtualSite <openff.toolkit.topology.MonovalentLonePairVirtualSite>`
+  - :py:class:`DivalentLonePairVirtualSite <openff.toolkit.topology.DivalentLonePairVirtualSite>`
+  - :py:class:`TrivalentLonePairVirtualSite <openff.toolkit.topology.TrivalentLonePairVirtualSite>`
 
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Adds
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Adds
 
-  - :py:class:`VirtualParticle <openforcefield.topology.VirtualParticle>`
-  - :py:class:`TopologyVirtualParticle <openforcefield.topology.TopologyVirtualParticle>`
-  - :py:meth:`BondChargeVirtualSite.get_openmm_virtual_site <openforcefield.topology.BondChargeVirtualSite.get_openmm_virtual_site>`
-  - :py:meth:`MonovalentLonePairVirtualSite.get_openmm_virtual_site <openforcefield.topology.MonovalentLonePairVirtualSite.get_openmm_virtual_site>`
-  - :py:meth:`DivalentLonePairVirtualSite.get_openmm_virtual_site <openforcefield.topology.DivalentLonePairVirtualSite.get_openmm_virtual_site>`
-  - :py:meth:`TrivalentLonePairVirtualSite.get_openmm_virtual_site <openforcefield.topology.TrivalentLonePairVirtualSite.get_openmm_virtual_site>`
-  - :py:meth:`ValenceDict.key_transform <openforcefield.topology.ValenceDict.key_transform>`
-  - :py:meth:`ValenceDict.index_of <openforcefield.topology.ValenceDict.index_of>`
-  - :py:meth:`ImproperDict.key_transform <openforcefield.topology.ImproperDict.key_transform>`
-  - :py:meth:`ImproperDict.index_of <openforcefield.topology.ImproperDict.index_of>`
+  - :py:class:`VirtualParticle <openff.toolkit.topology.VirtualParticle>`
+  - :py:class:`TopologyVirtualParticle <openff.toolkit.topology.TopologyVirtualParticle>`
+  - :py:meth:`BondChargeVirtualSite.get_openmm_virtual_site <openff.toolkit.topology.BondChargeVirtualSite.get_openmm_virtual_site>`
+  - :py:meth:`MonovalentLonePairVirtualSite.get_openmm_virtual_site <openff.toolkit.topology.MonovalentLonePairVirtualSite.get_openmm_virtual_site>`
+  - :py:meth:`DivalentLonePairVirtualSite.get_openmm_virtual_site <openff.toolkit.topology.DivalentLonePairVirtualSite.get_openmm_virtual_site>`
+  - :py:meth:`TrivalentLonePairVirtualSite.get_openmm_virtual_site <openff.toolkit.topology.TrivalentLonePairVirtualSite.get_openmm_virtual_site>`
+  - :py:meth:`ValenceDict.key_transform <openff.toolkit.topology.ValenceDict.key_transform>`
+  - :py:meth:`ValenceDict.index_of <openff.toolkit.topology.ValenceDict.index_of>`
+  - :py:meth:`ImproperDict.key_transform <openff.toolkit.topology.ImproperDict.key_transform>`
+  - :py:meth:`ImproperDict.index_of <openff.toolkit.topology.ImproperDict.index_of>`
 
-- `PR #705 <https://github.com/openforcefield/openforcefield/pull/705>`_: Adds interpolation
+- `PR #705 <https://github.com/openforcefield/openff-toolkit/pull/705>`_: Adds interpolation
   based on fractional bond orders for harmonic bonds. This includes interpolation for both
   the force constant ``k`` and/or equilibrium bond distance ``length``. This is accompanied by a
   bump in the ``<Bonds>`` section of the SMIRNOFF spec (but not the entire spec).
-- `PR #718 <https://github.com/openforcefield/openforcefield/pull/718>`_: Adds ``.rings`` and
-  ``.n_rings`` to :py:class:`Molecule <openforcefield.topology.Molecule>` and ``.is_in_ring``
-  to :py:class:`Atom <openforcefield.topology.Atom>` and
-  :py:class:`Bond <openforcefield.topology.Bond>`
+- `PR #718 <https://github.com/openforcefield/openff-toolkit/pull/718>`_: Adds ``.rings`` and
+  ``.n_rings`` to :py:class:`Molecule <openff.toolkit.topology.Molecule>` and ``.is_in_ring``
+  to :py:class:`Atom <openff.toolkit.topology.Atom>` and
+  :py:class:`Bond <openff.toolkit.topology.Bond>`
 
 Bugfixes
 """""""""
-- `PR #682 <https://github.com/openforcefield/openforcefield/pull/682>`_: Catches failures in
-  :py:meth:`Molecule.from_iupac <openforcefield.topology.Molecule.from_iupac>` instead of silently
+- `PR #682 <https://github.com/openforcefield/openff-toolkit/pull/682>`_: Catches failures in
+  :py:meth:`Molecule.from_iupac <openff.toolkit.topology.Molecule.from_iupac>` instead of silently
   failing.
-- `PR #743 <https://github.com/openforcefield/openforcefield/pull/743>`_: Prevents the non-bonded
+- `PR #743 <https://github.com/openforcefield/openff-toolkit/pull/743>`_: Prevents the non-bonded
   (vdW) cutoff from silently falling back to the OpenMM default of 1 nm in
   :py:meth:`Forcefield.create_openmm_system
-  <openforcefield.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>` and instead
+  <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>` and instead
   sets its to the value specified by the force field.
-- `PR #737 <https://github.com/openforcefield/openforcefield/pull/737>`_: Prevents OpenEye from
+- `PR #737 <https://github.com/openforcefield/openff-toolkit/pull/737>`_: Prevents OpenEye from
   incidentally being used in the conformer generation step of
   :py:class:`AmberToolsToolkitWrapper.assign_fractional_bond_orders
-  <openforcefield.utils.toolkits.AmberToolsToolkitWrapper.assign_fractional_bond_orders>`.
+  <openff.toolkit.utils.toolkits.AmberToolsToolkitWrapper.assign_fractional_bond_orders>`.
 
 Behavior changed
 """"""""""""""""
-- `PR #705 <https://github.com/openforcefield/openforcefield/pull/705>`_: Changes the default values
+- `PR #705 <https://github.com/openforcefield/openff-toolkit/pull/705>`_: Changes the default values
   in the ``<Bonds>`` section of the SMIRNOFF spec to ``fractional_bondorder_method="AM1-Wiberg"``
   and ``potential="(k/2)*(r-length)^2"``, which is backwards-compatible with and equivalent to
   ``potential="harmonic"``.
 
 Examples added
 """"""""""""""
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Adds a virtual site example notebook to run
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Adds a virtual site example notebook to run
   an OpenMM simulation with virtual sites, and compares positions and potential energy of TIP5P water between OpenFF
   and OpenMM force fields.
 
 API-breaking changes
 """"""""""""""""""""
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Methods
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Methods
 
-  - :py:meth:`Molecule.add_bond_charge_virtual_site <openforcefield.topology.Molecule.add_bond_charge_virtual_site>`
-  - :py:meth:`Molecule.add_monovalent_lone_pair_virtual_site <openforcefield.topology.Molecule.add_monovalent_lone_pair_virtual_site>`
-  - :py:meth:`Molecule.add_divalent_lone_pair_virtual_site <openforcefield.topology.Molecule.add_divalent_lone_pair_virtual_site>`
-  - :py:meth:`Molecule.add_trivalent_lone_pair_virtual_site <openforcefield.topology.Molecule.add_trivalent_lone_pair_virtual_site>`
+  - :py:meth:`Molecule.add_bond_charge_virtual_site <openff.toolkit.topology.Molecule.add_bond_charge_virtual_site>`
+  - :py:meth:`Molecule.add_monovalent_lone_pair_virtual_site <openff.toolkit.topology.Molecule.add_monovalent_lone_pair_virtual_site>`
+  - :py:meth:`Molecule.add_divalent_lone_pair_virtual_site <openff.toolkit.topology.Molecule.add_divalent_lone_pair_virtual_site>`
+  - :py:meth:`Molecule.add_trivalent_lone_pair_virtual_site <openff.toolkit.topology.Molecule.add_trivalent_lone_pair_virtual_site>`
   now only accept a list of atoms, not a list of integers, to define to parent atoms
 
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Removes
-  :py:meth:`VirtualParticle.molecule_particle_index <openforcefield.topology.VirtualParticle.molecule_particle_index>`
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Removes
+  :py:meth:`VirtualParticle.molecule_particle_index <openff.toolkit.topology.VirtualParticle.molecule_particle_index>`
 
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Removes ``outOfPlaneAngle`` from
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Removes ``outOfPlaneAngle`` from
 
-  - :py:class:`DivalentLonePairVirtualSite <openforcefield.topology.DivalentLonePairVirtualSite>`
-  - :py:class:`TrivalentLonePairVirtualSite <openforcefield.topology.TrivalentLonePairVirtualSite>`
+  - :py:class:`DivalentLonePairVirtualSite <openff.toolkit.topology.DivalentLonePairVirtualSite>`
+  - :py:class:`TrivalentLonePairVirtualSite <openff.toolkit.topology.TrivalentLonePairVirtualSite>`
 
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Removes ``inPlaneAngle`` from
-  :py:class:`TrivalentLonePairVirtualSite <openforcefield.topology.TrivalentLonePairVirtualSite>`
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Removes ``inPlaneAngle`` from
+  :py:class:`TrivalentLonePairVirtualSite <openff.toolkit.topology.TrivalentLonePairVirtualSite>`
 
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Removes ``weights`` from
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Removes ``weights`` from
 
-  - :py:class:`BondChargeVirtualSite <openforcefield.topology.BondChargeVirtualSite>`
-  - :py:class:`MonovalentLonePairVirtualSite <openforcefield.topology.MonovalentLonePairVirtualSite>`
-  - :py:class:`DivalentLonePairVirtualSite <openforcefield.topology.DivalentLonePairVirtualSite>`
-  - :py:class:`TrivalentLonePairVirtualSite <openforcefield.topology.TrivalentLonePairVirtualSite>`
+  - :py:class:`BondChargeVirtualSite <openff.toolkit.topology.BondChargeVirtualSite>`
+  - :py:class:`MonovalentLonePairVirtualSite <openff.toolkit.topology.MonovalentLonePairVirtualSite>`
+  - :py:class:`DivalentLonePairVirtualSite <openff.toolkit.topology.DivalentLonePairVirtualSite>`
+  - :py:class:`TrivalentLonePairVirtualSite <openff.toolkit.topology.TrivalentLonePairVirtualSite>`
 
 Tests added
 """""""""""
 
-- `PR #548 <https://github.com/openforcefield/openforcefield/pull/548>`_: Adds test for 
+- `PR #548 <https://github.com/openforcefield/openff-toolkit/pull/548>`_: Adds test for 
 
   - The virtual site parameter handler
   - TIP5P water dimer energy and positions
@@ -353,72 +353,72 @@ Tests added
 
 New features
 """"""""""""
-- `PR #662 <https://github.com/openforcefield/openforcefield/pull/662>`_: Adds ``.aromaticity_model``
-  of :py:class:`ForceField <openforcefield.typing.engines.smirnoff.forcefield.ForceField>` and ``.TAGNAME``
-  of :py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>` as
+- `PR #662 <https://github.com/openforcefield/openff-toolkit/pull/662>`_: Adds ``.aromaticity_model``
+  of :py:class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>` and ``.TAGNAME``
+  of :py:class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>` as
   public attributes.
-- `PR #667 <https://github.com/openforcefield/openforcefield/pull/667>`_ and
-  `PR #681 <https://github.com/openforcefield/openforcefield/pull/681>`_ linted the codebase with
+- `PR #667 <https://github.com/openforcefield/openff-toolkit/pull/667>`_ and
+  `PR #681 <https://github.com/openforcefield/openff-toolkit/pull/681>`_ linted the codebase with
   ``black`` and ``isort``, respectively.
-- `PR #675 <https://github.com/openforcefield/openforcefield/pull/675>`_ adds
+- `PR #675 <https://github.com/openforcefield/openff-toolkit/pull/675>`_ adds
   ``.toolkit_version`` to
-  :py:class:`ToolkitWrapper <openforcefield.utils.toolkits.ToolkitWrapper>` and
+  :py:class:`ToolkitWrapper <openff.toolkit.utils.toolkits.ToolkitWrapper>` and
   ``.registered_toolkit_versions`` to
-  :py:class:`ToolkitRegistry <openforcefield.utils.toolkits.ToolkitRegistry>`.
-- `PR #696 <https://github.com/openforcefield/openforcefield/pull/696>`_ Exposes a setter for
-  :py:class:`ForceField.aromaticity_model <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
-- `PR #685 <https://github.com/openforcefield/openforcefield/pull/685>`_ Adds a custom ``__hash__``
+  :py:class:`ToolkitRegistry <openff.toolkit.utils.toolkits.ToolkitRegistry>`.
+- `PR #696 <https://github.com/openforcefield/openff-toolkit/pull/696>`_ Exposes a setter for
+  :py:class:`ForceField.aromaticity_model <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
+- `PR #685 <https://github.com/openforcefield/openff-toolkit/pull/685>`_ Adds a custom ``__hash__``
   function to
-  :py:class:`ForceField <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
+  :py:class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
 
 
 Behavior changed
 """"""""""""""""
-- `PR #684 <https://github.com/openforcefield/openforcefield/pull/684>`_: Changes
-  :py:class:`ToolkitRegistry <openforcefield.utils.toolkits.ToolkitRegistry>` to return an empty
+- `PR #684 <https://github.com/openforcefield/openff-toolkit/pull/684>`_: Changes
+  :py:class:`ToolkitRegistry <openff.toolkit.utils.toolkits.ToolkitRegistry>` to return an empty
   registry when initialized with no arguments, i.e. ``ToolkitRegistry()`` and makes the
   ``register_imported_toolkit_wrappers`` argument private.
-- `PR #711 <https://github.com/openforcefield/openforcefield/pull/711>`_: The
-  setter for :py:class:`Topology.box_vectors <openforcefield.topology.Topology>`
+- `PR #711 <https://github.com/openforcefield/openff-toolkit/pull/711>`_: The
+  setter for :py:class:`Topology.box_vectors <openff.toolkit.topology.Topology>`
   now infers box vectors (a 3x3 matrix) when box lengths
   (a 3x1 array) are passed, assuming an orthogonal box.
-- `PR #649 <https://github.com/openforcefield/openforcefield/pull/648>`_: Makes SMARTS
+- `PR #649 <https://github.com/openforcefield/openff-toolkit/pull/648>`_: Makes SMARTS
   searches stereochemistry-specific (if stereo is specified in the SMARTS) for both OpenEye
   and RDKit backends. Also ensures molecule
   aromaticity is re-perceived according to the ForceField's specified
   aromaticity model, which may overwrite user-specified aromaticity on the ``Molecule``
-- `PR #648 <https://github.com/openforcefield/openforcefield/pull/648>`_: Removes the
+- `PR #648 <https://github.com/openforcefield/openff-toolkit/pull/648>`_: Removes the
   ``utils.structure`` module, which was deprecated in 0.2.0.
-- `PR #670 <https://github.com/openforcefield/openforcefield/pull/670>`_: Makes the
-  :py:class:`Topology <openforcefield.topology.Topology>` returned by ``create_openmm_system``
+- `PR #670 <https://github.com/openforcefield/openff-toolkit/pull/670>`_: Makes the
+  :py:class:`Topology <openff.toolkit.topology.Topology>` returned by ``create_openmm_system``
   contain the partial charges and partial bond orders (if any) assigned during parameterization.
-- `PR #675 <https://github.com/openforcefield/openforcefield/pull/675>`_ changes the
+- `PR #675 <https://github.com/openforcefield/openff-toolkit/pull/675>`_ changes the
   exception raised when no ``antechamber`` executable is found from ``IOError`` to
-  :py:class:`AntechamberNotFoundError <openforcefield.utils.toolkits.AntechamberNotFoundError>`
-- `PR #696 <https://github.com/openforcefield/openforcefield/pull/696>`_ Adds an
+  ``AntechamberNotFoundError``
+- `PR #696 <https://github.com/openforcefield/openff-toolkit/pull/696>`_ Adds an
   ``aromaticity_model`` keyword argument to the
-  :py:class:`ForceField <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
+  :py:class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
   constructor, which defaults to ``DEFAULT_AROMATICITY_MODEL``.
 
 Bugfixes
 """""""""
-- `PR #715 <https://github.com/openforcefield/openforcefield/pull/715>`_: Closes issue `Issue #475
-  <https://github.com/openforcefield/openforcefield/issues/475>`_ writing a "PDB" file using OE backend rearranges
+- `PR #715 <https://github.com/openforcefield/openff-toolkit/pull/715>`_: Closes issue `Issue #475
+  <https://github.com/openforcefield/openff-toolkit/issues/475>`_ writing a "PDB" file using OE backend rearranges
   the order of the atoms by pushing the hydrogens to the bottom.
-- `PR #649 <https://github.com/openforcefield/openforcefield/pull/648>`_: Prevents 2020 OE
+- `PR #649 <https://github.com/openforcefield/openff-toolkit/pull/648>`_: Prevents 2020 OE
   toolkit from issuing a warning caused by doing stereo-specific smarts searches on certain
   structures.
-- `PR #724 <https://github.com/openforcefield/openforcefield/pull/724>`_: Closes issue `Issue #502
-  <https://github.com/openforcefield/openforcefield/issues/502>`_ Adding a utility function Topology.to_file() to 
+- `PR #724 <https://github.com/openforcefield/openff-toolkit/pull/724>`_: Closes issue `Issue #502
+  <https://github.com/openforcefield/openff-toolkit/issues/502>`_ Adding a utility function Topology.to_file() to 
   write topology and positions to a "PDB" file using openmm backend for pdb file write.
 
 Tests added
 """""""""""
-- `PR #694 <https://github.com/openforcefield/openforcefield/pull/694>`_: Adds automated testing
+- `PR #694 <https://github.com/openforcefield/openff-toolkit/pull/694>`_: Adds automated testing
   to code snippets in docs.
-- `PR #715 <https://github.com/openforcefield/openforcefield/pull/715>`_: Adds tests for pdb file writes using OE
+- `PR #715 <https://github.com/openforcefield/openff-toolkit/pull/715>`_: Adds tests for pdb file writes using OE
   backend.
-- `PR #724 <https://github.com/openforcefield/openforcefield/pull/724>`_: Adds tests for the utility function Topology.to_file().
+- `PR #724 <https://github.com/openforcefield/openff-toolkit/pull/724>`_: Adds tests for the utility function Topology.to_file().
   
 
 0.7.1 - OETK2020 Compatibility and Minor Update
@@ -433,53 +433,53 @@ in molecule isomorphism checks.
 
 Behavior changed
 """"""""""""""""
-- `PR #646 <https://github.com/openforcefield/openforcefield/pull/646>`_: Checking for
-  :py:class:`Molecule <openforcefield.topology.Molecule>`
+- `PR #646 <https://github.com/openforcefield/openff-toolkit/pull/646>`_: Checking for
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>`
   equality using the ``==`` operator now disregards all pyrimidal nitrogen stereochemistry
   by default. To re-enable, use
-  :py:class:`Molecule.{is|are}_isomorphic <openforcefield.topology.Molecule>`
+  :py:class:`Molecule.{is|are}_isomorphic <openff.toolkit.topology.Molecule>`
   with the ``strip_pyrimidal_n_atom_stereo=False`` keyword argument.
-- `PR #646 <https://github.com/openforcefield/openforcefield/pull/646>`_: Adds
+- `PR #646 <https://github.com/openforcefield/openff-toolkit/pull/646>`_: Adds
   an optional ``toolkit_registry`` keyword argument to
-  :py:class:`Molecule.are_isomorphic <openforcefield.topology.Molecule>`,
+  :py:class:`Molecule.are_isomorphic <openff.toolkit.topology.Molecule>`,
   which identifies the toolkit that should be used to search for pyrimidal nitrogens.
 
 
 Bugfixes
 """"""""
-- `PR #647 <https://github.com/openforcefield/openforcefield/pull/647>`_: Updates
-  :py:class:`OpenEyeToolkitWrapper <openforcefield.utils.toolkits.OpenEyeToolkitWrapper>`
+- `PR #647 <https://github.com/openforcefield/openff-toolkit/pull/647>`_: Updates
+  :py:class:`OpenEyeToolkitWrapper <openff.toolkit.utils.toolkits.OpenEyeToolkitWrapper>`
   for 2020.0.4 OpenEye Toolkit behavior/API changes.
-- `PR #646 <https://github.com/openforcefield/openforcefield/pull/646>`_: Fixes a bug where
-  :py:class:`Molecule.chemical_environment_matches <openforcefield.topology.Molecule>`
-  was not able to accept a :py:class:`ChemicalEnvironment <openforcefield.typing.chemistry.ChemicalEnvironment>` object
+- `PR #646 <https://github.com/openforcefield/openff-toolkit/pull/646>`_: Fixes a bug where
+  :py:class:`Molecule.chemical_environment_matches <openff.toolkit.topology.Molecule>`
+  was not able to accept a :py:class:`ChemicalEnvironment <openff.toolkit.typing.chemistry.ChemicalEnvironment>` object
   as a query.
-- `PR #634 <https://github.com/openforcefield/openforcefield/pull/634>`_: Fixes a bug in which calling
-  :py:class:`RDKitToolkitWrapper.from_file <openforcefield.utils.toolkits.RDKitToolkitWrapper>` directly
+- `PR #634 <https://github.com/openforcefield/openff-toolkit/pull/634>`_: Fixes a bug in which calling
+  :py:class:`RDKitToolkitWrapper.from_file <openff.toolkit.utils.toolkits.RDKitToolkitWrapper>` directly
   would not load files correctly if passed lowercase ``file_format``. Note that this bug did not occur when calling
-  :py:class:`Molecule.from_file <openforcefield.topology.Molecule>`.
-- `PR #631 <https://github.com/openforcefield/openforcefield/pull/631>`_: Fixes a bug in which calling
-  :py:class:`unit_to_string <openforcefield.utils.utils.unit_to_string>` returned
+  :py:class:`Molecule.from_file <openff.toolkit.topology.Molecule>`.
+- `PR #631 <https://github.com/openforcefield/openff-toolkit/pull/631>`_: Fixes a bug in which calling
+  :py:class:`unit_to_string <openff.toolkit.utils.utils.unit_to_string>` returned
   ``None`` when the unit is dimensionless. Now ``"dimensionless"`` is returned.
-- `PR #630 <https://github.com/openforcefield/openforcefield/pull/630>`_: Closes issue `Issue #629
-  <https://github.com/openforcefield/openforcefield/issues/629>`_ in which the wrong exception is raised when
-  attempting to instantiate a :py:class:`ForceField <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
+- `PR #630 <https://github.com/openforcefield/openff-toolkit/pull/630>`_: Closes issue `Issue #629
+  <https://github.com/openforcefield/openff-toolkit/issues/629>`_ in which the wrong exception is raised when
+  attempting to instantiate a :py:class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
   from an unparsable string.
 
 New features
 """"""""""""
-- `PR #632 <https://github.com/openforcefield/openforcefield/pull/632>`_: Adds
-  :py:class:`ForceField.registered_parameter_handlers <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
-- `PR #614 <https://github.com/openforcefield/openforcefield/pull/614>`_: Adds 
-  :py:class:`ToolkitRegistry.deregister_toolkit <openforcefield.utils.toolkits.ToolkitRegistry>`
+- `PR #632 <https://github.com/openforcefield/openff-toolkit/pull/632>`_: Adds
+  :py:class:`ForceField.registered_parameter_handlers <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
+- `PR #614 <https://github.com/openforcefield/openff-toolkit/pull/614>`_: Adds 
+  :py:class:`ToolkitRegistry.deregister_toolkit <openff.toolkit.utils.toolkits.ToolkitRegistry>`
   to de-register registered toolkits, which can include toolkit wrappers loaded into ``GLOBAL_TOOLKIT_REGISTRY``
   by default.
-- `PR #656 <https://github.com/openforcefield/openforcefield/pull/656>`_: Adds
+- `PR #656 <https://github.com/openforcefield/openff-toolkit/pull/656>`_: Adds
   a new allowed ``am1elf10`` option to the OpenEye implementation of
-  :py:class:`assign_partial_charges <openforcefield.utils.toolkits.OpenEyeToolkitWrapper>` which
+  :py:class:`assign_partial_charges <openff.toolkit.utils.toolkits.OpenEyeToolkitWrapper>` which
   calculates the average partial charges at the AM1 level of theory using conformers selected using the ELF10 method.
-- `PR #643 <https://github.com/openforcefield/openforcefield/pull/643>`_: Adds
-  :py:class:`openforcefield.typing.engines.smirnoff.forcefield.get_available_force_fields <openforcefield.typing.engines.smirnoff.forcefield.get_available_force_fields>`,
+- `PR #643 <https://github.com/openforcefield/openff-toolkit/pull/643>`_: Adds
+  :py:class:`openforcefield.typing.engines.smirnoff.forcefield.get_available_force_fields <openff.toolkit.typing.engines.smirnoff.forcefield.get_available_force_fields>`,
   which returns paths to the files of force fields available through entry point plugins.
 
 
@@ -585,21 +585,21 @@ Full details of how to define a torsion-interpolating SMIRNOFF force fields are 
 
 Behavior changed
 """"""""""""""""
-- `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
+- `PR #508 <https://github.com/openforcefield/openff-toolkit/pull/508>`_:
   In order to provide the same results for the same chemical species, regardless of input
   conformation,
-  :py:class:`Molecule <openforcefield.topology.Molecule>`
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>`
   ``assign_partial_charges``, ``compute_partial_charges_am1bcc``, and
   ``assign_fractional_bond_orders`` methods now default to ignore input conformers
   and generate new conformer(s) of the molecule before running semiempirical calculations.
   Users can override this behavior by specifying the keyword argument
   ``use_conformers=molecule.conformers``.
-- `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_: Closes
-  `Issue #250 <https://github.com/openforcefield/openforcefield/issues/250>`_
+- `PR #281 <https://github.com/openforcefield/openff-toolkit/pull/281>`_: Closes
+  `Issue #250 <https://github.com/openforcefield/openff-toolkit/issues/250>`_
   by adding support for partial charge I/O in SDF. The partial charges are stored as a property in the
   SDF molecule block under the tag ``<atom.dprop.PartialCharge>``.
-- `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_: If a
-  :py:class:`Molecule <openforcefield.topology.Molecule>`'s
+- `PR #281 <https://github.com/openforcefield/openff-toolkit/pull/281>`_: If a
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>`'s
   ``partial_charges`` attribute is set to ``None`` (the default value), calling ``to_openeye`` will
   now produce a OE molecule with partial charges set to ``nan``. This would previously produce an OE
   molecule with partial charges of 0.0, which was a loss of information, since it wouldn't be clear
@@ -607,14 +607,14 @@ Behavior changed
   wrapper methods such as ``from_smiles`` and ``from_file`` now produce OFFMols with
   ``partial_charges = None`` when appropriate (previously these would produce OFFMols with
   all-zero charges, for the same reasoning as above).
-- `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_:
-  :py:class:`Molecule <openforcefield.topology.Molecule>`
+- `PR #281 <https://github.com/openforcefield/openff-toolkit/pull/281>`_:
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>`
   ``to_rdkit``
   now sets partial charges on the RDAtom's ``PartialCharges`` property (this was previously set
   on the ``partial_charges`` property). If the
-  :py:class:`Molecule <openforcefield.topology.Molecule>`'s partial_charges attribute is ``None``, this property
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>`'s partial_charges attribute is ``None``, this property
   will not be defined on the RDAtoms.
-- `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_:
+- `PR #281 <https://github.com/openforcefield/openff-toolkit/pull/281>`_:
   Enforce the behavior during SDF I/O that a SDF may contain multiple
   `molecules`, but that the OFF Toolkit
   does not assume that it contains multiple `conformers of the same molecule`. This is an
@@ -623,94 +623,94 @@ Behavior changed
   are defined differently for several "conformers" of chemically-identical species (More info
   `here <https://docs.eyesopen.com/toolkits/python/oechemtk/oemol.html#dude-where-s-my-sd-data>`_).
   If the user requests the OFF Toolkit to write a multi-conformer
-  :py:class:`Molecule <openforcefield.topology.Molecule>` to SDF, only the first conformer will be written.
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>` to SDF, only the first conformer will be written.
   For more fine-grained control of writing properties, conformers, and partial charges, consider
   using ``Molecule.to_rdkit`` or ``Molecule.to_openeye`` and using the functionality offered by
   those packages.
-- `PR #281 <https://github.com/openforcefield/openforcefield/pull/281>`_: Due to different
+- `PR #281 <https://github.com/openforcefield/openff-toolkit/pull/281>`_: Due to different
   constraints placed on the data types allowed by external toolkits, we make our best effort to
-  preserve :py:class:`Molecule <openforcefield.topology.Molecule>`
+  preserve :py:class:`Molecule <openff.toolkit.topology.Molecule>`
   ``properties`` when converting molecules to other packages, but users should be aware that
   no guarantee of data integrity is made. The only data format for keys and values in the property dict that
   we will try to support through a roundtrip to another toolkit's Molecule object is ``string``.
-- `PR #574 <https://github.com/openforcefield/openforcefield/pull/574>`_: Removed check that all
+- `PR #574 <https://github.com/openforcefield/openff-toolkit/pull/574>`_: Removed check that all
   partial charges are zero after assignment by ``quacpac`` when AM1BCC used for charge assignment.
   This check fails erroneously for cases in which the partial charge assignments are correctly all zero,
   such as for ``N#N``. It is also an unnecessary check given that ``quacpac`` will reliably indicate when
   it has failed to assign charges.
-- `PR #597 <https://github.com/openforcefield/openforcefield/pull/597>`_: Energy-minimized sample systems
+- `PR #597 <https://github.com/openforcefield/openff-toolkit/pull/597>`_: Energy-minimized sample systems
   with Parsley 1.1.0.
-- `PR #558 <https://github.com/openforcefield/openforcefield/pull/558>`_: The
-  :py:class:`Topology <openforcefield.topology.Topology>`
-  particle indexing system now orders :py:class:`TopologyVirtualSites <openforcefield.topology.TopologyVirtualSite>`
+- `PR #558 <https://github.com/openforcefield/openff-toolkit/pull/558>`_: The
+  :py:class:`Topology <openff.toolkit.topology.Topology>`
+  particle indexing system now orders :py:class:`TopologyVirtualSites <openff.toolkit.topology.TopologyVirtualSite>`
   after all atoms.
-- `PR #469 <https://github.com/openforcefield/openforcefield/pull/469>`_:
-  When running :py:meth:`Topology.to_openmm <openforcefield.topology.Topology.to_openmm>`, unique atom names
+- `PR #469 <https://github.com/openforcefield/openff-toolkit/pull/469>`_:
+  When running :py:meth:`Topology.to_openmm <openff.toolkit.topology.Topology.to_openmm>`, unique atom names
   are generated if the provided atom names are not unique (overriding any existing atom names). This
   uniqueness extends only to atoms in the same molecule. To disable this behavior, set the kwarg
   ``ensure_unique_atom_names=False``.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_:
-  :py:meth:`Molecule.__eq__ <openforcefield.topology.Molecule.__eq__>` now uses the new
-  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>` to perform the
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_:
+  :py:meth:`Molecule.__eq__ <openff.toolkit.topology.Molecule>` now uses the new
+  :py:meth:`Molecule.are_isomorphic <openff.toolkit.topology.Molecule.are_isomorphic>` to perform the
   similarity checking.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_:
-  The :py:meth:`Topology.from_openmm <openforcefield.topology.Topology.from_openmm>` and
-  :py:meth:`Topology.add_molecule <openforcefield.topology.Topology.add_molecule>` methods now use the
-  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>` method to match
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_:
+  The :py:meth:`Topology.from_openmm <openff.toolkit.topology.Topology.from_openmm>` and
+  :py:meth:`Topology.add_molecule <openff.toolkit.topology.Topology.add_molecule>` methods now use the
+  :py:meth:`Molecule.are_isomorphic <openff.toolkit.topology.Molecule.are_isomorphic>` method to match
   molecules.
-- `PR #551 <https://github.com/openforcefield/openforcefield/pull/551>`_: Implemented the
-  :py:meth:`ParameterHandler.get_parameter <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.get_parameter>`
+- `PR #551 <https://github.com/openforcefield/openff-toolkit/pull/551>`_: Implemented the
+  :py:meth:`ParameterHandler.get_parameter <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler.get_parameter>`
   function (would previously return ``None``).
 
 API-breaking changes
 """"""""""""""""""""
-- `PR #471 <https://github.com/openforcefield/openforcefield/pull/471>`_: Closes
-  `Issue #465 <https://github.com/openforcefield/openforcefield/issues/465>`_.
+- `PR #471 <https://github.com/openforcefield/openff-toolkit/pull/471>`_: Closes
+  `Issue #465 <https://github.com/openforcefield/openff-toolkit/issues/465>`_.
   ``atom.formal_charge`` and ``molecule.total_charge`` now return ``simtk.unit.Quantity`` objects
   instead of integers. To preserve backward compatibility, the setter for ``atom.formal_charge``
   can accept either a ``simtk.unit.Quantity`` or an integer.
-- `PR #601 <https://github.com/openforcefield/openforcefield/pull/601>`_: Removes
+- `PR #601 <https://github.com/openforcefield/openff-toolkit/pull/601>`_: Removes
   almost all of the previous
-  :py:class:`ChemicalEnvironment <openforcefield.typing.chemistry.ChemicalEnvironment>`
+  :py:class:`ChemicalEnvironment <openff.toolkit.typing.chemistry.ChemicalEnvironment>`
   API, since this entire module was simply copied from
   `Chemper <https://github.com/MobleyLab/chemper>`_ several years ago and has fallen behind on updates.
   Currently only
-  :py:meth:`ChemicalEnvironment.get_type <openforcefield.typing.chemistry.ChemicalEnvironment.get_type>`,
-  :py:meth:`ChemicalEnvironment.validate <openforcefield.typing.chemistry.ChemicalEnvironment.validate>`,
+  :py:meth:`ChemicalEnvironment.get_type <openff.toolkit.typing.chemistry.ChemicalEnvironment.get_type>`,
+  :py:meth:`ChemicalEnvironment.validate <openff.toolkit.typing.chemistry.ChemicalEnvironment.validate>`,
   and an equivalent classmethod
-  :py:meth:`ChemicalEnvironment.validate_smirks <openforcefield.typing.chemistry.ChemicalEnvironment.validate_smirks>`
+  :py:meth:`ChemicalEnvironment.validate_smirks <openff.toolkit.typing.chemistry.ChemicalEnvironment.validate_smirks>`
   remain. Also, please comment on
   `this GitHub issue <https://github.com/MobleyLab/chemper/issues/90>`_ if you HAVE been using
   the previous extra functionality in this module and would like us to prioritize creation of a Chemper
   conda package.
-- `PR #558 <https://github.com/openforcefield/openforcefield/pull/558>`_: Removes
-  ``TopologyMolecule.topology_particle_start_index``, since the :py:class:`Topology <openforcefield.topology.Topology>`
-  particle indexing system now orders :py:class:`TopologyVirtualSites <openforcefield.topology.TopologyVirtualSite>`
+- `PR #558 <https://github.com/openforcefield/openff-toolkit/pull/558>`_: Removes
+  ``TopologyMolecule.topology_particle_start_index``, since the :py:class:`Topology <openff.toolkit.topology.Topology>`
+  particle indexing system now orders :py:class:`TopologyVirtualSites <openff.toolkit.topology.TopologyVirtualSite>`
   after all atoms.
-  :py:meth:`TopologyMolecule.topology_atom_start_index <openforcefield.topology.TopologyMolecule.topology_atom_start_index>`
+  :py:meth:`TopologyMolecule.atom_start_topology_index <openff.toolkit.topology.TopologyMolecule.atom_start_topology_index>`
   and
-  :py:meth:`TopologyMolecule.topology_virtual_site_start_index <openforcefield.topology.TopologyMolecule.topology_virtual_site_start_index>`
+  :py:meth:`TopologyMolecule.virtual_particle_start_topology_index <openff.toolkit.topology.TopologyMolecule.virtual_particle_start_topology_index>`
   are still available to access the appropriate values in the respective topology indexing systems.
-- `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
+- `PR #508 <https://github.com/openforcefield/openff-toolkit/pull/508>`_:
   ``OpenEyeToolkitWrapper.compute_wiberg_bond_orders`` is now
-  :py:meth:`OpenEyeToolkitWrapper.assign_fractional_bond_orders <openforcefield.utils.toolkits.OpenEyeToolkitWrapper.assign_fractional_bond_orders>`.
+  :py:meth:`OpenEyeToolkitWrapper.assign_fractional_bond_orders <openff.toolkit.utils.toolkits.OpenEyeToolkitWrapper.assign_fractional_bond_orders>`.
   The ``charge_model`` keyword is now ``bond_order_model``. The allowed values of this keyword have
   changed from ``am1`` and ``pm3`` to ``am1-wiberg`` and ``pm3-wiberg``, respectively.
-- `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
+- `PR #508 <https://github.com/openforcefield/openff-toolkit/pull/508>`_:
   ``Molecule.compute_wiberg_bond_orders`` is now
-  :py:meth:`Molecule.assign_fractional_bond_orders <openforcefield.topology.Molecule.assign_fractional_bond_orders>`.
-- `PR #595 <https://github.com/openforcefield/openforcefield/pull/595>`_: Removed functions
+  :py:meth:`Molecule.assign_fractional_bond_orders <openff.toolkit.topology.Molecule.assign_fractional_bond_orders>`.
+- `PR #595 <https://github.com/openforcefield/openff-toolkit/pull/595>`_: Removed functions
   ``openforcefield.utils.utils.temporary_directory`` and
   ``openforcefield.utils.utils.temporary_cd`` and replaced their behavior with
   ``tempfile.TemporaryDirectory()``.
 
 New features
 """"""""""""
-- `PR #471 <https://github.com/openforcefield/openforcefield/pull/471>`_: Closes
-  `Issue #208 <https://github.com/openforcefield/openforcefield/issues/208>`_
+- `PR #471 <https://github.com/openforcefield/openff-toolkit/pull/471>`_: Closes
+  `Issue #208 <https://github.com/openforcefield/openff-toolkit/issues/208>`_
   by implementing support for the
   ``ChargeIncrementModel`` tag in the `SMIRNOFF specification <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#chargeincrementmodel-small-molecule-and-fragment-charges>`_.
-- `PR #471 <https://github.com/openforcefield/openforcefield/pull/471>`_: Implements
+- `PR #471 <https://github.com/openforcefield/openff-toolkit/pull/471>`_: Implements
   ``Molecule.assign_partial_charges``, which calls one of the newly-implemented
   ``OpenEyeToolkitWrapper.assign_partial_charges``, and
   ``AmberToolsToolkitWrapper.assign_partial_charges``. ``strict_n_conformers`` is a
@@ -719,196 +719,196 @@ New features
   supplied, but ``partial_charge_method="AM1BCC"`` is also set, then there is no clear use for
   the second conformer. The previous behavior in this case was to raise a warning, and to preserve that
   behavior, ``strict_n_conformers`` defaults to a value of ``False``.
-- `PR #471 <https://github.com/openforcefield/openforcefield/pull/471>`_: Adds
+- `PR #471 <https://github.com/openforcefield/openff-toolkit/pull/471>`_: Adds
   keyword argument ``raise_exception_types`` (default: ``[Exception]``) to
-  :py:meth:`ToolkitRegistry.call <openforcefield.utils.toolkits.ToolkitRegistry.call>`.
+  :py:meth:`ToolkitRegistry.call <openff.toolkit.utils.toolkits.ToolkitRegistry.call>`.
   The default value will provide the previous OpenFF Toolkit behavior, which is that the first ToolkitWrapper
   that can provide the requested method is called, and it either returns on success or raises an exception. This new
   keyword argument allows the ToolkitRegistry to *ignore* certain exceptions, but treat others as fatal.
   If ``raise_exception_types = []``, the ToolkitRegistry will attempt to call each ToolkitWrapper that provides the
   requested method and if none succeeds, a single ``ValueError`` will be raised, with text listing the
   errors that were raised by each ToolkitWrapper.
-- `PR #601 <https://github.com/openforcefield/openforcefield/pull/601>`_: Adds
-  :py:meth:`RDKitToolkitWrapper.get_tagged_smarts_connectivity <openforcefield.utils.toolkits.RDKitToolkitWrapper.get_tagged_smarts_connectivity>`
+- `PR #601 <https://github.com/openforcefield/openff-toolkit/pull/601>`_: Adds
+  :py:meth:`RDKitToolkitWrapper.get_tagged_smarts_connectivity <openff.toolkit.utils.toolkits.RDKitToolkitWrapper.get_tagged_smarts_connectivity>`
   and
-  :py:meth:`OpenEyeToolkitWrapper.get_tagged_smarts_connectivity <openforcefield.utils.toolkits.OpenEyeToolkitWrapper.get_tagged_smarts_connectivity>`,
+  :py:meth:`OpenEyeToolkitWrapper.get_tagged_smarts_connectivity <openff.toolkit.utils.toolkits.OpenEyeToolkitWrapper.get_tagged_smarts_connectivity>`,
   which allow the use of either toolkit for smirks/tagged smarts validation.
-- `PR #600 <https://github.com/openforcefield/openforcefield/pull/600>`_:
-  Adds :py:meth:`ForceField.__getitem__ <openforcefield.typing.engines.smirnoff.forcefield.ForceField.__getitem__>`
+- `PR #600 <https://github.com/openforcefield/openff-toolkit/pull/600>`_:
+  Adds :py:meth:`ForceField.__getitem__ <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
   to look up ``ParameterHandler`` objects based on their string names.
-- `PR #508 <https://github.com/openforcefield/openforcefield/pull/508>`_:
-  Adds :py:meth:`AmberToolsToolkitWrapper.assign_fractional_bond_orders <openforcefield.utils.toolkits.AmberToolsToolkitWrapper.assign_wiberg_bond_orders>`.
-- `PR #469 <https://github.com/openforcefield/openforcefield/pull/469>`_: The
-  :py:class:`Molecule <openforcefield.topology.Molecule>` class adds
-  :py:meth:`Molecule.has_unique_atom_names <openforcefield.topology.Molecule.has_unique_atom_names>`
-  and :py:meth:`Molecule.has_unique_atom_names <openforcefield.topology.Molecule.generate_unique_atom_names>`.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_:
-  Adds to the :py:class:`Molecule <openforcefield.topology.Molecule>` class
-  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>`
-  and :py:meth:`Molecule.is_isomorphic_with <openforcefield.topology.Molecule.is_isomorphic_with>`
-  and :py:meth:`Molecule.hill_formula <openforcefield.topology.Molecule.hill_formula>`
-  and :py:meth:`Molecule.to_hill_formula <openforcefield.topology.Molecule.to_hill_formula>`
-  and :py:meth:`Molecule.to_qcschema <openforcefield.topology.Molecule.to_qcschema>`
-  and :py:meth:`Molecule.from_qcschema <openforcefield.topology.Molecule.from_qcschema>`
-  and :py:meth:`Molecule.from_mapped_smiles <openforcefield.topology.Molecule.from_mapped_smiles>`
-  and :py:meth:`Molecule.from_pdb_and_smiles <openforcefield.topology.Molecule.from_pdb_and_smiles>`
-  and :py:meth:`Molecule.canonical_order_atoms <openforcefield.topology.Molecule.canonical_order_atoms>`
-  and :py:meth:`Molecule.remap <openforcefield.topology.Molecule.remap>`
+- `PR #508 <https://github.com/openforcefield/openff-toolkit/pull/508>`_:
+  Adds :py:meth:`AmberToolsToolkitWrapper.assign_fractional_bond_orders <openff.toolkit.utils.toolkits.AmberToolsToolkitWrapper.assign_fractional_bond_orders>`.
+- `PR #469 <https://github.com/openforcefield/openff-toolkit/pull/469>`_: The
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>` class adds
+  :py:meth:`Molecule.has_unique_atom_names <openff.toolkit.topology.Molecule.has_unique_atom_names>`
+  and :py:meth:`Molecule.has_unique_atom_names <openff.toolkit.topology.Molecule.generate_unique_atom_names>`.
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_:
+  Adds to the :py:class:`Molecule <openff.toolkit.topology.Molecule>` class
+  :py:meth:`Molecule.are_isomorphic <openff.toolkit.topology.Molecule.are_isomorphic>`
+  and :py:meth:`Molecule.is_isomorphic_with <openff.toolkit.topology.Molecule.is_isomorphic_with>`
+  and :py:meth:`Molecule.hill_formula <openff.toolkit.topology.Molecule.hill_formula>`
+  and :py:meth:`Molecule.to_hill_formula <openff.toolkit.topology.Molecule.to_hill_formula>`
+  and :py:meth:`Molecule.to_qcschema <openff.toolkit.topology.Molecule.to_qcschema>`
+  and :py:meth:`Molecule.from_qcschema <openff.toolkit.topology.Molecule.from_qcschema>`
+  and :py:meth:`Molecule.from_mapped_smiles <openff.toolkit.topology.Molecule.from_mapped_smiles>`
+  and :py:meth:`Molecule.from_pdb_and_smiles <openff.toolkit.topology.Molecule.from_pdb_and_smiles>`
+  and :py:meth:`Molecule.canonical_order_atoms <openff.toolkit.topology.Molecule.canonical_order_atoms>`
+  and :py:meth:`Molecule.remap <openff.toolkit.topology.Molecule.remap>`
       .. note::
          The to_qcschema method accepts an extras dictionary which is passed into the validated qcelemental.models.Molecule
          object.
-- `PR #506 <https://github.com/openforcefield/openforcefield/pull/506>`_:
-  The :py:class:`Molecule <openforcefield.topology.Molecule>` class adds
-  :py:meth:`Molecule.find_rotatable_bonds <openforcefield.topology.Molecule.find_rotatable_bonds>`
-- `PR #521 <https://github.com/openforcefield/openforcefield/pull/521>`_:
-  Adds :py:meth:`Molecule.to_inchi <openforcefield.topology.Molecule.to_inchi>`
-  and :py:meth:`Molecule.to_inchikey <openforcefield.topology.Molecule.to_inchikey>`
-  and :py:meth:`Molecule.from_inchi <openforcefield.topology.Molecule.from_inchi>`
+- `PR #506 <https://github.com/openforcefield/openff-toolkit/pull/506>`_:
+  The :py:class:`Molecule <openff.toolkit.topology.Molecule>` class adds
+  :py:meth:`Molecule.find_rotatable_bonds <openff.toolkit.topology.Molecule.find_rotatable_bonds>`
+- `PR #521 <https://github.com/openforcefield/openff-toolkit/pull/521>`_:
+  Adds :py:meth:`Molecule.to_inchi <openff.toolkit.topology.Molecule.to_inchi>`
+  and :py:meth:`Molecule.to_inchikey <openff.toolkit.topology.Molecule.to_inchikey>`
+  and :py:meth:`Molecule.from_inchi <openff.toolkit.topology.Molecule.from_inchi>`
       .. warning::
          InChI was not designed as an molecule interchange format and using it as one is not recommended. Many round trip
          tests will fail when using this format due to a loss of information. We have also added support for fixed
          hydrogen layer nonstandard InChI which can help in the case of tautomers, but overall creating molecules from InChI should be
          avoided.
-- `PR #529 <https://github.com/openforcefield/openforcefield/pull/529>`_: Adds the ability to write out to XYZ files via
-  :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` Both single frame and multiframe XYZ files are supported.
+- `PR #529 <https://github.com/openforcefield/openff-toolkit/pull/529>`_: Adds the ability to write out to XYZ files via
+  :py:meth:`Molecule.to_file <openff.toolkit.topology.Molecule.to_file>` Both single frame and multiframe XYZ files are supported.
   Note reading from XYZ files will not be supported due to the lack of connectivity information.
-- `PR #535 <https://github.com/openforcefield/openforcefield/pull/535>`_: Extends the the API for the
-  :py:meth:`Molecule.to_smiles <openforcefield.topology.Molecule.to_smiles>` to allow for the creation of cmiles
+- `PR #535 <https://github.com/openforcefield/openff-toolkit/pull/535>`_: Extends the the API for the
+  :py:meth:`Molecule.to_smiles <openff.toolkit.topology.Molecule.to_smiles>` to allow for the creation of cmiles
   identifiers through combinations of isomeric, explicit hydrogen and mapped smiles, the default settings will return
   isomeric explicit hydrogen smiles as expected.
         .. warning::
            Atom maps can be supplied to the properties dictionary to modify which atoms have their map index included,
            if no map is supplied all atoms will be mapped in the order they appear in the
-           :py:class:`Molecule <openforcefield.topology.Molecule>`.
-- `PR #563 <https://github.com/openforcefield/openforcefield/pull/563>`_:
+           :py:class:`Molecule <openff.toolkit.topology.Molecule>`.
+- `PR #563 <https://github.com/openforcefield/openff-toolkit/pull/563>`_:
   Adds ``test_forcefields/ion_charges.offxml``, giving ``LibraryCharges`` for monatomic ions.
-- `PR #543 <https://github.com/openforcefield/openforcefield/pull/543>`_:
-  Adds 3 new methods to the :py:class:`Molecule <openforcefield.topology.Molecule>` class which allow the enumeration of molecule
-  states. These are :py:meth:`Molecule.enumerate_tautomers <openforcefield.topology.Molecule.enumerate_tautomers>`,
-  :py:meth:`Molecule.enumerate_stereoisomers <openforcefield.topology.Molecule.enumerate_stereoisomers>`,
-  :py:meth:`Molecule.enumerate_protomers <openforcefield.topology.Molecule.enumerate_protomers>`
+- `PR #543 <https://github.com/openforcefield/openff-toolkit/pull/543>`_:
+  Adds 3 new methods to the :py:class:`Molecule <openff.toolkit.topology.Molecule>` class which allow the enumeration of molecule
+  states. These are :py:meth:`Molecule.enumerate_tautomers <openff.toolkit.topology.Molecule.enumerate_tautomers>`,
+  :py:meth:`Molecule.enumerate_stereoisomers <openff.toolkit.topology.Molecule.enumerate_stereoisomers>`,
+  :py:meth:`Molecule.enumerate_protomers <openff.toolkit.topology.Molecule.enumerate_protomers>`
       .. warning::
          Enumerate protomers is currently only available through the OpenEye toolkit.
-- `PR #573 <https://github.com/openforcefield/openforcefield/pull/573>`_:
+- `PR #573 <https://github.com/openforcefield/openff-toolkit/pull/573>`_:
   Adds ``quacpac`` error output to ``quacpac`` failure in ``Molecule.compute_partial_charges_am1bcc``.
-- `PR #560 <https://github.com/openforcefield/openforcefield/issues/560>`_: Added visualization method to the the Molecule class.
-- `PR #620 <https://github.com/openforcefield/openforcefield/pull/620>`_: Added the ability to register parameter handlers via entry point plugins. This functionality is accessible by initializing a ``ForceField`` with the ``load_plugins=True`` keyword argument. 
-- `PR #582 <https://github.com/openforcefield/openforcefield/pull/582>`_: Added fractional bond order interpolation
+- `PR #560 <https://github.com/openforcefield/openff-toolkit/issues/560>`_: Added visualization method to the the Molecule class.
+- `PR #620 <https://github.com/openforcefield/openff-toolkit/pull/620>`_: Added the ability to register parameter handlers via entry point plugins. This functionality is accessible by initializing a ``ForceField`` with the ``load_plugins=True`` keyword argument. 
+- `PR #582 <https://github.com/openforcefield/openff-toolkit/pull/582>`_: Added fractional bond order interpolation
   Adds `return_topology` kwarg to
-  :py:meth:`Forcefield.create_openmm_system <openforcefield.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>`,
+  :py:meth:`Forcefield.create_openmm_system <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>`,
   which returns the processed topology along with the system when ``True`` (default ``False``).
 
 Tests added
 """""""""""
-- `PR #558 <https://github.com/openforcefield/openforcefield/pull/558>`_: Adds tests ensuring
+- `PR #558 <https://github.com/openforcefield/openff-toolkit/pull/558>`_: Adds tests ensuring
   that the new Topology particle indexing system are properly implemented, and that TopologyVirtualSites
   reference the correct TopologyAtoms.
-- `PR #469 <https://github.com/openforcefield/openforcefield/pull/469>`_: Added round-trip SMILES test
-  to add coverage for :py:meth:`Molecule.from_smiles <openforcefield.topology.Molecule.from_smiles>`.
-- `PR #469 <https://github.com/openforcefield/openforcefield/pull/469>`_: Added tests for unique atom
-  naming behavior in  :py:meth:`Topology.to_openmm <openforcefield.topology.Topology.to_openmm>`, as
+- `PR #469 <https://github.com/openforcefield/openff-toolkit/pull/469>`_: Added round-trip SMILES test
+  to add coverage for :py:meth:`Molecule.from_smiles <openff.toolkit.topology.Molecule.from_smiles>`.
+- `PR #469 <https://github.com/openforcefield/openff-toolkit/pull/469>`_: Added tests for unique atom
+  naming behavior in  :py:meth:`Topology.to_openmm <openff.toolkit.topology.Topology.to_openmm>`, as
   well as tests of the ``ensure_unique_atom_names=False`` kwarg disabling this behavior.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_: Added tests for
-  :py:meth:`Molecule.hill_formula <openforcefield.topology.Molecule.hill_formula>` and
-  :py:meth:`Molecule.to_hill_formula <openforcefield.topology.Molecule.to_hill_formula>` for the
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_: Added tests for
+  :py:meth:`Molecule.hill_formula <openff.toolkit.topology.Molecule.hill_formula>` and
+  :py:meth:`Molecule.to_hill_formula <openff.toolkit.topology.Molecule.to_hill_formula>` for the
   various supported input types.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_: Added round-trip test for
-  :py:meth:`Molecule.from_qcschema <openforcefield.topology.Molecule.from_qcschema>` and
-  :py:meth:`Molecule.to_qcschema <openforcefield.topology.Molecule.to_qcschema>`.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_: Added tests for
-  :py:meth:`Molecule.is_isomorphic_with <openforcefield.topology.Molecule.is_isomorphic_with>` and
-  :py:meth:`Molecule.are_isomorphic <openforcefield.topology.Molecule.are_isomorphic>`
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_: Added round-trip test for
+  :py:meth:`Molecule.from_qcschema <openff.toolkit.topology.Molecule.from_qcschema>` and
+  :py:meth:`Molecule.to_qcschema <openff.toolkit.topology.Molecule.to_qcschema>`.
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_: Added tests for
+  :py:meth:`Molecule.is_isomorphic_with <openff.toolkit.topology.Molecule.is_isomorphic_with>` and
+  :py:meth:`Molecule.are_isomorphic <openff.toolkit.topology.Molecule.are_isomorphic>`
   with various levels of isomorphic graph matching.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_: Added toolkit dependent tests
-  for :py:meth:`Molecule.canonical_order_atoms <openforcefield.topology.Molecule.canonical_order_atoms>`
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_: Added toolkit dependent tests
+  for :py:meth:`Molecule.canonical_order_atoms <openff.toolkit.topology.Molecule.canonical_order_atoms>`
   due to differences in the algorithms used.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_: Added a test for
-  :py:meth:`Molecule.from_mapped_smiles <openforcefield.topology.Molecule.from_mapped_smiles>` using
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_: Added a test for
+  :py:meth:`Molecule.from_mapped_smiles <openff.toolkit.topology.Molecule.from_mapped_smiles>` using
   the molecule from issue #412 to ensure it is now fixed.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_: Added a test for
-  :py:meth:`Molecule.remap <openforcefield.topology.Molecule.remap>`, this also checks for expected
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_: Added a test for
+  :py:meth:`Molecule.remap <openff.toolkit.topology.Molecule.remap>`, this also checks for expected
   error when the mapping is not complete.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_: Added tests for
-  :py:meth:`Molecule.from_pdb_and_smiles <openforcefield.topology.Molecule.from_pdb_and_smiles>`
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_: Added tests for
+  :py:meth:`Molecule.from_pdb_and_smiles <openff.toolkit.topology.Molecule.from_pdb_and_smiles>`
   to check for a correct combination of smiles and PDB and incorrect combinations.
-- `PR #509 <https://github.com/openforcefield/openforcefield/pull/509>`_: Added test for
-  :py:meth:`Molecule.chemical_environment_matches <openforcefield.topology.Molecule.chemical_environment_matches>`
+- `PR #509 <https://github.com/openforcefield/openff-toolkit/pull/509>`_: Added test for
+  :py:meth:`Molecule.chemical_environment_matches <openff.toolkit.topology.Molecule.chemical_environment_matches>`
   to check that the complete set of matches is returned.
-- `PR #509 <https://github.com/openforcefield/openforcefield/pull/509>`_: Added test for
-  :py:meth:`Forcefield.create_openmm_system <openforcefield.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>`
+- `PR #509 <https://github.com/openforcefield/openff-toolkit/pull/509>`_: Added test for
+  :py:meth:`Forcefield.create_openmm_system <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>`
   to check that a protein system can be created.
-- `PR #506 <https://github.com/openforcefield/openforcefield/pull/506>`_: Added a test for the molecule
+- `PR #506 <https://github.com/openforcefield/openff-toolkit/pull/506>`_: Added a test for the molecule
   identified in issue #513 as losing aromaticity when converted to rdkit.
-- `PR #506 <https://github.com/openforcefield/openforcefield/pull/506>`_: Added a verity of toolkit dependent tests
+- `PR #506 <https://github.com/openforcefield/openff-toolkit/pull/506>`_: Added a verity of toolkit dependent tests
   for identifying rotatable bonds while ignoring the user requested types.
-- `PR #521 <https://github.com/openforcefield/openforcefield/pull/521>`_: Added toolkit independent round-trip InChI
-  tests which add coverage for :py:meth:`Molecule.to_inchi <openforcefield.topology.Molecule.to_inchi>` and
-  :py:meth:`Molecule.from_inchi <openforcefield.topology.Molecule.from_inchi>`. Also added coverage for bad inputs and
-  :py:meth:`Molecule.to_inchikey <openforcefield.topology.Molecule.to_inchikey>`.
-- `PR #529 <https://github.com/openforcefield/openforcefield/pull/529>`_: Added to XYZ file coverage tests.
-- `PR #563 <https://github.com/openforcefield/openforcefield/pull/563>`_: Added `LibraryCharges` parameterization test
+- `PR #521 <https://github.com/openforcefield/openff-toolkit/pull/521>`_: Added toolkit independent round-trip InChI
+  tests which add coverage for :py:meth:`Molecule.to_inchi <openff.toolkit.topology.Molecule.to_inchi>` and
+  :py:meth:`Molecule.from_inchi <openff.toolkit.topology.Molecule.from_inchi>`. Also added coverage for bad inputs and
+  :py:meth:`Molecule.to_inchikey <openff.toolkit.topology.Molecule.to_inchikey>`.
+- `PR #529 <https://github.com/openforcefield/openff-toolkit/pull/529>`_: Added to XYZ file coverage tests.
+- `PR #563 <https://github.com/openforcefield/openff-toolkit/pull/563>`_: Added `LibraryCharges` parameterization test
   for monatomic ions in ``test_forcefields/ion_charges.offxml``.
-- `PR #543 <https://github.com/openforcefield/openforcefield/pull/543>`_: Added tests to assure that state enumeration can
+- `PR #543 <https://github.com/openforcefield/openff-toolkit/pull/543>`_: Added tests to assure that state enumeration can
   correctly find molecules tautomers, stereoisomers and protomers when possible.
-- `PR #573 <https://github.com/openforcefield/openforcefield/pull/573>`_: Added test for ``quacpac`` error output
+- `PR #573 <https://github.com/openforcefield/openff-toolkit/pull/573>`_: Added test for ``quacpac`` error output
   for ``quacpac`` failure in ``Molecule.compute_partial_charges_am1bcc``.
-- `PR #579 <https://github.com/openforcefield/openforcefield/pull/579>`_: Adds regression tests to ensure RDKit can be
+- `PR #579 <https://github.com/openforcefield/openff-toolkit/pull/579>`_: Adds regression tests to ensure RDKit can be
   be used to write multi-model PDB files.
-- `PR #582 <https://github.com/openforcefield/openforcefield/pull/582>`_: Added fractional bond order interpolation tests,
-  tests for :py:class:`ValidatedDict <openforcefield.utils.collections.ValidatedDict>`.
+- `PR #582 <https://github.com/openforcefield/openff-toolkit/pull/582>`_: Added fractional bond order interpolation tests,
+  tests for :py:class:`ValidatedDict <openff.toolkit.utils.collections.ValidatedDict>`.
 
 
 Bugfixes
 """"""""
-- `PR #558 <https://github.com/openforcefield/openforcefield/pull/558>`_: Fixes a bug where
-  :py:meth:`TopologyVirtualSite.atoms <openforcefield.topology.TopologyVirtualSite.atoms>` would
+- `PR #558 <https://github.com/openforcefield/openff-toolkit/pull/558>`_: Fixes a bug where
+  :py:meth:`TopologyVirtualSite.atoms <openff.toolkit.topology.TopologyVirtualSite.atoms>` would
   not correctly apply ``TopologyMolecule`` atom ordering on top of the reference molecule ordering,
   in cases where the same molecule appears multiple times, but in a different order, in the same Topology.
-- `Issue #460 <https://github.com/openforcefield/openforcefield/issues/460>`_: Creates unique atom
-  names in :py:meth:`Topology.to_openmm <openforcefield.topology.Topology.to_openmm>` if the existing
+- `Issue #460 <https://github.com/openforcefield/openff-toolkit/issues/460>`_: Creates unique atom
+  names in :py:meth:`Topology.to_openmm <openff.toolkit.topology.Topology.to_openmm>` if the existing
   ones are not unique. The lack of unique atom names had been causing problems in workflows involving
   downstream tools that expect unique atom names.
-- `Issue #448 <https://github.com/openforcefield/openforcefield/issues/448>`_: We can now make molecules
-  from mapped smiles using :py:meth:`Molecule.from_mapped_smiles <openforcefield.topology.Molecule.from_mapped_smiles>`
+- `Issue #448 <https://github.com/openforcefield/openff-toolkit/issues/448>`_: We can now make molecules
+  from mapped smiles using :py:meth:`Molecule.from_mapped_smiles <openff.toolkit.topology.Molecule.from_mapped_smiles>`
   where the order will correspond to the indeing used in the smiles.
   Molecules can also be re-indexed at any time using the
-  :py:meth:`Molecule.remap <openforcefield.topology.Molecule.remap>`.
-- `Issue #462 <https://github.com/openforcefield/openforcefield/issues/462>`_: We can now instance the
-  :py:class:`Molecule <openforcefield.topology.Molecule>` from a QCArchive entry record instance or dictionary
+  :py:meth:`Molecule.remap <openff.toolkit.topology.Molecule.remap>`.
+- `Issue #462 <https://github.com/openforcefield/openff-toolkit/issues/462>`_: We can now instance the
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>` from a QCArchive entry record instance or dictionary
   representation.
-- `Issue #412 <https://github.com/openforcefield/openforcefield/issues/412>`_: We can now instance the
-  :py:class:`Molecule <openforcefield.topology.Molecule>` using
-  :py:meth:`Molecule.from_mapped_smiles <openforcefield.topology.Molecule.from_mapped_smiles>`. This resolves
+- `Issue #412 <https://github.com/openforcefield/openff-toolkit/issues/412>`_: We can now instance the
+  :py:class:`Molecule <openff.toolkit.topology.Molecule>` using
+  :py:meth:`Molecule.from_mapped_smiles <openff.toolkit.topology.Molecule.from_mapped_smiles>`. This resolves
   an issue caused by RDKit considering atom map indices to be a distinguishing feature of an atom, which led
   to erroneous definition of chirality (as otherwise symmetric substituents would be seen as different).
   We anticipate that this will reduce the number of times you need to
   type ``allow_undefined_stereo=True`` when processing molecules that do not actually contain stereochemistrty.
-- `Issue #513 <https://github.com/openforcefield/openforcefield/issues/513>`_: The
-  :py:meth:`Molecule.to_rdkit <openforcefield.topology.Molecule.to_rdkit>` now re-sets the aromaticity model
+- `Issue #513 <https://github.com/openforcefield/openff-toolkit/issues/513>`_: The
+  :py:meth:`Molecule.to_rdkit <openff.toolkit.topology.Molecule.to_rdkit>` now re-sets the aromaticity model
   after sanitizing the molecule.
-- `Issue #500 <https://github.com/openforcefield/openforcefield/issues/500>`_: The
-  :py:meth:`Molecule.find_rotatable_bonds <openforcefield.topology.Molecule.find_rotatable_bonds>` has been added
-  which returns a list of rotatable :py:class:`Bond <openforcefield.topology.Bond>` instances for the molecule.
-- `Issue #491 <https://github.com/openforcefield/openforcefield/issues/491>`_: We can now parse large molecules without hitting a match limit cap.
-- `Issue #474 <https://github.com/openforcefield/openforcefield/issues/474>`_: We can now  convert molecules to InChI and
+- `Issue #500 <https://github.com/openforcefield/openff-toolkit/issues/500>`_: The
+  :py:meth:`Molecule.find_rotatable_bonds <openff.toolkit.topology.Molecule.find_rotatable_bonds>` has been added
+  which returns a list of rotatable :py:class:`Bond <openff.toolkit.topology.Bond>` instances for the molecule.
+- `Issue #491 <https://github.com/openforcefield/openff-toolkit/issues/491>`_: We can now parse large molecules without hitting a match limit cap.
+- `Issue #474 <https://github.com/openforcefield/openff-toolkit/issues/474>`_: We can now  convert molecules to InChI and
   InChIKey and from InChI.
-- `Issue #523 <https://github.com/openforcefield/openforcefield/issues/523>`_: The
-  :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` method can now correctly write to ``MOL``
+- `Issue #523 <https://github.com/openforcefield/openff-toolkit/issues/523>`_: The
+  :py:meth:`Molecule.to_file <openff.toolkit.topology.Molecule.to_file>` method can now correctly write to ``MOL``
   files, in line with the supported file type list.
-- `Issue #568 <https://github.com/openforcefield/openforcefield/issues/568>`_: The
-  :py:meth:`Molecule.to_file <openforcefield.topology.Molecule.to_file>` can now correctly write multi-model PDB files
+- `Issue #568 <https://github.com/openforcefield/openff-toolkit/issues/568>`_: The
+  :py:meth:`Molecule.to_file <openff.toolkit.topology.Molecule.to_file>` can now correctly write multi-model PDB files
   when using the RDKit backend toolkit.
 
 
 Examples added
 """"""""""""""
-- `PR #591 <https://github.com/openforcefield/openforcefield/pull/591>`_ and
-  `PR #533 <https://github.com/openforcefield/openforcefield/pull/533>`_: Adds an
-  `example notebook and utility to compute conformer energies <https://github.com/openforcefield/openforcefield/blob/master/examples/conformer_energies>`_.
+- `PR #591 <https://github.com/openforcefield/openff-toolkit/pull/591>`_ and
+  `PR #533 <https://github.com/openforcefield/openff-toolkit/pull/533>`_: Adds an
+  `example notebook and utility to compute conformer energies <https://github.com/openforcefield/openff-toolkit/blob/master/examples/conformer_energies>`_.
   This example is made to be reverse-compatible with the 0.6.0 OpenFF Toolkit release.
-- `PR #472 <https://github.com/openforcefield/openforcefield/pull/472>`_: Adds an example notebook
-  `QCarchive_interface.ipynb <https://github.com/openforcefield/openforcefield/blob/master/examples/QCArchive_interface/QCarchive_interface.ipynb>`_
-  which shows users how to instance the :py:class:`Molecule <openforcefield.topology.Molecule>` from
+- `PR #472 <https://github.com/openforcefield/openff-toolkit/pull/472>`_: Adds an example notebook
+  `QCarchive_interface.ipynb <https://github.com/openforcefield/openff-toolkit/blob/master/examples/QCArchive_interface/QCarchive_interface.ipynb>`_
+  which shows users how to instance the :py:class:`Molecule <openff.toolkit.topology.Molecule>` from
   a QCArchive entry level record and calculate the energy using RDKit through QCEngine.
 
 
@@ -930,18 +930,18 @@ keywords for overriding them are in the "Behavior Changed" section below.
 With this release, we update ``test_forcefields/tip3p.offxml`` to be a working example of assigning LibraryCharges.
 However, we do not provide any force field files to assign protein residue ``LibraryCharges``.
 If you are interested in translating an existing protein FF to SMIRNOFF format or developing a new one, please
-feel free to contact us on the `Issue tracker <https://github.com/openforcefield/openforcefield/issues>`_ or open a
-`Pull Request <https://github.com/openforcefield/openforcefield/pulls>`_.
+feel free to contact us on the `Issue tracker <https://github.com/openforcefield/openff-toolkit/issues>`_ or open a
+`Pull Request <https://github.com/openforcefield/openff-toolkit/pulls>`_.
 
 
 New features
 """"""""""""
-- `PR #433 <https://github.com/openforcefield/openforcefield/pull/433>`_: Closes
-  `Issue #25 <https://github.com/openforcefield/openforcefield/issues/25>`_ by adding
+- `PR #433 <https://github.com/openforcefield/openff-toolkit/pull/433>`_: Closes
+  `Issue #25 <https://github.com/openforcefield/openff-toolkit/issues/25>`_ by adding
   initial support for the
   `LibraryCharges tag in the SMIRNOFF specification <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#librarycharges-library-charges-for-polymeric-residues-and-special-solvent-models>`_
   using
-  :py:class:`LibraryChargeHandler <openforcefield.typing.engines.smirnoff.parameters.LibraryChargeHandler>`.
+  :py:class:`LibraryChargeHandler <openff.toolkit.typing.engines.smirnoff.parameters.LibraryChargeHandler>`.
   For a molecule to have charges assigned using Library Charges, all of its atoms must be covered by
   at least one ``LibraryCharge``. If an atom is covered by multiple ``LibraryCharge`` s, then the last
   ``LibraryCharge`` matched will be applied (per the hierarchy rules in the SMIRNOFF format).
@@ -962,17 +962,17 @@ New features
   partial overlaps were found to frequently be sources of undesired behavior, so it is recommended
   that users define whole-molecule ``LibraryCharge`` SMARTS whenever possible.
 
-- `PR #455 <https://github.com/openforcefield/openforcefield/pull/455>`_: Addresses
-  `Issue #393 <https://github.com/openforcefield/openforcefield/issues/393>`_ by adding
-  :py:meth:`ParameterHandler.attribute_is_cosmetic <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler.attribute_is_cosmetic>`
+- `PR #455 <https://github.com/openforcefield/openff-toolkit/pull/455>`_: Addresses
+  `Issue #393 <https://github.com/openforcefield/openff-toolkit/issues/393>`_ by adding
+  :py:meth:`ParameterHandler.attribute_is_cosmetic <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler.attribute_is_cosmetic>`
   and
-  :py:meth:`ParameterType.attribute_is_cosmetic <openforcefield.typing.engines.smirnoff.parameters.ParameterType.attribute_is_cosmetic>`,
+  :py:meth:`ParameterType.attribute_is_cosmetic <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType.attribute_is_cosmetic>`,
   which return True if the provided attribute name is defined for the queried object
   but does not correspond to an allowed value in the SMIRNOFF spec.
 
 Behavior changed
 """"""""""""""""
-- `PR #433 <https://github.com/openforcefield/openforcefield/pull/433>`_: If a molecule
+- `PR #433 <https://github.com/openforcefield/openff-toolkit/pull/433>`_: If a molecule
   can not be assigned charges by any charge-assignment method, an
   ``openforcefield.typing.engines.smirnoff.parameters.UnassignedMoleculeChargeException``
   will be raised. Previously, creating a system without either ``ToolkitAM1BCCHandler`` or
@@ -982,7 +982,7 @@ Behavior changed
   failures not be silent. Molecules with zero charge can still be produced by setting the
   ``Molecule.partial_charges`` array to be all zeroes, and including the molecule in the
   ``charge_from_molecules`` keyword argument to ``create_openmm_system``.
-- `PR #433 <https://github.com/openforcefield/openforcefield/pull/433>`_: Due to risks
+- `PR #433 <https://github.com/openforcefield/openff-toolkit/pull/433>`_: Due to risks
   introduced by permitting charge assignment using partially-overlapping ``LibraryCharge`` s,
   the toolkit will now raise a
   ``openforcefield.typing.engines.smirnoff.parameters.NonIntegralMoleculeChargeException``
@@ -995,26 +995,26 @@ Behavior changed
 
 Tests added
 """""""""""
-- `PR #430 <https://github.com/openforcefield/openforcefield/pull/430>`_: Added test for
+- `PR #430 <https://github.com/openforcefield/openff-toolkit/pull/430>`_: Added test for
   Wiberg Bond Order implemented in OpenEye Toolkits. Molecules taken from
   DOI:10.5281/zenodo.3405489 . Added by Sukanya Sasmal.
-- `PR #569 <https://github.com/openforcefield/openforcefield/pull/569>`_: Added round-trip tests for more serialization formats (dict, YAML, TOML, JSON, BSON, messagepack, pickle). Note that some are unsupported, but the tests raise the appropriate error.
+- `PR #569 <https://github.com/openforcefield/openff-toolkit/pull/569>`_: Added round-trip tests for more serialization formats (dict, YAML, TOML, JSON, BSON, messagepack, pickle). Note that some are unsupported, but the tests raise the appropriate error.
 
 
 Bugfixes
 """"""""
-- `PR #431 <https://github.com/openforcefield/openforcefield/pull/431>`_: Fixes an issue
+- `PR #431 <https://github.com/openforcefield/openff-toolkit/pull/431>`_: Fixes an issue
   where ``ToolkitWrapper`` objects would improperly search for functionality in the
   ``GLOBAL_TOOLKIT_REGISTRY``, even though a specific ``ToolkitRegistry`` was requested for an
   operation.
-- `PR #439 <https://github.com/openforcefield/openforcefield/pull/439>`_: Fixes
-  `Issue #438 <https://github.com/openforcefield/openforcefield/issues/438>`_, by replacing
+- `PR #439 <https://github.com/openforcefield/openff-toolkit/pull/439>`_: Fixes
+  `Issue #438 <https://github.com/openforcefield/openff-toolkit/issues/438>`_, by replacing
   call to NetworkX ``Graph.node`` with call to ``Graph.nodes``, per
   `2.4 migration guide <https://networkx.github.io/documentation/stable/release/release_2.4.html>`_.
 
 Files modified
 """"""""""""""
-- `PR #433 <https://github.com/openforcefield/openforcefield/pull/433>`_: Updates
+- `PR #433 <https://github.com/openforcefield/openff-toolkit/pull/433>`_: Updates
   the previously-nonfunctional ``test_forcefields/tip3p.offxml`` to a functional state
   by updating it to the SMIRNOFF
   0.3 specification, and specifying atomic charges using the ``LibraryCharges`` tag.
@@ -1024,7 +1024,7 @@ Files modified
 ------------------------------------------------------
 
 This release contains a new notebook example,
-`check_parameter_coverage.ipynb <https://github.com/openforcefield/openforcefield/blob/master/examples/check_dataset_parameter_coverage/check_parameter_coverage.ipynb>`_,
+`check_parameter_coverage.ipynb <https://github.com/openforcefield/openff-toolkit/blob/master/examples/check_dataset_parameter_coverage/check_parameter_coverage.ipynb>`_,
 which loads sets of molecules, checks whether they are parameterizable,
 and generates reports of chemical motifs that are not.
 It also fixes several simple issues, improves warnings and docstring text,
@@ -1059,9 +1059,9 @@ Complete details about this release are below.
 
 Example added
 """""""""""""
-- `PR #419 <https://github.com/openforcefield/openforcefield/pull/419>`_: Adds
+- `PR #419 <https://github.com/openforcefield/openff-toolkit/pull/419>`_: Adds
   an example notebook
-  `check_parameter_coverage.ipynb <https://github.com/openforcefield/openforcefield/blob/master/examples/check_dataset_parameter_coverage/check_parameter_coverage.ipynb>`_
+  `check_parameter_coverage.ipynb <https://github.com/openforcefield/openff-toolkit/blob/master/examples/check_dataset_parameter_coverage/check_parameter_coverage.ipynb>`_
   which shows how to use the toolkit to check a molecule
   dataset for missing parameter coverage, and provides functionality to output
   tagged SMILES and 2D drawings of the unparameterizable chemistry.
@@ -1069,52 +1069,52 @@ Example added
 
 New features
 """"""""""""
-- `PR #419 <https://github.com/openforcefield/openforcefield/pull/419>`_: Unassigned
+- `PR #419 <https://github.com/openforcefield/openff-toolkit/pull/419>`_: Unassigned
   valence parameter exceptions now include a list of tuples of
-  :py:class:`TopologyAtom <openforcefield.topology.TopologyAtom>`
+  :py:class:`TopologyAtom <openff.toolkit.topology.TopologyAtom>`
   which were unable to be parameterized (``exception.unassigned_topology_atom_tuples``)
   and the class of the
-  :py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>`
+  :py:class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>`
   that raised the exception (``exception.handler_class``).
-- `PR #425 <https://github.com/openforcefield/openforcefield/pull/425>`_: Implements
+- `PR #425 <https://github.com/openforcefield/openff-toolkit/pull/425>`_: Implements
   Trevor Gokey's suggestion from
-  `Issue #411 <https://github.com/openforcefield/openforcefield/issues/411>`_, which
+  `Issue #411 <https://github.com/openforcefield/openff-toolkit/issues/411>`_, which
   enables pickling of
-  :py:class:`ForceFields <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
+  :py:class:`ForceFields <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
   and
-  :py:class:`ParameterHandlers <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>`.
+  :py:class:`ParameterHandlers <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>`.
   Note that, while XML representations of ``ForceField``s are stable and conform to the SMIRNOFF
   specification, the pickled ``ForceField``s that this functionality enables are not guaranteed
   to be compatible with future toolkit versions.
 
 Improved documentation and warnings
 """""""""""""""""""""""""""""""""""
-- `PR #425 <https://github.com/openforcefield/openforcefield/pull/425>`_: Addresses
-  `Issue #410 <https://github.com/openforcefield/openforcefield/issues/410>`_, by explicitly
+- `PR #425 <https://github.com/openforcefield/openff-toolkit/pull/425>`_: Addresses
+  `Issue #410 <https://github.com/openforcefield/openff-toolkit/issues/410>`_, by explicitly
   having toolkit warnings print ``Warning:`` at the beginning of each warning, and adding
   clearer language to the warning produced when the OpenEye Toolkits can not be loaded.
-- `PR #425 <https://github.com/openforcefield/openforcefield/pull/425>`_: Addresses
-  `Issue #421 <https://github.com/openforcefield/openforcefield/issues/421>`_ by
+- `PR #425 <https://github.com/openforcefield/openff-toolkit/pull/425>`_: Addresses
+  `Issue #421 <https://github.com/openforcefield/openff-toolkit/issues/421>`_ by
   adding type/shape information to all Molecule partial charge and conformer docstrings.
-- `PR #425 <https://github.com/openforcefield/openforcefield/pull/425>`_: Addresses
-  `Issue #407 <https://github.com/openforcefield/openforcefield/issues/421>`_ by
+- `PR #425 <https://github.com/openforcefield/openff-toolkit/pull/425>`_: Addresses
+  `Issue #407 <https://github.com/openforcefield/openff-toolkit/issues/421>`_ by
   providing a more extensive explanation of why we don't use RDKit's mol2 parser
   for molecule input.
 
 Bugfixes
 """"""""
-- `PR #419 <https://github.com/openforcefield/openforcefield/pull/419>`_: Fixes
-  `Issue #417 <https://github.com/openforcefield/openforcefield/issues/417>`_ and
-  `Issue #418 <https://github.com/openforcefield/openforcefield/issues/418>`_, where
-  :py:meth:`RDKitToolkitWrapper.from_file <openforcefield.utils.toolkits.RDKitToolkitWrapper.from_file>`
+- `PR #419 <https://github.com/openforcefield/openff-toolkit/pull/419>`_: Fixes
+  `Issue #417 <https://github.com/openforcefield/openff-toolkit/issues/417>`_ and
+  `Issue #418 <https://github.com/openforcefield/openff-toolkit/issues/418>`_, where
+  :py:meth:`RDKitToolkitWrapper.from_file <openff.toolkit.utils.toolkits.RDKitToolkitWrapper.from_file>`
   would disregard the ``allow_undefined_stereo`` kwarg and skip the first molecule
   when reading a SMILES file.
 
 
 Files removed
 """""""""""""
-- `PR #425 <https://github.com/openforcefield/openforcefield/pull/425>`_: Addresses
-  `Issue #424 <https://github.com/openforcefield/openforcefield/issues/424>`_ by
+- `PR #425 <https://github.com/openforcefield/openff-toolkit/pull/425>`_: Addresses
+  `Issue #424 <https://github.com/openforcefield/openff-toolkit/issues/424>`_ by
   deleting the unused files ``openforcefield/typing/engines/smirnoff/gbsaforces.py``
   and ``openforcefield/tests/test_smirnoff.py``. ``gbsaforces.py`` was only used internally
   and ``test_smirnoff.py`` tested unsupported functionality from before the 0.2.0 release.
@@ -1145,8 +1145,8 @@ which are now accessible as ``torsion.k1``, ``torsion.k2``, etc. (the previous a
 
 New features
 """"""""""""
-- `PR #363 <https://github.com/openforcefield/openforcefield/pull/363>`_: Implements
-  :py:class:`GBSAHandler <openforcefield.typing.engines.smirnoff.parameters.GBSAHandler>`,
+- `PR #363 <https://github.com/openforcefield/openff-toolkit/pull/363>`_: Implements
+  :py:class:`GBSAHandler <openff.toolkit.typing.engines.smirnoff.parameters.GBSAHandler>`,
   which supports the
   `GBSA tag in the SMIRNOFF specification <https://open-forcefield-toolkit.readthedocs.io/en/0.5.0/smirnoff.html#gbsa>`_.
   Currently, only GBSAHandlers with ``gb_model="OBC2"`` support
@@ -1164,36 +1164,36 @@ New features
       <https://github.com/ParmEd/ParmEd/blob/3.2.0/parmed/openmm/topsystem.py#L148-L150>`_.
       These GBSA forces are currently only computable using OpenMM.
 
-- `PR #363 <https://github.com/openforcefield/openforcefield/pull/363>`_: When using
-  :py:meth:`Topology.to_openmm() <openforcefield.topology.Topology.to_openmm>`, periodic
+- `PR #363 <https://github.com/openforcefield/openff-toolkit/pull/363>`_: When using
+  :py:meth:`Topology.to_openmm() <openff.toolkit.topology.Topology.to_openmm>`, periodic
   box vectors are now transferred from the Open Force Field Toolkit Topology
   into the newly-created OpenMM Topology.
-- `PR #377 <https://github.com/openforcefield/openforcefield/pull/377>`_: Single indexed parameters in
-  :py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>`
-  and :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>`
+- `PR #377 <https://github.com/openforcefield/openff-toolkit/pull/377>`_: Single indexed parameters in
+  :py:class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>`
+  and :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>`
   can now be get/set through normal attribute syntax in addition to the list syntax.
-- `PR #394 <https://github.com/openforcefield/openforcefield/pull/394>`_: Include element and atom name
+- `PR #394 <https://github.com/openforcefield/openff-toolkit/pull/394>`_: Include element and atom name
   in error output when there are missing valence parameters during molecule parameterization.
 
 Bugfixes
 """"""""
-- `PR #385 <https://github.com/openforcefield/openforcefield/pull/385>`_: Fixes
-  `Issue #346 <https://github.com/openforcefield/openforcefield/issues/346>`_ by
-  having :py:meth:`OpenEyeToolkitWrapper.compute_partial_charges_am1bcc <openforcefield.utils.toolkits.OpenEyeToolkitWrapper.compute_partial_charges_am1bcc>`
+- `PR #385 <https://github.com/openforcefield/openff-toolkit/pull/385>`_: Fixes
+  `Issue #346 <https://github.com/openforcefield/openff-toolkit/issues/346>`_ by
+  having :py:meth:`OpenEyeToolkitWrapper.compute_partial_charges_am1bcc <openff.toolkit.utils.toolkits.OpenEyeToolkitWrapper.compute_partial_charges_am1bcc>`
   fall back to using standard AM1-BCC if AM1-BCC ELF10 charge generation raises
   an error about "trans COOH conformers"
-- `PR #399 <https://github.com/openforcefield/openforcefield/pull/399>`_: Fixes
+- `PR #399 <https://github.com/openforcefield/openff-toolkit/pull/399>`_: Fixes
   issue where
-  :py:class:`ForceField <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
+  :py:class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
   constructor would ignore ``parameter_handler_classes`` kwarg.
-- `PR #400 <https://github.com/openforcefield/openforcefield/pull/400>`_: Makes
+- `PR #400 <https://github.com/openforcefield/openff-toolkit/pull/400>`_: Makes
   link-checking tests retry three times before failing.
 
 
 
 Files added
 """""""""""
-- `PR #363 <https://github.com/openforcefield/openforcefield/pull/363>`_: Adds
+- `PR #363 <https://github.com/openforcefield/openff-toolkit/pull/363>`_: Adds
   ``test_forcefields/GBSA_HCT-1.0.offxml``, ``test_forcefields/GBSA_OBC1-1.0.offxml``,
   and ``test_forcefields/GBSA_OBC2-1.0.offxml``, which are experimental implementations
   of GBSA models. These are primarily used in validation tests against OpenMM's models, and
@@ -1206,57 +1206,57 @@ This update fixes several toolkit bugs that have been reported by the community.
 Details of these bugfixes are provided below.
 
 It also refactors how
-:py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>`
+:py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>`
 and
-:py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>`
+:py:class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>`
 store their attributes, by introducing
-:py:class:`ParameterAttribute <openforcefield.typing.engines.smirnoff.parameters.ParameterAttribute>`
+:py:class:`ParameterAttribute <openff.toolkit.typing.engines.smirnoff.parameters.ParameterAttribute>`
 and
-:py:class:`IndexedParameterAttribute <openforcefield.typing.engines.smirnoff.parameters.IndexedParameterAttribute>`.
+:py:class:`IndexedParameterAttribute <openff.toolkit.typing.engines.smirnoff.parameters.IndexedParameterAttribute>`.
 These new attribute-handling classes provide a consistent backend which should simplify manipulation of parameters
 and implementation of new handlers.
 
 Bug fixes
 """""""""
-- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a
+- `PR #329 <https://github.com/openforcefield/openff-toolkit/pull/329>`_: Fixed a
   bug where the two
-  :py:class:`BondType <openforcefield.typing.engines.smirnoff.parameters.BondHandler.BondType>`
+  :py:class:`BondType <openff.toolkit.typing.engines.smirnoff.parameters.BondHandler.BondType>`
   parameter attributes ``k`` and ``length`` were treated as indexed attributes. (``k`` and
   ``length`` values that correspond to specific bond orders will be indexed under
   ``k_bondorder1``, ``k_bondorder2``, etc when implemented in the future)
-- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Fixed a
+- `PR #329 <https://github.com/openforcefield/openff-toolkit/pull/329>`_: Fixed a
   bug that allowed setting indexed attributes to single values instead of strictly lists.
-- `PR #370 <https://github.com/openforcefield/openforcefield/pull/370>`_: Fixed a
+- `PR #370 <https://github.com/openforcefield/openff-toolkit/pull/370>`_: Fixed a
   bug in the API where
-  :py:class:`BondHandler <openforcefield.typing.engines.smirnoff.parameters.BondHandler>`,
-  :py:class:`ProperTorsionHandler <openforcefield.typing.engines.smirnoff.parameters.ProperTorsionHandler>`
+  :py:class:`BondHandler <openff.toolkit.typing.engines.smirnoff.parameters.BondHandler>`,
+  :py:class:`ProperTorsionHandler <openff.toolkit.typing.engines.smirnoff.parameters.ProperTorsionHandler>`
   , and
-  :py:class:`ImproperTorsionHandler <openforcefield.typing.engines.smirnoff.parameters.ImproperTorsionHandler>`
+  :py:class:`ImproperTorsionHandler <openff.toolkit.typing.engines.smirnoff.parameters.ImproperTorsionHandler>`
   exposed non-functional indexed parameters.
-- `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
-  `Issue #344 <https://github.com/openforcefield/openforcefield/issues/344>`_,
-  in which the main :py:class:`FrozenMolecule <openforcefield.topology.FrozenMolecule>`
+- `PR #351 <https://github.com/openforcefield/openff-toolkit/pull/351>`_: Fixes
+  `Issue #344 <https://github.com/openforcefield/openff-toolkit/issues/344>`_,
+  in which the main :py:class:`FrozenMolecule <openff.toolkit.topology.FrozenMolecule>`
   constructor and several other Molecule-construction functions ignored or did not
   expose the ``allow_undefined_stereo`` keyword argument.
-- `PR #351 <https://github.com/openforcefield/openforcefield/pull/351>`_: Fixes
+- `PR #351 <https://github.com/openforcefield/openff-toolkit/pull/351>`_: Fixes
   a bug where a molecule which previously generated a SMILES using one cheminformatics toolkit
   returns the same SMILES, even though a different toolkit (which would generate
   a different SMILES for the molecule) is explicitly called.
-- `PR #354 <https://github.com/openforcefield/openforcefield/pull/354>`_: Fixes
+- `PR #354 <https://github.com/openforcefield/openff-toolkit/pull/354>`_: Fixes
   the error message that is printed if an unexpected parameter attribute is found while loading
-  data into a :py:class:`ForceField <openforcefield.typing.engines.smirnoff.forcefield.ForceField>`
+  data into a :py:class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`
   (now instructs users to specify ``allow_cosmetic_attributes`` instead of ``permit_cosmetic_attributes``)
-- `PR #364 <https://github.com/openforcefield/openforcefield/pull/364>`_: Fixes
-  `Issue #362 <https://github.com/openforcefield/openforcefield/issues/362>`_ by
+- `PR #364 <https://github.com/openforcefield/openff-toolkit/pull/364>`_: Fixes
+  `Issue #362 <https://github.com/openforcefield/openff-toolkit/issues/362>`_ by
   modifying
-  :py:meth:`OpenEyeToolkitWrapper.from_smiles <openforcefield.utils.toolkits.OpenEyeToolkitWrapper.from_smiles>`
+  :py:meth:`OpenEyeToolkitWrapper.from_smiles <openff.toolkit.utils.toolkits.OpenEyeToolkitWrapper.from_smiles>`
   and
-  :py:meth:`RDKitToolkitWrapper.from_smiles <openforcefield.utils.toolkits.RDKitToolkitWrapper.from_smiles>`
+  :py:meth:`RDKitToolkitWrapper.from_smiles <openff.toolkit.utils.toolkits.RDKitToolkitWrapper.from_smiles>`
   to make implicit hydrogens explicit before molecule creation. These functions also
   now raise an error if the optional keyword ``hydrogens_are_explicit=True`` but the
   SMILES are interpreted by the backend cheminformatic toolkit as having implicit
   hydrogens.
-- `PR #371 <https://github.com/openforcefield/openforcefield/pull/371>`_: Fixes
+- `PR #371 <https://github.com/openforcefield/openff-toolkit/pull/371>`_: Fixes
   error when reading early SMIRNOFF 0.1 spec files enclosed by a top-level ``SMIRFF`` tag.
 
 .. note ::
@@ -1266,15 +1266,15 @@ Bug fixes
 
 Code enhancements
 """""""""""""""""
-- `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_:
-  :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>`
+- `PR #329 <https://github.com/openforcefield/openff-toolkit/pull/329>`_:
+  :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>`
   was refactored to improve its extensibility. It is now possible to create new parameter
   types by using the new descriptors
-  :py:class:`ParameterAttribute <openforcefield.typing.engines.smirnoff.parameters.ParameterAttribute>`
+  :py:class:`ParameterAttribute <openff.toolkit.typing.engines.smirnoff.parameters.ParameterAttribute>`
   and
-  :py:class:`IndexedParameterAttribute <openforcefield.typing.engines.smirnoff.parameters.IndexedParameterAttribute>`.
-- `PR #357 <https://github.com/openforcefield/openforcefield/pull/357>`_: Addresses
-  `Issue #356 <https://github.com/openforcefield/openforcefield/issues/356>`_ by raising
+  :py:class:`IndexedParameterAttribute <openff.toolkit.typing.engines.smirnoff.parameters.IndexedParameterAttribute>`.
+- `PR #357 <https://github.com/openforcefield/openff-toolkit/pull/357>`_: Addresses
+  `Issue #356 <https://github.com/openforcefield/openff-toolkit/issues/356>`_ by raising
   an informative error message if a user attempts to load an OpenMM topology which
   is probably missing connectivity information.
 
@@ -1282,11 +1282,11 @@ Code enhancements
 
 Force fields added
 """"""""""""""""""
-- `PR #368 <https://github.com/openforcefield/openforcefield/pull/368>`_: Temporarily adds
+- `PR #368 <https://github.com/openforcefield/openff-toolkit/pull/368>`_: Temporarily adds
   ``test_forcefields/smirnoff99frosst_experimental.offxml`` to address hierarchy problems, redundancies, SMIRKS
-  pattern typos etc., as documented in `issue #367 <https://github.com/openforcefield/openforcefield/issues/367>`_.
+  pattern typos etc., as documented in `issue #367 <https://github.com/openforcefield/openff-toolkit/issues/367>`_.
   Will ultimately be propagated to an updated force field in the ``openforcefield/smirnoff99frosst`` repo.
-- `PR #371 <https://github.com/openforcefield/openforcefield/pull/371>`_: Adds
+- `PR #371 <https://github.com/openforcefield/openff-toolkit/pull/371>`_: Adds
   ``test_forcefields/smirff99Frosst_reference_0_1_spec.offxml``, a SMIRNOFF 0.1 spec file enclosed by the legacy
   ``SMIRFF`` tag. This file is used in backwards-compatibility testing.
 
@@ -1295,7 +1295,7 @@ Force fields added
 0.4.0 - Performance optimizations and support for SMIRNOFF 0.3 specification
 ----------------------------------------------------------------------------
 
-This update contains performance enhancements that significantly reduce the time to create OpenMM systems for topologies containing many molecules via :py:meth:`ForceField.create_openmm_system <openforcefield.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>`.
+This update contains performance enhancements that significantly reduce the time to create OpenMM systems for topologies containing many molecules via :py:meth:`ForceField.create_openmm_system <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>`.
 
 This update also introduces the `SMIRNOFF 0.3 specification <https://open-forcefield-toolkit.readthedocs.io/en/0.4.0/smirnoff.html>`_.
 The spec update is the result of discussions about how to handle the evolution of data and parameter types as further functional forms are added to the SMIRNOFF spec.
@@ -1328,24 +1328,24 @@ This functionality allows the toolkit to continue to read files containing SMIRN
 Performance improvements and bugfixes
 """""""""""""""""""""""""""""""""""""
 
-* `PR #329 <https://github.com/openforcefield/openforcefield/pull/329>`_: Performance improvements when creating systems for topologies with many atoms.
-* `PR #347 <https://github.com/openforcefield/openforcefield/pull/347>`_: Fixes bug in charge assignment that occurs when charges are read from file, and reference and charge molecules have different atom orderings.
+* `PR #329 <https://github.com/openforcefield/openff-toolkit/pull/329>`_: Performance improvements when creating systems for topologies with many atoms.
+* `PR #347 <https://github.com/openforcefield/openff-toolkit/pull/347>`_: Fixes bug in charge assignment that occurs when charges are read from file, and reference and charge molecules have different atom orderings.
 
 
 New features
 """"""""""""
 
-* `PR #311 <https://github.com/openforcefield/openforcefield/pull/311>`_: Several new experimental functions.
+* `PR #311 <https://github.com/openforcefield/openff-toolkit/pull/311>`_: Several new experimental functions.
 
-  * Adds :py:meth:`convert_0_2_smirnoff_to_0_3 <openforcefield.utils.utils.convert_0_2_smirnoff_to_0_3>`, which takes a SMIRNOFF 0.2-spec data dict, and updates it to 0.3.
+  * Adds :py:meth:`convert_0_2_smirnoff_to_0_3 <openff.toolkit.utils.utils.convert_0_2_smirnoff_to_0_3>`, which takes a SMIRNOFF 0.2-spec data dict, and updates it to 0.3.
     This function is called automatically when creating a ``ForceField`` from a SMIRNOFF 0.2 spec OFFXML file.
-  * Adds :py:meth:`convert_0_1_smirnoff_to_0_2 <openforcefield.utils.utils.convert_0_1_smirnoff_to_0_2>`, which takes a SMIRNOFF 0.1-spec data dict, and updates it to 0.2.
+  * Adds :py:meth:`convert_0_1_smirnoff_to_0_2 <openff.toolkit.utils.utils.convert_0_1_smirnoff_to_0_2>`, which takes a SMIRNOFF 0.1-spec data dict, and updates it to 0.2.
     This function is called automatically when creating a ``ForceField`` from a SMIRNOFF 0.1 spec OFFXML file.
   * NOTE: The format of the "SMIRNOFF data dict" above is likely to change significantly in the future.
-    Users that require a stable serialized ForceField object should use the output of :py:meth:`ForceField.to_string('XML') <openforcefield.typing.engines.smirnoff.forcefield.ForceField.to_string>` instead.
-  * Adds :py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>` and :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>` :py:meth:`add_cosmetic_attribute <openforcefield.typing.engines.smirnoff.parameters.ParameterType.add_cosmetic_attribute>` and :py:meth:`delete_cosmetic_attribute <openforcefield.typing.engines.smirnoff.parameters.ParameterType.delete_cosmetic_attribute>` functions.
+    Users that require a stable serialized ForceField object should use the output of :py:meth:`ForceField.to_string('XML') <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.to_string>` instead.
+  * Adds :py:class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>` and :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>` :py:meth:`add_cosmetic_attribute <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType.add_cosmetic_attribute>` and :py:meth:`delete_cosmetic_attribute <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType.delete_cosmetic_attribute>` functions.
     Once created, cosmetic attributes can be accessed and modified as attributes of the underlying object (eg. ``ParameterType.my_cosmetic_attrib = 'blue'``)
-    These functions are experimental, and we are interested in feedback on how cosmetic attribute handling could be improved. (`See Issue #338 <https://github.com/openforcefield/openforcefield/issues/338>`_)
+    These functions are experimental, and we are interested in feedback on how cosmetic attribute handling could be improved. (`See Issue #338 <https://github.com/openforcefield/openff-toolkit/issues/338>`_)
     Note that if a new cosmetic attribute is added to an object without using these functions, it will not be recognized by the toolkit and will not be written out during serialization.
   * Values for the top-level ``Author`` and ``Date`` tags are now kept during SMIRNOFF data I/O.
     If multiple data sources containing these fields are read, the values are concatenated using "AND" as a separator.
@@ -1353,15 +1353,15 @@ New features
 
 API-breaking changes
 """"""""""""""""""""
-* :py:meth:`ForceField.to_string <openforcefield.typing.engines.smirnoff.forcefield.ForceField.to_string>` and :py:meth:`ForceField.to_file <openforcefield.typing.engines.smirnoff.forcefield.ForceField.to_file>` have had the default value of their ``discard_cosmetic_attributes`` kwarg set to False.
-* :py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>` and :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>` constructors now expect the ``version`` kwarg (per the SMIRNOFF spec change above)
+* :py:meth:`ForceField.to_string <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.to_string>` and :py:meth:`ForceField.to_file <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.to_file>` have had the default value of their ``discard_cosmetic_attributes`` kwarg set to False.
+* :py:class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>` and :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>` constructors now expect the ``version`` kwarg (per the SMIRNOFF spec change above)
   This requirement can be skipped by providing the kwarg ``skip_version_check=True``
-* :py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>` and :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>` functions no longer handle ``X_unit`` attributes in SMIRNOFF data (per the SMIRNOFF spec change above).
+* :py:class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>` and :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>` functions no longer handle ``X_unit`` attributes in SMIRNOFF data (per the SMIRNOFF spec change above).
 * The scripts in ``utilities/convert_frosst`` are now deprecated.
   This functionality is important for provenance and will be migrated to the ``openforcefield/smirnoff99Frosst`` repository in the coming weeks.
-* :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>` ``._SMIRNOFF_ATTRIBS`` is now :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>` ``._REQUIRED_SPEC_ATTRIBS``, to better parallel the structure of the ``ParameterHandler`` class.
-* :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>` ``._OPTIONAL_ATTRIBS`` is now :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>` ``._OPTIONAL_SPEC_ATTRIBS``, to better parallel the structure of the ``ParameterHandler`` class.
-* Added class-level dictionaries :py:class:`ParameterHandler <openforcefield.typing.engines.smirnoff.parameters.ParameterHandler>` ``._DEFAULT_SPEC_ATTRIBS`` and :py:class:`ParameterType <openforcefield.typing.engines.smirnoff.parameters.ParameterType>` ``._DEFAULT_SPEC_ATTRIBS``.
+* :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>` ``._SMIRNOFF_ATTRIBS`` is now :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>` ``._REQUIRED_SPEC_ATTRIBS``, to better parallel the structure of the ``ParameterHandler`` class.
+* :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>` ``._OPTIONAL_ATTRIBS`` is now :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>` ``._OPTIONAL_SPEC_ATTRIBS``, to better parallel the structure of the ``ParameterHandler`` class.
+* Added class-level dictionaries :py:class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>` ``._DEFAULT_SPEC_ATTRIBS`` and :py:class:`ParameterType <openff.toolkit.typing.engines.smirnoff.parameters.ParameterType>` ``._DEFAULT_SPEC_ATTRIBS``.
 
 0.3.0 - API Improvements
 ------------------------
@@ -1371,24 +1371,24 @@ Several improvements and changes to public API.
 New features
 """"""""""""
 
-* `PR #292 <https://github.com/openforcefield/openforcefield/pull/292>`_: Implement ``Topology.to_openmm`` and remove ``ToolkitRegistry.toolkit_is_available``
-* `PR #322 <https://github.com/openforcefield/openforcefield/pull/322>`_: Install directories for the lookup of OFFXML files through the entry point group ``openforcefield.smirnoff_forcefield_directory``. The ``ForceField`` class doesn't search in the ``data/forcefield/`` folder anymore (now renamed ``data/test_forcefields/``), but only in ``data/``.
+* `PR #292 <https://github.com/openforcefield/openff-toolkit/pull/292>`_: Implement ``Topology.to_openmm`` and remove ``ToolkitRegistry.toolkit_is_available``
+* `PR #322 <https://github.com/openforcefield/openff-toolkit/pull/322>`_: Install directories for the lookup of OFFXML files through the entry point group ``openforcefield.smirnoff_forcefield_directory``. The ``ForceField`` class doesn't search in the ``data/forcefield/`` folder anymore (now renamed ``data/test_forcefields/``), but only in ``data/``.
 
 API-breaking Changes
 """"""""""""""""""""
-* `PR #278 <https://github.com/openforcefield/openforcefield/pull/278>`_: Standardize variable/method names
-* `PR #291 <https://github.com/openforcefield/openforcefield/pull/291>`_: Remove ``ForceField.load/to_smirnoff_data``, add ``ForceField.to_file/string`` and ``ParameterHandler.add_parameters``. Change behavior of ``ForceField.register_X_handler`` functions.
+* `PR #278 <https://github.com/openforcefield/openff-toolkit/pull/278>`_: Standardize variable/method names
+* `PR #291 <https://github.com/openforcefield/openff-toolkit/pull/291>`_: Remove ``ForceField.load/to_smirnoff_data``, add ``ForceField.to_file/string`` and ``ParameterHandler.add_parameters``. Change behavior of ``ForceField.register_X_handler`` functions.
 
 Bugfixes
 """"""""
-* `PR #327 <https://github.com/openforcefield/openforcefield/pull/327>`_: Fix units in tip3p.offxml (note that this file is still not loadable by current toolkit)
-* `PR #325 <https://github.com/openforcefield/openforcefield/pull/325>`_: Fix solvent box for provided test system to resolve periodic clashes.
-* `PR #325 <https://github.com/openforcefield/openforcefield/pull/325>`_: Add informative message containing Hill formula when a molecule can't be matched in ``Topology.from_openmm``.
-* `PR #325 <https://github.com/openforcefield/openforcefield/pull/325>`_: Provide warning or error message as appropriate when a molecule is missing stereochemistry.
-* `PR #316 <https://github.com/openforcefield/openforcefield/pull/316>`_: Fix formatting issues in GBSA section of SMIRNOFF spec
-* `PR #308 <https://github.com/openforcefield/openforcefield/pull/308>`_: Cache molecule SMILES to improve system creation speed
-* `PR #306 <https://github.com/openforcefield/openforcefield/pull/306>`_: Allow single-atom molecules with all zero coordinates to be converted to OE/RDK mols
-* `PR #313 <https://github.com/openforcefield/openforcefield/pull/313>`_: Fix issue where constraints are applied twice to constrained bonds
+* `PR #327 <https://github.com/openforcefield/openff-toolkit/pull/327>`_: Fix units in tip3p.offxml (note that this file is still not loadable by current toolkit)
+* `PR #325 <https://github.com/openforcefield/openff-toolkit/pull/325>`_: Fix solvent box for provided test system to resolve periodic clashes.
+* `PR #325 <https://github.com/openforcefield/openff-toolkit/pull/325>`_: Add informative message containing Hill formula when a molecule can't be matched in ``Topology.from_openmm``.
+* `PR #325 <https://github.com/openforcefield/openff-toolkit/pull/325>`_: Provide warning or error message as appropriate when a molecule is missing stereochemistry.
+* `PR #316 <https://github.com/openforcefield/openff-toolkit/pull/316>`_: Fix formatting issues in GBSA section of SMIRNOFF spec
+* `PR #308 <https://github.com/openforcefield/openff-toolkit/pull/308>`_: Cache molecule SMILES to improve system creation speed
+* `PR #306 <https://github.com/openforcefield/openff-toolkit/pull/306>`_: Allow single-atom molecules with all zero coordinates to be converted to OE/RDK mols
+* `PR #313 <https://github.com/openforcefield/openff-toolkit/pull/313>`_: Fix issue where constraints are applied twice to constrained bonds
 
 0.2.2 - Bugfix release
 ----------------------
@@ -1397,9 +1397,9 @@ This release modifies an example to show how to parameterize a solvated system, 
 
 Bugfixes
 """"""""
-* `PR #279 <https://github.com/openforcefield/openforcefield/pull/279>`_: Cleanup of unused code/warnings in main package ``__init__``
-* `PR #259 <https://github.com/openforcefield/openforcefield/pull/259>`_: Update T4 Lysozyme + toluene example to show how to set up solvated systems
-* `PR #256 <https://github.com/openforcefield/openforcefield/pull/256>`_ and `PR #274 <https://github.com/openforcefield/openforcefield/pull/274>`_: Add functionality to ensure that links in READMEs resolve successfully
+* `PR #279 <https://github.com/openforcefield/openff-toolkit/pull/279>`_: Cleanup of unused code/warnings in main package ``__init__``
+* `PR #259 <https://github.com/openforcefield/openff-toolkit/pull/259>`_: Update T4 Lysozyme + toluene example to show how to set up solvated systems
+* `PR #256 <https://github.com/openforcefield/openff-toolkit/pull/256>`_ and `PR #274 <https://github.com/openforcefield/openff-toolkit/pull/274>`_: Add functionality to ensure that links in READMEs resolve successfully
 
 
 0.2.1 - Bugfix release
@@ -1409,9 +1409,9 @@ This release features various documentation fixes, minor bugfixes, and code clea
 
 Bugfixes
 """"""""
-* `PR #267 <https://github.com/openforcefield/openforcefield/pull/267>`_: Add neglected ``<ToolkitAM1BCC>`` documentation to the SMIRNOFF 0.2 spec
-* `PR #258 <https://github.com/openforcefield/openforcefield/pull/258>`_: General cleanup and removal of unused/inaccessible code.
-* `PR #244 <https://github.com/openforcefield/openforcefield/pull/244>`_: Improvements and typo fixes for BRD4:inhibitor benchmark
+* `PR #267 <https://github.com/openforcefield/openff-toolkit/pull/267>`_: Add neglected ``<ToolkitAM1BCC>`` documentation to the SMIRNOFF 0.2 spec
+* `PR #258 <https://github.com/openforcefield/openff-toolkit/pull/258>`_: General cleanup and removal of unused/inaccessible code.
+* `PR #244 <https://github.com/openforcefield/openff-toolkit/pull/244>`_: Improvements and typo fixes for BRD4:inhibitor benchmark
 
 0.2.0 - Initial RDKit support
 -----------------------------
@@ -1423,10 +1423,10 @@ New features
 
 * Major overhaul, resulting in the creation of the `SMIRNOFF 0.2 specification <https://open-forcefield-toolkit.readthedocs.io/en/master/smirnoff.html>`_ and its XML representation
 * Updated API and infrastructure for reference SMIRNOFF :class:`ForceField` implementation
-* Implementation of modular :class:`ParameterHandler` classes which process the topology to add all necessary forces to the system.
-* Implementation of modular :class:`ParameterIOHandler` classes for reading/writing different serialized SMIRNOFF force field representations
-* Introduction of :class:`Molecule` and :class:`Topology` classes for representing molecules and biomolecular systems
-* New :class:`ToolkitWrapper` interface to RDKit, OpenEye, and AmberTools toolkits, managed by :class:`ToolkitRegistry`
+* Implementation of modular :class:`ParameterHandler <openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler>` classes which process the topology to add all necessary forces to the system.
+* Implementation of modular :class:`ParameterIOHandler <openff.toolkit.typing.engines.smirnoff.io.ParameterIOHandler>` classes for reading/writing different serialized SMIRNOFF force field representations
+* Introduction of :class:`Molecule <openff.toolkit.topology.Molecule>` and :class:`Topology <openff.toolkit.topology.Topology>` classes for representing molecules and biomolecular systems
+* New :class:`ToolkitWrapper <openff.toolkit.utils.toolkits.ToolkitWrapper>` interface to RDKit, OpenEye, and AmberTools toolkits, managed by :class:`ToolkitRegistry <openff.toolkit.utils.toolkits.ToolkitRegistry>`
 * API improvements to more closely follow `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ guidelines
 * Improved documentation and examples
 

--- a/docs/topology.rst
+++ b/docs/topology.rst
@@ -1,11 +1,16 @@
-.. _topology ::
+.. _topology :
 
 Molecular topology representations
 ==================================
 
-This module provides pure-Python classes for representing molecules and molecular systems.
-These classes offer several advantages over corresponding ``Topology`` objects in `OpenMM <http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.topology.Topology.html#simtk.openmm.app.topology.Topology>`_ and `MDTraj <http://mdtraj.org/latest/api/generated/mdtraj.Topology.html#mdtraj.Topology>`_,
-including offering serialization to a variety of standard formats (including `XML <https://www.w3.org/XML/>`_, `JSON <https://www.json.org/>`_, `YAML <http://yaml.org/>`_, `BSON <http://bsonspec.org/>`_, `TOML <https://github.com/toml-lang/toml>`_, and `MessagePack <https://msgpack.org/index.html>`_).
+This module provides pure-Python classes for representing molecules and molecular systems. These
+classes offer several advantages over corresponding ``Topology`` objects in `OpenMM
+<http://docs.openmm.org/latest/api-python/generated/simtk.openmm.app.topology.Topology.html#simtk.openmm.app.topology.Topology>`_
+and `MDTraj <https://mdtraj.org/1.9.4/api/generated/mdtraj.Topology.html>`_,
+including offering serialization to a variety of standard formats (including `XML
+<https://www.w3.org/XML/>`_, `JSON <https://www.json.org/>`_, `YAML <http://yaml.org/>`_, `BSON
+<http://bsonspec.org/>`_, `TOML <https://github.com/toml-lang/toml>`_, and `MessagePack
+<https://msgpack.org/index.html>`_).
 
 
 Primary objects

--- a/docs/typing.rst
+++ b/docs/typing.rst
@@ -1,4 +1,4 @@
-.. _typing ::
+.. _typing :
 
 Force field typing tools
 ========================

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -1,4 +1,4 @@
-.. _utils ::
+.. _utils :
 
 Utilities
 =========

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -90,6 +90,19 @@ Serialization support
 
     Serializable
 
+Collections
+---------------------
+
+Custom collections for the toolkit
+
+.. currentmodule:: openff.toolkit.utils.collections
+.. autosummary::
+    :nosignatures:
+    :toctree: api/generated/
+
+    ValidatedList
+    ValidatedDict
+
 Miscellaneous utilities
 -----------------------
 
@@ -107,3 +120,4 @@ Miscellaneous utility functions.
     convert_0_1_smirnoff_to_0_2
     convert_0_2_smirnoff_to_0_3
     get_molecule_parameterIDs
+    unit_to_string

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -104,8 +104,10 @@ class Particle(Serializable):
 
         .. todo::
 
-           * Should we have a single unique ``Molecule`` for each molecule type in the system,
-           or if we have multiple copies of the same molecule, should we have multiple ``Molecule``s?
+            * Should we have a single unique ``Molecule`` for each molecule
+              type in the system, or if we have multiple copies of the same
+              molecule, should we have multiple ``Molecule``\ s?
+
         """
         return self._molecule
 
@@ -357,6 +359,7 @@ class Atom(Particle):
         The standard atomic weight (abundance-weighted isotopic mass) of the atomic site.
 
         .. todo :: Should we discriminate between standard atomic weight and most abundant isotopic mass?
+
         TODO (from jeff): Are there atoms that have different chemical properties based on their isotopes?
 
         """
@@ -1681,7 +1684,8 @@ class FrozenMolecule(Serializable):
     """
     Immutable chemical representation of a molecule, such as a small molecule or biopolymer.
 
-    .. todo :: What other API calls would be useful for supporting biopolymers as small molecules? Perhaps iterating over chains and residues?
+    .. todo :: What other API calls would be useful for supporting biopolymers
+               as small molecules? Perhaps iterating over chains and residues?
 
     Examples
     --------
@@ -1733,28 +1737,34 @@ class FrozenMolecule(Serializable):
 
         .. todo ::
 
-           * If a filename or file-like object is specified but the file contains more than one molecule, what is the proper behavior?
-           Read just the first molecule, or raise an exception if more than one molecule is found?
+           * If a filename or file-like object is specified but the file
+             contains more than one molecule, what is the proper behavior?
+             Read just the first molecule, or raise an exception if more
+             than one molecule is found?
 
-           * Should we also support SMILES strings or IUPAC names for ``other``?
+           * Should we also support SMILES strings or IUPAC names for
+             ``other``\ ?
 
         Parameters
         ----------
         other : optional, default=None
-            If specified, attempt to construct a copy of the Molecule from the specified object.
-            This can be any one of the following:
+            If specified, attempt to construct a copy of the Molecule from
+            the specified object. This can be any one of the following:
 
             * a :class:`Molecule` object
             * a file that can be used to construct a :class:`Molecule` object
             * an ``openeye.oechem.OEMol``
             * an ``rdkit.Chem.rdchem.Mol``
             * a serialized :class:`Molecule` object
+
         file_format : str, optional, default=None
             If providing a file-like object, you must specify the format
             of the data. If providing a file, the file format will attempt
             to be guessed from the suffix.
-        toolkit_registry : a :class:`ToolkitRegistry` or :class:`ToolkitWrapper` object, optional, default=GLOBAL_TOOLKIT_REGISTRY
-            :class:`ToolkitRegistry` or :class:`ToolkitWrapper` to use for I/O operations
+        toolkit_registry : a :class:`ToolkitRegistry` or
+            :class:`ToolkitWrapper` object, optional,
+            default=GLOBAL_TOOLKIT_REGISTRY :class:`ToolkitRegistry`
+            or :class:`ToolkitWrapper` to use for I/O operations
         allow_undefined_stereo : bool, default=False
             If loaded from a file and ``False``, raises an exception if
             undefined stereochemistry is detected during the molecule's
@@ -2802,10 +2812,11 @@ class FrozenMolecule(Serializable):
         ] = GLOBAL_TOOLKIT_REGISTRY,
         **kwargs,
     ):
-        """Applies the `ELF method<https://docs.eyesopen.com/toolkits/python/quacpactk/
-        molchargetheory.html#elf-conformer-selection>`_ to select a set of diverse
-        conformers which have minimal electrostatically strongly interacting functional
-        groups from a molecules conformers.
+        """Applies the `ELF method
+        <https://docs.eyesopen.com/toolkits/python/quacpactk/molchargetheory.html#elf-conformer-selection>`_
+        to select a set of diverse conformers which have minimal
+        electrostatically strongly interacting functional groups from a
+        molecules conformers.
 
         Notes
         -----
@@ -2824,8 +2835,8 @@ class FrozenMolecule(Serializable):
         toolkit_registry
             The underlying toolkit to use to select the ELF conformers.
         percentage
-            The percentage of conformers with the lowest electrostatic interaction
-            energies to greedily select from.
+            The percentage of conformers with the lowest electrostatic
+            interaction energies to greedily select from.
         limit
             The maximum number of conformers to select.
         """
@@ -4614,8 +4625,8 @@ class FrozenMolecule(Serializable):
         qcelemental.models.Molecule :
             A validated qcschema
 
-        Example
-        -------
+        Examples
+        --------
 
         Create and validate a qcelemental input
 
@@ -5256,8 +5267,8 @@ class Molecule(FrozenMolecule):
         Parameters
         ----------
         other : optional, default=None
-            If specified, attempt to construct a copy of the Molecule from the specified object.
-            This can be any one of the following:
+            If specified, attempt to construct a copy of the Molecule from the
+            specified object. This can be any one of the following:
 
             * a :class:`Molecule` object
             * a file that can be used to construct a :class:`Molecule` object
@@ -5311,10 +5322,13 @@ class Molecule(FrozenMolecule):
 
         .. todo ::
 
-           * If a filename or file-like object is specified but the file contains more than one molecule, what is the
-           proper behavior? Read just the first molecule, or raise an exception if more than one molecule is found?
+           * If a filename or file-like object is specified but the file
+             contains more than one molecule, what is the proper behavior?
+             Read just the first molecule, or raise an exception if more
+             than one molecule is found?
 
-           * Should we also support SMILES strings or IUPAC names for ``other``?
+           * Should we also support SMILES strings or IUPAC names for
+             ``other``?
 
         """
         # super(self, Molecule).__init__(*args, **kwargs)
@@ -5374,17 +5388,28 @@ class Molecule(FrozenMolecule):
 
     def add_bond_charge_virtual_site(self, atoms, distance, **kwargs):
         """
-        Create a bond charge-type virtual site, in which the location of the charge is specified by the position of two atoms. This supports placement of a virtual site S along a vector between two specified atoms, e.g. to allow for a sigma hole for halogens or similar contexts. With positive values of the distance, the virtual site lies outside the first indexed atom.
+        Add a virtual site representing the charge on a bond.
+
+        Create a bond charge-type virtual site, in which the location of the
+        charge is specified by the position of two atoms. This supports
+        placement of a virtual site S along a vector between two specified
+        atoms, e.g. to allow for a sigma hole for halogens or similar contexts.
+        With positive values of the distance, the virtual site lies outside the
+        first indexed atom.
+
         Parameters
         ----------
-        atoms : list of openff.toolkit.topology.molecule.Atom objects or ints of shape [N
+        atoms : list of openff.toolkit.topology.molecule.Atom objects or ints of shape [N]
             The atoms defining the virtual site's position or their indices
         distance : float
 
         weights : list of floats of shape [N] or None, optional, default=None
-            weights[index] is the weight of particles[index] contributing to the position of the virtual site. Default is None
+            weights[index] is the weight of particles[index] contributing to
+            the position of the virtual site. Default is None
         charge_increments : list of floats of shape [N], optional, default=None
-            The amount of charge to remove from the VirtualSite's atoms and put in the VirtualSite. Indexing in this list should match the ordering in the atoms list. Default is None.
+            The amount of charge to remove from the VirtualSite's atoms and put
+            in the VirtualSite. Indexing in this list should match the ordering
+            in the atoms list. Default is None.
         epsilon : float
             Epsilon term for VdW properties of virtual site. Default is None.
         sigma : float, default=None

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1431,6 +1431,7 @@ class Topology(Serializable):
     @property
     def box_vectors(self):
         """Return the box vectors of the topology, if specified
+
         Returns
         -------
         box_vectors : simtk.unit.Quantity wrapped numpy array of shape (3, 3)
@@ -1895,6 +1896,7 @@ class Topology(Serializable):
         Retrieve all matches for a given chemical environment query.
 
         TODO:
+
         * Do we want to generalize this to other kinds of queries too, like mdtraj DSL, pymol selections, atom index slices, etc?
           We could just call it topology.matches(query)
 
@@ -2279,13 +2281,19 @@ class Topology(Serializable):
 
     def to_file(self, filename, positions, file_format="PDB", keepIds=False):
         """
-        To save a PDB file with coordinates as well as topology from OpenFF topology object
+        Save coordinates and topology to a PDB file.
+
         Reference: https://github.com/openforcefield/openff-toolkit/issues/502
-        Note: 1. This doesn't handle virtual sites (they're ignored)
-              2. Atom numbering may not remain same, for example if the atoms in water are numbered as 1001, 1002, 1003,
-                 they would change to 1, 2, 3.
-                 This doesn't affect the topology or coordinates or atom-ordering in anyway
-              3. Same issue with the amino acid names in the pdb file, they are not returned
+
+        Notes:
+
+        1. This doesn't handle virtual sites (they're ignored)
+        2. Atom numbering may not remain same, for example if the atoms
+           in water are numbered as 1001, 1002, 1003, they would change
+           to 1, 2, 3. This doesn't affect the topology or coordinates or
+           atom-ordering in any way.
+        3. Same issue with the amino acid names in the pdb file, they are
+           not returned.
 
         Parameters
         ----------

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -96,18 +96,18 @@ def _get_installed_offxml_dir_paths():
 
 def get_available_force_fields(full_paths=False):
     """
-     Get the filenames of all available .offxml force field files.
+    Get the filenames of all available .offxml force field files.
 
-     Availability is determined by what is discovered through the
-    `openforcefield.smirnoff_forcefield_directory` entry point. If the
-    `openff-forcefields` package is installed, this should include several
-    .offxml files such as `openff-1.0.0.offxml`.
+    Availability is determined by what is discovered through the
+    ``openforcefield.smirnoff_forcefield_directory`` entry point. If the
+    ``openff-forcefields`` package is installed, this should include several
+    .offxml files such as ``openff-1.0.0.offxml``\ .
 
      Parameters
      ----------
      full_paths : bool, default=False
-         If False, return the name of each available *.offxml file.
-         If True, return the full path to each available .offxml file.
+         If False, return the name of each available \*.offxml file.
+         If True, return the full path to each available \*.offxml file.
 
      Returns
      -------

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -300,10 +300,10 @@ class ParameterAttribute:
     attributes have the ``default`` set to the special type ``UNDEFINED``.
 
     Converters can be both static or instance functions/methods with
-    respective signatures
+    respective signatures::
 
-    converter(value): -> converted_value
-    converter(instance, parameter_attribute, value): -> converted_value
+        converter(value): -> converted_value
+        converter(instance, parameter_attribute, value): -> converted_value
 
     A decorator syntax is available (see example below).
 
@@ -392,6 +392,7 @@ class ParameterAttribute:
     2.0
 
     The custom converter associated to attr_int_to_float converts only integers instead.
+
     >>> my_par.attr_int_to_float = 3
     >>> my_par.attr_int_to_float
     3.0
@@ -407,10 +408,11 @@ class ParameterAttribute:
 
         pass
 
-    def __init__(self, default=UNDEFINED, unit=None, converter=None):
+    def __init__(self, default=UNDEFINED, unit=None, converter=None, docstring=""):
         self.default = default
         self._unit = unit
         self._converter = converter
+        self.__doc__ = docstring
 
     def __set_name__(self, owner, name):
         self._name = "_" + name
@@ -651,7 +653,7 @@ class IndexedMappedParameterAttribute(ParameterAttribute):
     For example, torsions with fractional bond orders have parameters such as
     k1_bondorder1, k1_bondorder2, k2_bondorder1, k2_bondorder2, ..., and
     ``IndexedMappedParameterAttribute`` can be used to encapsulate the sequence of
-    terms as mappings (typically, `dict`s) of their components.
+    terms as mappings (typically, ``dict``\ s) of their components.
 
     The only substantial difference with ``IndexedParameterAttribute`` is that
     only sequences of mappings are supported as values and converters and units are
@@ -1761,7 +1763,7 @@ class ParameterType(_ParameterAttributeHandler):
 
     Parameter attributes that can be indexed can be handled with the
     ``IndexedParameterAttribute``. These support unit validation and
-    converters exactly as ``ParameterAttribute``s, but the validation/conversion
+    converters exactly as ``ParameterAttribute``\ s, but the validation/conversion
     is performed for each indexed attribute.
 
     >>> class MyTorsionType(ParameterType):

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -224,12 +224,12 @@ class ToolkitWrapper:
         return self.__class__._toolkit_name
 
     @property
-    @classmethod
-    def toolkit_installation_instructions(cls):
+    # @classmethod
+    def toolkit_installation_instructions(self):
         """
         Instructions on how to install the wrapped toolkit.
         """
-        return cls._toolkit_installation_instructions
+        return self._toolkit_installation_instructions
 
     # @classmethod
     @property
@@ -1483,47 +1483,48 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
     @staticmethod
     def to_openeye(molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
         """
-         Create an OpenEye molecule using the specified aromaticity model
+        Create an OpenEye molecule using the specified aromaticity model
 
-         ``OEAtom`` s have a different set of allowed value for partial charges than
-         ``openff.toolkit.topology.Molecule`` s. In the OpenEye toolkits, partial charges
-         are stored on individual ``OEAtom`` s, and their values are initialized to ``0.0``.
-         In the Open Force Field Toolkit, an ``openff.toolkit.topology.Molecule``'s
-         ``partial_charges`` attribute is initialized to ``None`` and can be set to a
-         ``simtk.unit.Quantity``-wrapped numpy array with units of
-         elementary charge. The Open Force
-         Field Toolkit considers an ``OEMol`` where every ``OEAtom`` has a partial
-         charge of ``float('nan')`` to be equivalent to an Open Force Field Toolkit ``Molecule``'s
-         ``partial_charges = None``.
-         This assumption is made in both ``to_openeye`` and ``from_openeye``.
+        ``OEAtom`` s have a different set of allowed value for partial
+        charges than ``openff.toolkit.topology.Molecule``\ s. In the
+        OpenEye toolkits, partial charges are stored on individual
+        ``OEAtom``\ s, and their values are initialized to ``0.0``. In
+        the Open Force Field Toolkit, an``openff.toolkit.topology.Molecule``'s
+        ``partial_charges`` attribute is initialized to ``None`` and can
+        be set to a ``simtk.unit.Quantity``-wrapped numpy array with
+        units of elementary charge. The Open Force Field Toolkit
+        considers an ``OEMol`` where every ``OEAtom`` has a partial
+        charge of ``float('nan')`` to be equivalent to an Open Force
+        Field Toolkit ``Molecule``'s ``partial_charges = None``. This
+        assumption is made in both ``to_openeye`` and ``from_openeye``.
 
-         .. todo ::
+        .. todo ::
 
-            * Should the aromaticity model be specified in some other way?
+           * Should the aromaticity model be specified in some other way?
 
         .. warning :: This API is experimental and subject to change.
 
-         Parameters
-         ----------
-         molecule : openff.toolkit.topology.molecule.Molecule object
-             The molecule to convert to an OEMol
-         aromaticity_model : str, optional, default=DEFAULT_AROMATICITY_MODEL
-             The aromaticity model to use
+        Parameters
+        ----------
+        molecule : openff.toolkit.topology.molecule.Molecule object
+            The molecule to convert to an OEMol
+        aromaticity_model : str, optional, default=DEFAULT_AROMATICITY_MODEL
+            The aromaticity model to use
 
-         Returns
-         -------
-         oemol : openeye.oechem.OEMol
-             An OpenEye molecule
+        Returns
+        -------
+        oemol : openeye.oechem.OEMol
+            An OpenEye molecule
 
-         Examples
-         --------
+        Examples
+        --------
 
-         Create an OpenEye molecule from a Molecule
+        Create an OpenEye molecule from a Molecule
 
-         >>> from openff.toolkit.topology import Molecule
-         >>> toolkit_wrapper = OpenEyeToolkitWrapper()
-         >>> molecule = Molecule.from_smiles('CC')
-         >>> oemol = toolkit_wrapper.to_openeye(molecule)
+        >>> from openff.toolkit.topology import Molecule
+        >>> toolkit_wrapper = OpenEyeToolkitWrapper()
+        >>> molecule = Molecule.from_smiles('CC')
+        >>> oemol = toolkit_wrapper.to_openeye(molecule)
 
         """
         from openeye import oechem
@@ -2067,12 +2068,12 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         .. todo ::
 
-           * which parameters should we expose? (or can we implement a general system with **kwargs?)
-           * will the coordinates be returned in the OpenFF Molecule's own indexing system? Or is there a chance that
-           they'll get reindexed when we convert the input into an OEmol?
+            * which parameters should we expose? (or can we implement a general system with \*\*kwargs?)
+            * will the coordinates be returned in the OpenFF Molecule's own indexing system? Or is there a chance that
+              they'll get reindexed when we convert the input into an OEmol?
 
         Parameters
-        ---------
+        ----------
         molecule : a :class:`Molecule`
             The molecule to generate conformers for.
         n_conformers : int, default=1
@@ -2121,8 +2122,9 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         percentage: float = 2.0,
         limit: int = 10,
     ):
-        """Applies the `ELF method<https://docs.eyesopen.com/toolkits/python/quacpactk/
-        molchargetheory.html#elf-conformer-selection>`_ to select a set of diverse
+        """Applies the `ELF method
+        <https://docs.eyesopen.com/toolkits/python/quacpactk/molchargetheory.html#elf-conformer-selection>`_
+        to select a set of diverse
         conformers which have minimal electrostatically strongly interacting functional
         groups from a molecules conformers.
 
@@ -3411,11 +3413,11 @@ class RDKitToolkitWrapper(ToolkitWrapper):
 
         .. todo ::
 
-           * which parameters should we expose? (or can we implement a general system with **kwargs?)
+           * which parameters should we expose? (or can we implement a general system with \*\*kwargs?)
            * will the coordinates be returned in the OpenFF Molecule's own indexing system? Or is there a chance that they'll get reindexed when we convert the input into an RDMol?
 
         Parameters
-        ---------
+        ----------
         molecule : a :class:`Molecule`
             The molecule to generate conformers for.
         n_conformers : int, default=1
@@ -3815,10 +3817,10 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         limit: int = 10,
         rms_tolerance: unit.Quantity = 0.05 * unit.angstrom,
     ):
-        """Applies the `ELF method<https://docs.eyesopen.com/toolkits/python/quacpactk/
-        molchargetheory.html#elf-conformer-selection>`_ to select a set of diverse
-        conformers which have minimal electrostatically strongly interacting functional
-        groups from a molecules conformers.
+        """Applies the `ELF method
+        <https://docs.eyesopen.com/toolkits/python/quacpactk/molchargetheory.html#elf-conformer-selection>`_
+        to select a set of diverse conformers which have minimal electrostatically
+        strongly interacting functional groups from a molecules conformers.
 
         The diverse conformer selection is performed by the ``_elf_select_diverse_conformers``
         function, which attempts to greedily select conformers which are most distinct

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -152,15 +152,20 @@ def all_subclasses(cls):
 @contextlib.contextmanager
 def temporary_cd(dir_path):
     """Context to temporary change the working directory.
+
     Parameters
     ----------
+
     dir_path : str
         The directory path to enter within the context
+
     Examples
     --------
+
     >>> dir_path = '/tmp'
     >>> with temporary_cd(dir_path):
     ...     pass  # do something in dir_path
+
     """
     import os
 
@@ -177,10 +182,13 @@ def get_data_file_path(relative_path):
     In the source distribution, these files are in ``openff/toolkit/data/``,
     but on installation, they're moved to somewhere in the user's python
     site-packages directory.
+
     Parameters
     ----------
+
     name : str
         Name of the file to load (with respect to the repex folder).
+
     """
 
     import os


### PR DESCRIPTION
Previously, building the documentation raised about 400 warnings. This pull request brings that number down to 12.

Many of these warnings (>100) were simple errors in ReStructuredText syntax where the developers' intent was clear.I haven't individually documented these but they frequently caused the rendered documentation to appear incorrect, suggesting that developers are not checking the rendered documentation for the docstrings they write. I suggest we document how to do this clearly in the development guide, add building the documentation to CI, and consider moving away from ReST and towards a simpler format like Markdown.

A major source of warnings (~255 warnings) was that the `ParameterAttribute` class' docstring was reused every time the descriptor was used. This caused warnings owing to the documentation being out of context, and also caused the implementation details of the `ParameterAttribute` class to appear all over the code. This PR adds a `docstring` optional argument to `ParameterAttribute.__init__()` so that by default, a `ParameterAttribute`'s docstring will be empty, but also allowing it to be set by the implementor. This resolves #397.

This PR also removes the `@classmethod` decorator from `utils.toolkits.ToolkitWrapper.toolkit_installation_instructions()`. Previously this method was decorated by both `@property` and `@classmethod`, causing it not to actually work in ordinary Python code as well as documentation warnings. With this PR it is a property that points to the class attribute `ToolkitWrapper._toolkit_installation_instructions`. An alternative fix would be to remove the method and simply rename the attribute to `toolkit_installation_instructions`.

The remaining warnings stem from 2 sources:
1. autodoc tries to import classes like `vdWHandler.vdWType` as though `vdWHandler` was a module when it's actually a class. This accounts for seven warnings. The actual source of this warning is that sphinx-autosummary assumes  `vdWHandler` is a module when it generates the stub files; this can be seen by adding `autosummary_generate_overwrite = False` to `docs/conf.py` and editing one of the auto-generated stub files:
```diff
--- a/api/generated/openff.toolkit.typing.engines.smirnoff.parameters.GBSAHandler.GBSAType.rst
+++ b/api/generated/openff.toolkit.typing.engines.smirnoff.parameters.GBSAHandler.GBSAType.rst
@@ -3,10 +3,10 @@
 
 .. currentmodule:: openff.toolkit.typing.engines.smirnoff.parameters
 
-.. autoclass:: GBSAHandler.GBSAType
+.. autoclass:: openff.toolkit.typing.engines.smirnoff.parameters::GBSAHandler.GBSAType
 
    
-   .. automethod:: __init__
+   .. automethod:: openff.toolkit.typing.engines.smirnoff.parameters::GBSAHandler.GBSAType.__init__
 
    
    .. rubric:: Methods

```
With this change, the corresponding warning goes away. I have filed an [issue](https://github.com/sphinx-doc/sphinx/issues/8919) upstream.

2. The SMIRNOFF spec is in Markdown and converted to RST via M2R2. This raises five spurious warnings that can probably only be fixed upstream in M2R2.

### Checklist
- [x] Tag issue being addressed
- [ ] ~~Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)~~
- [ ] ~~Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable~~
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
