### PR TITLE
Clarified that systems are OpenMM `System`s

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -211,7 +211,7 @@ But when we do need to make tradeoffs, "assume the user is an expert" is our gui
 
 At the same time, we aim for "automagic" behavior whenever a decision will clearly go one way over another.
 System parametrization is an inherently complex topic, and the OFF toolkit would be nearly unusable if we required the user to explicitly approve every aspect of the process.
-For example, if a ``Topology`` has its ``box_vectors`` attribute defined, we assume that the resulting ``System`` should be periodic.
+For example, if a ``Topology`` has its ``box_vectors`` attribute defined, we assume that the resulting OpenMM ``System`` should be periodic.
 
 
 

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -66,6 +66,9 @@ Improved documentation and warnings
   <openff.toolkit.typing.engines.smirnoff.parameters.ParameterAttribute>` documentation no longer
   appears incorrectly in classes where it is used. Fixes `Issue #397
   <https://github.com/openforcefield/openforcefield/issues/397>`_.
+- `PR #862 <https://github.com/openforcefield/openforcefield/pull/862>`_: Clarify that ``System`` objects
+  produced by the toolkit are OpenMM ``System``\ s in anticipation of forthcoming OpenFF ``System``\ s.
+  Fixes `Issue #618 <https://github.com/openforcefield/openforcefield/issues/618>`_.
 
 0.9.0 - Namespace Migration
 ---------------------------

--- a/docs/releasehistory.rst
+++ b/docs/releasehistory.rst
@@ -209,14 +209,14 @@ Bugfixes
 0.8.0 - Virtual Sites
 ---------------------
 
-This release implements the SMIRNOFF virtual site specification. The implementation enables support for models using off-site charges, including 4- and 5-point water models, in addition to lone pair modeling on various functional groups. The primary focus was on the ability to parameterize a system using virtual sites, and generating an OpenMM system with all virtual sites present and ready for evaluation. Support for formats other than OpenMM has not be implemented in this release, but may come with the appearance of the OpenFF system object. In addition to implementing the specification, the toolkit :py:class:`Molecule <openff.toolkit.topology.Molecule>` objects now allow the creation and manipulation of virtual sites.
+This release implements the SMIRNOFF virtual site specification. The implementation enables support for models using off-site charges, including 4- and 5-point water models, in addition to lone pair modeling on various functional groups. The primary focus was on the ability to parameterize a system using virtual sites, and generating an OpenMM ``System`` with all virtual sites present and ready for evaluation. Support for formats other than OpenMM has not be implemented in this release, but may come with the appearance of the OpenFF system object. In addition to implementing the specification, the toolkit :py:class:`Molecule <openff.toolkit.topology.Molecule>` objects now allow the creation and manipulation of virtual sites.
 
 **Major Feature: Support for the SMIRNOFF VirtualSite tag**
 
-Virtual sites can be added to a System in two ways:
+Virtual sites can be added to an OpenMM ``System`` in two ways:
 
 * `SMIRNOFF Force Fields can contain a VirtualSites tag <https://open-forcefield-toolkit.readthedocs.io/en/latest/smirnoff.html#virtualsites-virtual-sites-for-off-atom-charges>`_ , specifying the addition of virtual sites according to SMARTS-based rules.
