### PR TITLE
Refactor ring methods in Molecule class

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -3098,9 +3098,8 @@ class TestMolecule:
     @requires_rdkit
     def test_molecule_rings(self, smiles, n_rings):
         """Test the Molecule.rings property"""
-        assert (
-            n_rings == Molecule.from_smiles(smiles, allow_undefined_stereo=True).n_rings
-        )
+        mol = Molecule.from_smiles(smiles, allow_undefined_stereo=True)
+        assert n_rings == mol.get_n_rings()
 
     @pytest.mark.parametrize(
         ("smiles", "n_atom_rings", "n_bond_rings"),
@@ -3115,8 +3114,8 @@ class TestMolecule:
         """Test Atom.is_in_ring and Bond.is_in_ring"""
         mol = Molecule.from_smiles(smiles)
 
-        assert len([atom for atom in mol.atoms if atom.is_in_ring]) == n_atom_rings
-        assert len([bond for bond in mol.bonds if bond.is_in_ring]) == n_bond_rings
+        assert len([atom for atom in mol.atoms if atom.is_in_ring()]) == n_atom_rings
+        assert len([bond for bond in mol.bonds if bond.is_in_ring()]) == n_bond_rings
 
     @requires_pkg("ipython")
     @requires_rdkit

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -436,10 +436,11 @@ class Atom(Particle):
                     return True
         return False
 
-    @property
-    def is_in_ring(self):
+    def is_in_ring(self, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY) -> bool:
         """
         Return whether or not this atom is in a ring(s) (of any size)
+
+        Currently only implemented via The RDKit, which must be installed.
 
         """
         if self._molecule is None:
@@ -447,7 +448,13 @@ class Atom(Particle):
                 "This Atom does not belong to a Molecule object"
             )
 
-        return any([self.molecule_atom_index in ring for ring in self._molecule.rings])
+        _is_in_ring = toolkit_registry.call(
+            "atom_is_in_ring",
+            self._molecule,
+            self.molecule_atom_index,
+        )
+
+        return _is_in_ring
 
     @property
     def virtual_sites(self):
@@ -1646,8 +1653,7 @@ class Bond(Serializable):
             raise ValueError("This Atom does not belong to a Molecule object")
         return self._molecule.bonds.index(self)
 
-    @property
-    def is_in_ring(self):
+    def is_in_ring(self, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY) -> bool:
         """
         Return whether or not this bond is in a ring(s) (of any size)
 
@@ -1657,10 +1663,10 @@ class Bond(Serializable):
                 "This Bond does not belong to a Molecule object"
             )
 
-        for ring in self._molecule.rings:
-            if self.atom1.molecule_atom_index in ring:
-                if self.atom2.molecule_atom_index in ring:
-                    return True
+        if self.atom1.is_in_ring(toolkit_registry=toolkit_registry):
+            if self.atom2.is_in_ring(toolkit_registry=toolkit_registry):
+                return True
+
         return False
 
     def __repr__(self):
@@ -3031,7 +3037,6 @@ class FrozenMolecule(Serializable):
 
         self._cached_smiles = None
         # TODO: Clear fractional bond orders
-        self._rings = None
 
     def to_networkx(self):
         """Generate a NetworkX undirected graph from the Molecule.
@@ -3590,11 +3595,11 @@ class FrozenMolecule(Serializable):
         self._construct_torsions()
         return len(self._impropers)
 
-    @property
-    def n_rings(self):
-        """Return the number of rings found in the Molecule
+    def get_n_rings(self, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+        """Return the number of rings found in the Molecule as determined by
+        a cheminformatics toolkit
 
-        Requires the RDKit to be installed.
+        Currently only implemented via The RDKit, which must be installed.
 
         .. note ::
 
