### PR TITLE
Don't use existing conformers for WBO calculation during system creation

### DIFF
--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -37,6 +37,10 @@ Behavior changed
 
 Bugfixes
 """"""""
+- `PR #849 <https://github.com/openforcefield/openforcefield/pull/849>`_: Changes
+  :py:meth:`create_openmm_system <openff.toolkit.typing.engines.smirnoff.ForceField.create_openmm_system>` so
+  that it no longer uses the conformers on existing reference molecules (if present) to calculate Wiberg
+  bond orders. Instead, new conformers are always generated during parameterization.
 - `PR #838 <https://github.com/openforcefield/openforcefield/pull/838>`_: Corrects spacing of "forcefield" to "force
   field" throughout documentation. Fixes `Issue #112 <https://github.com/openforcefield/openforcefield/issues/112>`_.
 

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -4379,7 +4379,10 @@ class TestForceFieldParameterAssignment:
         for idx in range(default_torsion_force.getNumTorsions()):
             default_k = default_torsion_force.getTorsionParameters(idx)[-1]
             mod_k = mod_torsion_force.getTorsionParameters(idx)[-1]
-            assert default_k == mod_k
+            assert np.isclose(
+                default_k.value_in_unit(default_k.unit),
+                mod_k.value_in_unit(default_k.unit),
+            )
 
         # Check that the returned topology has the correct bond order
         for bond1, bond2 in zip(

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -4328,9 +4328,15 @@ class TestForceFieldParameterAssignment:
 
         mod_mol = create_ethanol()
         mod_mol.generate_conformers()
-        mod_mol._conformers[0][0][0] = mod_mol._conformers[0][0][0] + 1. * unit.angstrom
-        mod_mol._conformers[0][1][0] = mod_mol._conformers[0][1][0] - 1. * unit.angstrom
-        mod_mol._conformers[0][2][0] = mod_mol._conformers[0][2][0] + 1. * unit.angstrom
+        mod_mol._conformers[0][0][0] = (
+            mod_mol._conformers[0][0][0] + 1.0 * unit.angstrom
+        )
+        mod_mol._conformers[0][1][0] = (
+            mod_mol._conformers[0][1][0] - 1.0 * unit.angstrom
+        )
+        mod_mol._conformers[0][2][0] = (
+            mod_mol._conformers[0][2][0] + 1.0 * unit.angstrom
+        )
 
         mod_top = Topology.from_molecules(mod_mol)
 
@@ -4380,11 +4386,6 @@ class TestForceFieldParameterAssignment:
             omm_sys_top.topology_bonds, mod_omm_sys_top.topology_bonds
         ):
             assert bond1.bond.fractional_bond_order == bond2.bond.fractional_bond_order
