### PR TITLE
Adding element getter to topology atoms

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -22,6 +22,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   `Molecule.from_rdkit`, `Molecule.from_smiles`, `OpenEyeToolkitWrapper.from_smiles`, and 
   `RDKitToolkitWrapper.from_smiles` will now load atom maps into the the resulting 
   `Molecule's` `offmol.properties['atom_map']` field, even if not all atoms have map indices assigned.
+- [PR #904](https://github.com/openforcefield/openforcefield/pull/904): `TopologyAtom` objects now have 
+  an element getter `TopologyAtom.element`.
 
 ### Bugfixes
 

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -18,6 +18,7 @@ from unittest import TestCase
 import numpy as np
 import pytest
 from simtk import unit
+from simtk.openmm.app import element
 
 from openff.toolkit.tests.test_forcefield import (
     create_cyclohexane,
@@ -318,6 +319,22 @@ class TestTopology(TestCase):
 
         with self.assertRaises(Exception) as context:
             topology_atom = topology.atom(8)
+
+    def test_topology_atom_element(self):
+        """Test getters of TopologyAtom element and atomic number"""
+        topology = Topology()
+        topology.add_molecule(self.toluene_from_sdf)
+
+        first_element = topology.atom(0).element
+        eighth_element = topology.atom(7).element
+
+        # Check if instances are correct
+        assert isinstance(first_element, element.Element)
+        assert isinstance(eighth_element, element.Element)
+
+        # Make sure first is a carbon element and eighth is a hydrogen element
+        assert first_element == element.carbon
+        assert eighth_element == element.hydrogen
 
     def test_get_bond(self):
         """Test Topology.bond function (bond lookup from index)"""

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -328,7 +328,7 @@ class TestTopology(TestCase):
         first_element = topology.atom(0).element
         eighth_element = topology.atom(7).element
 
-        # Check if instances are correct
+        # Check if types/instances are correct
         assert isinstance(first_element, element.Element)
         assert isinstance(eighth_element, element.Element)
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -340,8 +340,11 @@ class Atom(Particle):
     @property
     def element(self):
         """
-        The element name
+        The element of this atom.
 
+        Returns
+        -------
+        simtk.openmm.app.element.Element
         """
         return element.Element.getByAtomicNumber(self._atomic_number)
 

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -345,6 +345,17 @@ class TopologyAtom(Serializable):
         return self._atom.atomic_number
 
     @property
+    def element(self):
+        """
+        Get the element name of this atom.
+
+        Returns
+        -------
+        simtk.openmm.app.element.Element
+        """
+        return self._atom.element
+
+    @property
     def topology_molecule(self):
         """
         Get the TopologyMolecule that this TopologyAtom belongs to.


### PR DESCRIPTION
- [x] This adds `TopologyAtom.element` getter.
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