-* Virtual sites can be added to a :py:class:`Molecule <openff.toolkit.topology.Molecule>`, and these will appear in the final OpenMM system if a virtual site handler is present in the :py:class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`.
+* Virtual sites can be added to a :py:class:`Molecule <openff.toolkit.topology.Molecule>`, and these will appear in the final OpenMM ``System`` if a virtual site handler is present in the :py:class:`ForceField <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField>`.
 
 Virtual sites are the first parameters which directly depend on 3D conformation, where the position of the virtual sites are based on vectors defined on the atoms that were matched during parameterization. Because of this, a virtual site matching the triplet of atoms 1-2-3 will define a point that is different from a triplet matching 3-2-1. This is similar to defining "right-handed" and "left-handed" coordinate systems. This subtlety interplays with two major concepts in force field development:
 
@@ -592,7 +592,7 @@ of molecular symmetry. For example, a methyl group could match the SMIRKS ``[C:1
 (with different orderings of the three hydrogen atoms), but the user would almost certainly not intend for the charge
 increments to be applied six times. The "regardless of order" clause was added specifically to address this.
 
-In short, the first time a group of atoms becomes involved in a ``ChargeIncrement`` together, the System gains a new
+In short, the first time a group of atoms becomes involved in a ``ChargeIncrement`` together, the OpenMM ``System`` gains a new
 parameter "slot". Only another ``ChargeIncrement`` which applies to the exact same group of atoms (in any order) can
 take over the "slot", pushing the original ``ChargeIncrement`` out.
 
@@ -829,7 +829,7 @@ New features
 - `PR #582 <https://github.com/openforcefield/openff-toolkit/pull/582>`_: Added fractional bond order interpolation
   Adds `return_topology` kwarg to
   :py:meth:`Forcefield.create_openmm_system <openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system>`,