-
-
-
-
-
 
     @pytest.mark.parametrize(
         (

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -4360,9 +4360,16 @@ class TestForceFieldParameterAssignment:
         ][0]
 
         for idx in range(default_bond_force.getNumBonds()):
-            assert default_bond_force.getBondParameters(
-                idx
-            ) == mod_bond_force.getBondParameters(idx)
+            assert all(
+                np.isclose(
+                    default_value.value_in_unit(default_value.unit),
+                    mod_value.value_in_unit(default_value.unit),
+                )
+                for default_value, mod_value in zip(
+                    default_bond_force.getBondParameters(idx)[2:],
+                    mod_bond_force.getBondParameters(idx)[2:],
+                )
+            )
 
         # Check that the assigned torsion parameters are identical for both systems
         default_torsion_force = [

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -4395,7 +4395,9 @@ class TestForceFieldParameterAssignment:
         for bond1, bond2 in zip(
             omm_sys_top.topology_bonds, mod_omm_sys_top.topology_bonds
         ):
-            assert bond1.bond.fractional_bond_order == bond2.bond.fractional_bond_order
+            assert np.isclose(
+                bond1.bond.fractional_bond_order, bond2.bond.fractional_bond_order
+            )
 
     @pytest.mark.parametrize(
         (

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -1542,8 +1542,8 @@ class TestOpenEyeToolkitWrapper:
         )
 
         for bond1, bond2 in zip(molecule.bonds, molecule_diff_coords.bonds):
-            assert abs(bond1.fractional_bond_order - bond2.fractional_bond_order) > 1e-3        
-        
+            assert abs(bond1.fractional_bond_order - bond2.fractional_bond_order) > 1e-3
+
     @pytest.mark.parametrize(
         "bond_order_model",
         ["am1-wiberg", "am1-wiberg-elf10", "pm3-wiberg", "pm3-wiberg-elf10"],
@@ -3155,7 +3155,6 @@ class TestAmberToolsToolkitWrapper:
 
         for bond1, bond2 in zip(molecule.bonds, molecule_diff_coords.bonds):
             assert abs(bond1.fractional_bond_order - bond2.fractional_bond_order) > 1e-3
-
 
     @pytest.mark.parametrize("bond_order_model", ["am1-wiberg"])
     def test_assign_fractional_bond_orders_neutral_charge_mol(self, bond_order_model):

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -1439,6 +1439,36 @@ class TestOpenEyeToolkitWrapper:
             )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
 
+
+    def test_assign_fractional_bond_orders_conformer_dependence(self):
+        """
+        Test that OpenEyeToolkitWrapper assign_fractional_bond_orders() provides different results when using
+        different conformers
+        """
+
+        toolkit_wrapper = OpenEyeToolkitWrapper()
+        # Get the WBOs using one conformer
+        molecule = create_ethanol()
+        molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
+        molecule.assign_fractional_bond_orders(
+            toolkit_registry=toolkit_wrapper,
+            use_conformers=molecule.conformers,
+            bond_order_model='am1-wiberg')
+
+        # Do the same again, but change the conformer to yield a different result
+        molecule_diff_coords = create_ethanol()
+        molecule_diff_coords.generate_conformers(toolkit_registry=toolkit_wrapper)
+        molecule_diff_coords._conformers[0][0][0] = molecule_diff_coords._conformers[0][0][0] + 1. * unit.angstrom
+        molecule_diff_coords._conformers[0][1][0] = molecule_diff_coords._conformers[0][1][0] - 1. * unit.angstrom
+        molecule_diff_coords._conformers[0][2][0] = molecule_diff_coords._conformers[0][2][0] + 1. * unit.angstrom
+        molecule_diff_coords.assign_fractional_bond_orders(
+            toolkit_registry=toolkit_wrapper,
+            use_conformers=molecule_diff_coords.conformers,
+            bond_order_model='am1-wiberg')
+
+        for bond1, bond2 in zip(molecule.bonds, molecule_diff_coords.bonds):
+            assert abs(bond1.fractional_bond_order - bond2.fractional_bond_order) > 1e-3
+
     def test_assign_fractional_bond_orders_neutral_charge_mol(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders() for neutral and charged molecule"""
 
@@ -3016,6 +3046,36 @@ class TestAmberToolsToolkitWrapper:
                 toolkit_registry=toolkit_registry, bond_order_model=bond_order_model
             )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
+
+
+    def test_assign_fractional_bond_orders_conformer_dependence(self):
+        """
+        Test that RDKitToolkitWrapper assign_fractional_bond_orders() provides different results when using
+        different conformers
+        """
+
+        toolkit_wrapper = ToolkitRegistry([RDKitToolkitWrapper, AmberToolsToolkitWrapper])
+        # Get the WBOs using one conformer
+        molecule = create_ethanol()
+        molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
+        molecule.assign_fractional_bond_orders(
+            toolkit_registry=toolkit_wrapper,
+            use_conformers=molecule.conformers,
+            bond_order_model='am1-wiberg')
+
+        # Do the same again, but change the conformer to yield a different result
+        molecule_diff_coords = create_ethanol()
+        molecule_diff_coords.generate_conformers(toolkit_registry=toolkit_wrapper)
+        molecule_diff_coords._conformers[0][0][0] = molecule_diff_coords._conformers[0][0][0] + 1. * unit.angstrom
+        molecule_diff_coords._conformers[0][1][0] = molecule_diff_coords._conformers[0][1][0] - 1. * unit.angstrom
+        molecule_diff_coords._conformers[0][2][0] = molecule_diff_coords._conformers[0][2][0] + 1. * unit.angstrom
+        molecule_diff_coords.assign_fractional_bond_orders(
+            toolkit_registry=toolkit_wrapper,
+            use_conformers=molecule_diff_coords.conformers,
+            bond_order_model='am1-wiberg')
+
+        for bond1, bond2 in zip(molecule.bonds, molecule_diff_coords.bonds):
+            assert abs(bond1.fractional_bond_order - bond2.fractional_bond_order) > 1e-3
 
     def test_assign_fractional_bond_orders_neutral_charge_mol(self):
         """Test OpenEyeToolkitWrapper assign_fractional_bond_orders() for neutral and charged molecule.

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -1439,7 +1439,6 @@ class TestOpenEyeToolkitWrapper:
             )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
 
-
     def test_assign_fractional_bond_orders_conformer_dependence(self):
         """
         Test that OpenEyeToolkitWrapper assign_fractional_bond_orders() provides different results when using
@@ -1453,18 +1452,26 @@ class TestOpenEyeToolkitWrapper:
         molecule.assign_fractional_bond_orders(
             toolkit_registry=toolkit_wrapper,
             use_conformers=molecule.conformers,
-            bond_order_model='am1-wiberg')
+            bond_order_model="am1-wiberg",
+        )
 
         # Do the same again, but change the conformer to yield a different result
         molecule_diff_coords = create_ethanol()
         molecule_diff_coords.generate_conformers(toolkit_registry=toolkit_wrapper)
-        molecule_diff_coords._conformers[0][0][0] = molecule_diff_coords._conformers[0][0][0] + 1. * unit.angstrom
-        molecule_diff_coords._conformers[0][1][0] = molecule_diff_coords._conformers[0][1][0] - 1. * unit.angstrom
-        molecule_diff_coords._conformers[0][2][0] = molecule_diff_coords._conformers[0][2][0] + 1. * unit.angstrom
+        molecule_diff_coords._conformers[0][0][0] = (
+            molecule_diff_coords._conformers[0][0][0] + 1.0 * unit.angstrom
+        )
+        molecule_diff_coords._conformers[0][1][0] = (
+            molecule_diff_coords._conformers[0][1][0] - 1.0 * unit.angstrom
+        )
+        molecule_diff_coords._conformers[0][2][0] = (
+            molecule_diff_coords._conformers[0][2][0] + 1.0 * unit.angstrom
+        )
         molecule_diff_coords.assign_fractional_bond_orders(
             toolkit_registry=toolkit_wrapper,
             use_conformers=molecule_diff_coords.conformers,
-            bond_order_model='am1-wiberg')
+            bond_order_model="am1-wiberg",
+        )
 
         for bond1, bond2 in zip(molecule.bonds, molecule_diff_coords.bonds):
             assert abs(bond1.fractional_bond_order - bond2.fractional_bond_order) > 1e-3
@@ -3047,32 +3054,41 @@ class TestAmberToolsToolkitWrapper:
             )
             # TODO: Add test for equivalent Wiberg orders for equivalent bonds
 
-
     def test_assign_fractional_bond_orders_conformer_dependence(self):
         """
         Test that RDKitToolkitWrapper assign_fractional_bond_orders() provides different results when using
         different conformers
         """
 
-        toolkit_wrapper = ToolkitRegistry([RDKitToolkitWrapper, AmberToolsToolkitWrapper])
+        toolkit_wrapper = ToolkitRegistry(
+            [RDKitToolkitWrapper, AmberToolsToolkitWrapper]
+        )
         # Get the WBOs using one conformer
         molecule = create_ethanol()
         molecule.generate_conformers(toolkit_registry=toolkit_wrapper)
         molecule.assign_fractional_bond_orders(
             toolkit_registry=toolkit_wrapper,
             use_conformers=molecule.conformers,
-            bond_order_model='am1-wiberg')
+            bond_order_model="am1-wiberg",
+        )
 
         # Do the same again, but change the conformer to yield a different result
         molecule_diff_coords = create_ethanol()
         molecule_diff_coords.generate_conformers(toolkit_registry=toolkit_wrapper)
-        molecule_diff_coords._conformers[0][0][0] = molecule_diff_coords._conformers[0][0][0] + 1. * unit.angstrom
-        molecule_diff_coords._conformers[0][1][0] = molecule_diff_coords._conformers[0][1][0] - 1. * unit.angstrom
-        molecule_diff_coords._conformers[0][2][0] = molecule_diff_coords._conformers[0][2][0] + 1. * unit.angstrom
+        molecule_diff_coords._conformers[0][0][0] = (
+            molecule_diff_coords._conformers[0][0][0] + 1.0 * unit.angstrom
+        )
+        molecule_diff_coords._conformers[0][1][0] = (
+            molecule_diff_coords._conformers[0][1][0] - 1.0 * unit.angstrom
+        )
+        molecule_diff_coords._conformers[0][2][0] = (
+            molecule_diff_coords._conformers[0][2][0] + 1.0 * unit.angstrom
+        )
         molecule_diff_coords.assign_fractional_bond_orders(
             toolkit_registry=toolkit_wrapper,
             use_conformers=molecule_diff_coords.conformers,
-            bond_order_model='am1-wiberg')
+            bond_order_model="am1-wiberg",
+        )
 
         for bond1, bond2 in zip(molecule.bonds, molecule_diff_coords.bonds):
             assert abs(bond1.fractional_bond_order - bond2.fractional_bond_order) > 1e-3

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -2827,7 +2827,6 @@ class BondHandler(ParameterHandler):
                 )
                 match.reference_molecule.assign_fractional_bond_orders(
                     toolkit_registry=toolkit_registry,
-                    use_conformers=match.reference_molecule.conformers,
                     bond_order_model=self.fractional_bondorder_method.lower(),
                 )
 
@@ -3234,7 +3233,6 @@ class ProperTorsionHandler(ParameterHandler):
                 )
                 match.reference_molecule.assign_fractional_bond_orders(
                     toolkit_registry=toolkit_registry,
-                    use_conformers=match.reference_molecule.conformers,
                     bond_order_model=self.fractional_bondorder_method.lower(),
                 )
 


### PR DESCRIPTION
- [x] Make `create_openmm_system` disregard existing conformers on reference molecules during system creation
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)