### PR TITLE
Update deployment tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,15 +1,6 @@
 name: Conda
 
 on: 
-  # Removing these triggers before merging
-  push:
-    branches:
-      - "master"
-      - "maintenance/.+"
-  pull_request:
-    branches:
-      - "master"
-      - "maintenance/.+"
   release:
     types:
       - released

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,6 +1,15 @@
 name: Conda
 
 on: 
+  # Removing these triggers before merging
+  push:
+    branches:
+      - "master"
+      - "maintenance/.+"
+  pull_request:
+    branches:
+      - "master"
+      - "maintenance/.+"
   release:
     types:
       - released
@@ -11,26 +20,35 @@ on:
 
 jobs:
   test:
-    name: Test on ${{ matrix.cfg.os }}, Python ${{ matrix.python-version }}, OpenEye=${{ matrix.openeye }}
-    runs-on: ${{ matrix.cfg.os }}
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.cfg.python-version }}, OpenEye=${{ matrix.cfg.openeye }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version:
-          - 3.7
-          - 3.8
-          - 3.9
-        openeye:
-          - "true"
-          - "false"
+        os:
+          - ubuntu-latest
+          - macos-latest
         cfg:
-          - os: ubuntu-latest
-          - os: macOS-latest
+          - python-version: 3.7
+            openeye: "true"
+
+          - python-version: 3.7
+            openeye: "false"
+
+          - python-version: 3.8
+            openeye: "true"
+
+          - python-version: 3.8
+            openeye: "false"
+
+            # Add a 3.9 + OE build when OETK are released on 3.9
+          - python-version: 3.9
+            openeye: "false"
 
     env:
-      CI_OS: ${{ matrix.cfg.os }}
-      OPENEYE: ${{ matrix.openeye }}
-      PYVER: ${{ matrix.python-version }}
+      CI_OS: ${{ matrix.os }}
+      OPENEYE: ${{ matrix.cfg.openeye }}
+      PYVER: ${{ matrix.cfg.python-version }}
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       PACKAGE: openff-toolkit
 
@@ -39,17 +57,17 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         name: Vanilla install from conda
-        if: ${{ matrix.openeye == 'false' }}
+        if: ${{ matrix.cfg.openeye == 'false' }}
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.cfg.python-version }}
           activate-environment: test
           environment-file: devtools/conda-envs/conda.yaml
           auto-activate-base: false
       - uses: conda-incubator/setup-miniconda@v2
         name: Install from conda with OpenEye
-        if: ${{ matrix.openeye == 'true' }}
+        if: ${{ matrix.cfg.openeye == 'true' }}
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.cfg.python-version }}
           activate-environment: test
           environment-file: devtools/conda-envs/conda_oe.yaml
           auto-activate-base: false

--- a/devtools/conda-envs/conda.yaml
+++ b/devtools/conda-envs/conda.yaml
@@ -6,8 +6,6 @@ dependencies:
     # Base depends
   - openff-toolkit
 
-    # Removed until a new release which targets openff-toolkit is made.
-#  - openmmforcefields
-  - openmm
+  - openmmforcefields
   - pytest
   - nbval

--- a/devtools/conda-envs/conda_oe.yaml
+++ b/devtools/conda-envs/conda_oe.yaml
@@ -6,9 +6,8 @@ channels:
 dependencies:
     # Base depends
   - openff-toolkit
-    # Removed until a new release which targets openff-toolkit is made.
-#  - openmmforcefields
-  - openmm
+
+  - openmmforcefields
   - openeye-toolkits
   - pytest
   - nbval


### PR DESCRIPTION
The deployment tests have been partially broken for a few weeks now, and recent efforts (https://github.com/openforcefield/openff-toolkit/pull/873/commits/2af709222973aeea73fb688945f340b186317a60) did not properly fix them.

- [x] Skip Python 3.9 + OpenEye Toolkits runs
- [x] Install `openmmforcefields` now that it has been repackaged post-namespace migration
- [x] Update test matrix to be more similar to CI jobs