-  which returns the processed topology along with the system when ``True`` (default ``False``).
+  which returns the processed topology along with the OpenMM ``System`` when ``True`` (default ``False``).
 
 Tests added
 """""""""""
@@ -1010,7 +1010,7 @@ Behavior changed
   ``openforcefield.typing.engines.smirnoff.parameters.UnassignedMoleculeChargeException``
   will be raised. Previously, creating a system without either ``ToolkitAM1BCCHandler`` or
   the ``charge_from_molecules`` keyword argument to ``ForceField.create_openmm_system`` would
-  produce a system where the molecule has zero charge on all atoms. However, given that we
+  produce an OpenMM ``System`` where the molecule has zero charge on all atoms. However, given that we
   will soon be adding more options for charge assignment, it is important that
   failures not be silent. Molecules with zero charge can still be produced by setting the
   ``Molecule.partial_charges`` array to be all zeroes, and including the molecule in the

--- a/docs/typing.rst
+++ b/docs/typing.rst
@@ -31,7 +31,7 @@ ForceField
 
 The ``ForceField`` class is a primary part of the top-level toolkit API.
 ``ForceField`` objects are initialized from SMIRNOFF data sources (e.g. an ``OFFXML`` file).
-For a basic example of system creation using a ``ForceField``, see ``examples/SMIRNOFF_simulation``.
+For a basic example of OpenMM ``System`` creation using a ``ForceField``, see ``examples/SMIRNOFF_simulation``.
 
 
 .. currentmodule:: openff.toolkit.typing.engines.smirnoff.forcefield
@@ -67,8 +67,8 @@ For more information, see ``examples/forcefield_modification``.
 Parameter Handlers
 ~~~~~~~~~~~~~~~~~~
 
-Each ``ForceField`` primarily consists of several ``ParameterHandler`` objects, which each contain the machinery to add one energy component to a system.
-During system creation, each ``ParameterHandler`` registered to a ``ForceField`` has its ``assign_parameters()`` function called..
+Each ``ForceField`` primarily consists of several ``ParameterHandler`` objects, which each contain the machinery to add one energy component to an OpenMM ``System``.
+During ``System`` creation, each ``ParameterHandler`` registered to a ``ForceField`` has its ``assign_parameters()`` function called.
 
 .. currentmodule:: openff.toolkit.typing.engines.smirnoff.parameters
 .. autosummary::

--- a/examples/using_smirnoff_in_amber_or_gromacs/README.md
+++ b/examples/using_smirnoff_in_amber_or_gromacs/README.md
@@ -1,8 +1,8 @@
-## Export OpenFF-generated System to AMBER and GROMACS files
+## Export OpenFF-generated OpenMM System to AMBER and GROMACS files
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openforcefield/openff-toolkit/d129d0c1f3399aa3e2611443210fce526bc62dd6)
 
-This example shows how you can convert a `System` generated with the Open Forcefield Toolkit, which can be simulated natively with OpenMM, into AMBER prmtop/inpcrd and GROMACS top/gro input files through the ParmEd library.
+This example shows how you can convert an OpenMM `System` generated with the Open Forcefield Toolkit, which can be simulated natively with OpenMM, into AMBER prmtop/inpcrd and GROMACS top/gro input files through the ParmEd library.
 
 #### Manifest:
 

--- a/examples/using_smirnoff_in_amber_or_gromacs/convert_to_amber_gromacs.ipynb
+++ b/examples/using_smirnoff_in_amber_or_gromacs/convert_to_amber_gromacs.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## Convert Open Forcefield System to AMBER and GROMACS input files\n",
     "\n",
-    "The Open Forcefield Toolkit can create parametrized `System` objects that can be natively simulated with OpenMM. This example shows how you can convert a `System` into AMBER prmtop/inpcrd and GROMACS top/gro input files through the ParmEd library."
+    "The Open Forcefield Toolkit can create parametrized `System` objects that can be natively simulated with OpenMM. This example shows how you can convert such an OpenMM `System` into AMBER prmtop/inpcrd and GROMACS top/gro input files through the ParmEd library."
    ]
   },
   {

--- a/examples/using_smirnoff_with_amber_protein_forcefield/toluene_in_T4_lysozyme.ipynb
+++ b/examples/using_smirnoff_with_amber_protein_forcefield/toluene_in_T4_lysozyme.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "## Create a system mixing SMIRNOFF and non-SMIRNOFF-formatted force fields\n",
     "\n",
-    "This example shows how to create a receptor-ligand `System` where the ligand (toluene) is parametrized with a SMIRNOFF force field and the protein (T4 Lysozyme) solvated in water is assigned AMBER and TIP3P-FB parameters through the ParmEd library.\n",
+    "This example shows how to create a receptor-ligand OpenMM `System` where the ligand (toluene) is parametrized with a SMIRNOFF force field and the protein (T4 Lysozyme) solvated in water is assigned AMBER and TIP3P-FB parameters through the ParmEd library.\n",
     "\n",
     "We'll need two PDB files. One for the ligand in vacuum, and one for the solvated protein without ligand. The coordinates of the protein-ligand complex will be determined by these PDB files, so their positions needs to be consistent with the ligand being positioned in the binding pocket if this is the desired initial configuration of your simulation."
    ]

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -1379,7 +1379,7 @@ class ForceField:
         Parameters
         ----------
         topology : openff.toolkit.topology.Topology
-            The ``Topology`` corresponding to the ``System`` object to be created.
+            The ``Topology`` corresponding to the OpenMM ``System`` object to be created.
         positions : simtk.unit.Quantity of dimension (natoms,3) with units compatible with angstroms
             The positions corresponding to the ``System`` object to be created
 

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -1843,8 +1843,8 @@ class ParameterType(_ParameterAttributeHandler):
 # PARAMETER HANDLERS
 #
 # The following classes are Handlers that know how to create Force
-# subclasses and add them to a System that is being created. Each Handler
-# class must define three methods:
+# subclasses and add them to an OpenMM System that is being created. Each
+# Handler class must define three methods:
 # 1) a constructor which takes as input hierarchical dictionaries of data
 #    conformant to the SMIRNOFF spec;
 # 2) a create_force() method that constructs the Force object and adds it
@@ -2307,7 +2307,7 @@ class ParameterHandler(_ParameterAttributeHandler):
             reference_molecule.get_bond_between(atom_i, atom_j)
 
     def assign_parameters(self, topology, system):
-        """Assign parameters for the given Topology to the specified System object.
+        """Assign parameters for the given Topology to the specified OpenMM ``System`` object.
 
         Parameters
         ----------
@@ -2320,7 +2320,7 @@ class ParameterHandler(_ParameterAttributeHandler):
         pass
 
     def postprocess_system(self, topology, system, **kwargs):
-        """Allow the force to perform a a final post-processing pass on the System following parameter assignment, if needed.
+        """Allow the force to perform a a final post-processing pass on the OpenMM ``System`` following parameter assignment, if needed.
 
         Parameters
         ----------


### PR DESCRIPTION
This PR explicitly describes `System`s generated by the toolkit as OpenMM `System`s to resolve future confusion with the forthcoming OpenFF `System` object. The codebase already did a good job of this, but some of the documentation and examples needed clarification. Resolves #618.

- [x] Tag issue being addressed
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
