### PR TITLE
More reliable CI...?

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -57,6 +57,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - uses: conda-incubator/setup-miniconda@v2
         name: Install both RDKit and OpenEye toolkits


### PR DESCRIPTION
Codecov causes spurious status failures on a fairly regular basis in this repo. It reports the following error, even on successful runs:

```
Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0
```

It then sometimes fails with

```js
{'detail': ErrorDetail(string='Actions workflow run is stale', code='not_found')}
```

So my hypothesis (very low confidence) is that its trying to detect the commit. Usually its successful and the test is successful. Occasionally it doesn't detect the correct commit, tries to go ahead with the wrong one, and then fails with a report that it's stale. Maybe. 

Googling the former gives [this issue](https://github.com/codecov/codecov-action/issues/190) from the Action repo and [this thread](https://community.codecov.io/t/cant-get-codecov-to-work-with-monorepo/2462) from the codecov forum. Both suggest following the directions and setting fetch depth to 0 or a value greater than 1. `fetch-depth` is a setting for the [checkout](https://github.com/actions/checkout) action that determines how many commits to download. By default it is set to 1 as a performance optimisation. 0 downloads the entire repository. I've set it to 2 in this PR. If the message goes away but codecov still fails at least once, we can rule this out as a possibility!

The performance impact of this change should be small as commits are very small and only add up when you have a lot of them. Indeed, the time for the checkout in my very unscientific comparison (n=2) was 6 seconds in both this PR and in another recent one.