@@ -3604,7 +3609,24 @@ class FrozenMolecule(Serializable):
             (5+) rings or bicyclic moieties (i.e. norbornane).
 
         """
-        return len(self.rings)
+        if isinstance(toolkit_registry, ToolkitRegistry):
+            rings = toolkit_registry.call(
+                "find_rings",
+                molecule=self,
+            )
+        elif isinstance(toolkit_registry, ToolkitWrapper):
+            toolkit = toolkit_registry
+            rings = toolkit.find_rings(
+                molecule=self,
+            )
+        else:
+            raise InvalidToolkitRegistryError(
+                "Invalid toolkit_registry passed to from_smiles. Expected ToolkitRegistry or ToolkitWrapper. "
+                f"Got  {type(toolkit_registry)}"
+            )
+
+        n_rings = len(rings)
+        return n_rings
 
     @property
     def particles(self):
@@ -5231,29 +5253,11 @@ class FrozenMolecule(Serializable):
 
         raise NotBondedError("No bond between atom {} and {}".format(i, j))
 
-    @property
-    def rings(self):
-        """Return the number of rings in this molecule.
-
-        Requires the RDKit to be installed.
-
-        .. note ::
-
-            For systems containing some special cases of connected rings, this
-            function may not be well-behaved and may report a different number
-            rings than expected. Some problematic cases include networks of many
-            (5+) rings or bicyclic moieties (i.e. norbornane).
-
-        """
-        if self._rings is None:
-            self._get_rings()
-        return self._rings
-
-    def _get_rings(self, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
+    def get_rings(self, toolkit_registry=GLOBAL_TOOLKIT_REGISTRY):
         """
         Call out to ToolkitWrapper methods to find the rings in this molecule.
 
-        Currently only implemented vai The RDKit, which must be installed.
+        Currently only implemented via The RDKit, which must be installed.
 
         .. note ::
 
@@ -5286,7 +5290,7 @@ class FrozenMolecule(Serializable):
                 f"Got  {type(toolkit_registry)}"
             )
 
-        self._rings = rings
+        return rings
 
 
 class Molecule(FrozenMolecule):

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -4611,6 +4611,27 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         rings = ring_info.AtomRings()
         return rings
 
+    def atom_is_in_ring(self, molecule, atom_index: int) -> bool:
+        """Return whether or not an atom is in a ring.
+
+        Parameters
+        ----------
+        molecule : openff.toolkit.topology.Molecule
+            The molecule containing the atom of interest
+        atom_index : int
+            The index of the atom of interest
+
+        Returns
+        -------
+        is_in_ring : bool
+            Whether or not the atom of index `atom_index` is in a ring
+
+        """
+        rdmol = molecule.to_rdkit()
+        is_in_ring = rdmol.GetAtomWithIdx(atom_index).IsInRing()
+
+        return is_in_ring
+
     @staticmethod
     def _find_undefined_stereo_atoms(rdmol, assign_stereo=False):
         """Find the chiral atoms with undefined stereochemsitry in the RDMol.


### PR DESCRIPTION
This PR tries to implement solutions to #823. The major change is that several properties `Molecule.rings`, `.n_rings`, `Atom.is_in_ring`, `Bond.is_in_ring`, have been converted to methods, which breaks the existing API. The ways that membership in rings was being checked wasn't necessarily the best, since RDKit exposes a more direct way to do this (I assume OEChem does as well).

The main problem with the earlier implementation is that storing rings in `Molecule._rings` loses the provenance of which toolkit determined the number of rings (RDKit, OpenEye, and other toolkits are not guaranteed to agree). So these methods now generate rings on the fly as needed instead of storing them as private attributes and exposing getters. This should work around edge cases resulting from toolkit differences (unclear how we can test these without OpenEye functionality added). There an obvious downside of this change is wasteful re-computing the rings. I don't know if this is an important performance hit or not.

- [ ] Number of bonds in rings has changed by 1 for some conjugated rings?
- [ ] Any way to keep ring data as properties while respecting toolkit behaviors? (Is this even a good idea?)
- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
