### PR TITLE
Update testing matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,38 +18,40 @@ on:
 jobs:
   test:
     if: (github.event_name == 'schedule' && github.repository == 'openforcefield/openff-toolkit') || (github.event_name != 'schedule')
-    name: Test on ${{ matrix.cfg.os }}, Python ${{ matrix.python-version }}, RDKit=${{ matrix.cfg.rdkit }}, OpenEye=${{ matrix.cfg.openeye }}
-    runs-on: ${{ matrix.cfg.os }}
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.cfg.python-version }}, RDKit=${{ matrix.cfg.rdkit }}, OpenEye=${{ matrix.cfg.openeye }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
+        os:
+          - ubuntu-latest
+          - macos-latest
         cfg:
-          - os: ubuntu-latest
+          - python-version: 3.7
             rdkit: "true"
             openeye: "false"
 
-          - os: ubuntu-latest
+          - python-version: 3.7
             rdkit: "false"
             openeye: "true"
 
-          - os: ubuntu-latest
+          - python-version: 3.7
             rdkit: "true"
             openeye: "true"
 
-          - os: macOS-latest
+          - python-version: 3.8
+            rdkit: "true"
+            openeye: "false"
+
+          - python-version: 3.9
             rdkit: "true"
             openeye: "false"
 
     env:
-      CI_OS: ${{ matrix.cfg.os }}
+      CI_OS: ${{ matrix.os }}
       RDKIT: ${{ matrix.cfg.rdkit }}
       OPENEYE: ${{ matrix.cfg.openeye }}
-      PYVER: ${{ matrix.python-version }}
+      PYVER: ${{ matrix.cfg.python-version }}
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       PACKAGE: openff
       PYTEST_ARGS: -r fE --tb=short --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
@@ -62,7 +64,7 @@ jobs:
         name: Install both RDKit and OpenEye toolkits
         if: ${{ matrix.cfg.rdkit == 'TRUE' && matrix.cfg.openeye == 'TRUE' }}
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.cfg.python-version }}
           activate-environment: test
           environment-file: devtools/conda-envs/test_env.yaml
           auto-activate-base: false
@@ -70,7 +72,7 @@ jobs:
         name: Install only RDKit
         if: ${{ matrix.cfg.rdkit == 'TRUE' && matrix.cfg.openeye == 'FALSE' }}
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.cfg.python-version }}
           activate-environment: test
           environment-file: devtools/conda-envs/rdkit.yaml
           auto-activate-base: false
@@ -78,7 +80,7 @@ jobs:
         name: Install with OpenEye toolkits
         if: ${{ matrix.cfg.rdkit == 'FALSE' && matrix.cfg.openeye == 'TRUE' }}
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.cfg.python-version }}
           activate-environment: test
           environment-file: devtools/conda-envs/openeye.yaml
           auto-activate-base: false

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -292,3 +292,28 @@ There is a step in CI that uses these tools to check for a consistent style. The
     $ isort openff
 
 Anything not covered above is currently up to personal preference, but may change as new linters are added.
+
+Supported Python versions
+"""""""""""""""""""""""""
+
+The OpenFF Toolkit roughly follows `NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_. As of version 0.9.1 (March 2021) this means Python 3.7-3.9 is officially supported. We develop, test, and distribute on macOS and Linux-based operating systems. We do not currently support Windows. Some CI builds run using only The RDKit as a backend, some run using only OpenEye Toolkits, and some run using both installed at once.
+
+The CI matrix is currently as follows:
+
++-----------------------+------------+-----------+-------------+------------+-----------+-------------+
+| Operating system      | Linux                                | macOS                                |
++-----------------------+------------+-----------+-------------+------------+-----------+-------------+
+| Wrapped toolkit(s)    | RDKit      | OpenEye   | RDKit + OE  | RDKit      | OpenEye   | RDKit + OE  |
++-----------------------+------------+-----------+-------------+------------+-----------+-------------+
+| Python version        |            |           |             |            |           |             |
++=======================+========================+=============+========================+=============+
+| Python 3.6 and older  | No support after 0.9.1 (March 20201)                                        |
++-----------------------+------------+-----------+-------------+------------+-----------+-------------+
+| Python 3.7            | Test       | Test      | Test        | Test       | Test      | Test        |
++-----------------------+------------+-----------+-------------+------------+-----------+-------------+
+| Python 3.8            | Test       | Skip      |        Skip | Test       | Skip      | Skip        |
++-----------------------+------------+-----------+-------------+------------+-----------+-------------+
+| Python 3.9            | Test       | Skip      |        Skip | Test       | Skip      | Skip        |
++-----------------------+------------+-----------+-------------+------------+-----------+-------------+
+| Python 3.10 and newer |   Waiting on official releases and upstream support                         |
++-----------------------+------------+-----------+-------------+------------+-----------+-------------+


### PR DESCRIPTION
Ready to go now that 0.9.1 is released


The upcoming toolkit release 0.9.1 will be the last release to support Python 3.6. Many other scientific packages have already dropped it ([NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#detailed-description) schedule this change for last summer!) and we are currently unaware of any users that require 3.6 support.

We agreed on the following matrix
![image](https://user-images.githubusercontent.com/7935382/109672999-348ee900-7b3b-11eb-80bc-71bf7b4986bb.png)

Note that OpenEye has not published Python 3.9 builds for their toolkits [link](
https://anaconda.org/OpenEye/OpenEye-toolkits/files), so RDKit-only is the only option at the moment for 3.9. The 3.8 builds are being trimmed in order to get CI running a little quicker; all Python versions, each combination of toolkits, and both Linux and macOS are still being tested, just not all combinations of each.


- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
