### PR TITLE
Add parallel CI for examples, including their own deps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,29 +150,6 @@ jobs:
           fi
           pytest $PYTEST_ARGS openff/toolkit/tests/
 
-      - name: Run example scripts
-        shell: bash -l {0}
-        run: |
-          if [[ "$RDKIT" == false ]]; then
-            PYTEST_ARGS+=" --ignore=examples/check_dataset_parameter_coverage"
-            PYTEST_ARGS+=" --ignore=examples/QCArchive_interface"
-          fi
-          pytest $PYTEST_ARGS openff/toolkit/tests/test_examples.py
-
-      - name: Run example notebooks
-        shell: bash -l {0}
-        run: |
-          NB_ARGS+=" --ignore=examples/using_smirnoff_in_amber_or_gromacs"
-          # XFail until a new `openmmforcefields` build is made which depends on `openff-toolkit`.
-          NB_ARGS+=" --ignore=examples/swap_amber_parameters"
-          if [[ "$RDKIT" == false ]]; then
-            NB_ARGS+=" --ignore=examples/check_dataset_parameter_coverage"
-            NB_ARGS+=" --ignore=examples/conformer_energies"
-            NB_ARGS+=" --ignore=examples/QCArchive_interface"
-            NB_ARGS+=" --ignore=examples/visualization"
-          fi
-          pytest $NB_ARGS examples/
-
       - name: Run code snippets in docs
         shell: bash -l {0}
         if: ${{ matrix.cfg.rdkit == 'TRUE' && matrix.cfg.openeye == 'TRUE' }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           EXAMPLES="$(find examples -mindepth 1 -maxdepth 1 -type d ! -name deprecated)"
           for example in $EXAMPLES; do
-            pytest $NB_ARGS $examples
+            pytest $NB_ARGS $example
           done
 
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -117,6 +117,11 @@ jobs:
       - name: Run example notebooks
         shell: bash -l {0}
         run: |
+          if [[ "$RDKIT" == false ]]; then
+            NB_ARGS+=" --ignore=examples/QCArchive_interface"
+            NB_ARGS+=" --ignore=examples/check_dataset_parameter_coverage"
+            NB_ARGS+=" --ignore=examples/conformer_energies"
+          fi
           pytest $NB_ARGS examples
 
       - name: Codecov

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -110,7 +110,10 @@ jobs:
       - name: Run example notebooks
         shell: bash -l {0}
         run: |
-          pytest $NB_ARGS examples/
+          EXAMPLES="$(find examples -mindepth 1 -maxdepth 1 -type d ! -name deprecated)"
+          for example in $EXAMPLES; do
+            pytest $NB_ARGS $examples
+          done
 
 
       # - name: Check openff-examples list is complete and correct

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install additional example dependencies
         shell: bash -l {0}
         run: |
-          conda env update --file examples/environment.yaml
+          conda env update --file examples/environment.yaml --name test
 
       - name: Additional info about the build
         shell: bash -l {0}
@@ -110,44 +110,7 @@ jobs:
       - name: Run example notebooks
         shell: bash -l {0}
         run: |
-          EXAMPLES="$(find examples -mindepth 1 -maxdepth 1 -type d ! -name deprecated)"
-          for example in $EXAMPLES; do
-            pytest $NB_ARGS $example
-          done
-
-
-      # - name: Check openff-examples list is complete and correct
-      #   shell: bash -l {0}
-      #   run: |
-      #     # LS="$(/bin/ls examples --ignore='deprecated' --ignore='*.*' -1 | sort)"
-      #     FIND="$(find openff/examples -mindepth 1 -maxdepth 1 -type d ! -name deprecated | sed -e 's/^openff\/examples\///' | sort)"
-      #     EXAMPLES="$(openff-examples list | sort)"
-
-      #     if [ "$FIND" == "$EXAMPLES" ]; then
-      #       echo 'openff-examples list works!'
-      #     else
-      #       echo 'openff-examples list does not match ls examples.'
-      #       echo 'Output of `openff-examples list | sort`:'
-      #       echo "$EXAMPLES"
-      #       echo 'Output of `find openff/examples -mindepth 1 -maxdepth 1 -type d ! -name deprecated -printf '%f\n' | sort`:'
-      #       echo "$FIND"
-      #       false
-      #     fi
-
-      # - name: Run example notebooks
-      #   shell: bash -l {0}
-      #   run: |
-      #     NOTEBOOKS=( $(openff-examples list) )
-
-      #     openff-examples install --update-environment ${NOTEBOOKS[0]}
-      #     pytest $NB_ARGS ${NOTEBOOKS[0]}/
-
-      #     conda list
-
-      #     for notebook in ${NOTEBOOKS[@]:1}; do
-      #       openff-examples install $notebook
-      #       pytest $NB_ARGS $notebook/
-      #     done
+          pytest $NB_ARGS examples
 
       - name: Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,154 @@
+name: Examples
+
+on:
+  push:
+    branches:
+      - "master"
+      - "maintenance/.+"
+  pull_request:
+    branches:
+      - "master"
+      - "maintenance/.+"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    if: (github.event_name == 'schedule' && github.repository == 'openforcefield/openff-toolkit') || (github.event_name != 'schedule')
+    name: ${{ matrix.os }}, Python ${{ matrix.cfg.python-version }}, RDKit=${{ matrix.cfg.rdkit }}, OpenEye=${{ matrix.cfg.openeye }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        cfg:
+          - python-version: 3.7
+            rdkit: "true"
+            openeye: "false"
+
+          - python-version: 3.7
+            rdkit: "false"
+            openeye: "true"
+
+
+    env:
+      CI_OS: ${{ matrix.os }}
+      RDKIT: ${{ matrix.cfg.rdkit }}
+      OPENEYE: ${{ matrix.cfg.openeye }}
+      PYVER: ${{ matrix.cfg.python-version }}
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+      PACKAGE: openff
+      PYTEST_ARGS: -r fE --tb=short --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
+      NB_ARGS: -v --nbval-lax --ignore=examples/deprecated
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        name: Install only RDKit
+        if: ${{ matrix.cfg.rdkit == 'TRUE' && matrix.cfg.openeye == 'FALSE' }}
+        with:
+          python-version: ${{ matrix.cfg.python-version }}
+          activate-environment: test
+          environment-file: devtools/conda-envs/rdkit.yaml
+          auto-activate-base: false
+      - uses: conda-incubator/setup-miniconda@v2
+        name: Install with OpenEye toolkits
+        if: ${{ matrix.cfg.rdkit == 'FALSE' && matrix.cfg.openeye == 'TRUE' }}
+        with:
+          python-version: ${{ matrix.cfg.python-version }}
+          activate-environment: test
+          environment-file: devtools/conda-envs/openeye.yaml
+          auto-activate-base: false
+
+      - name: Install additional example dependencies
+        shell: bash -l {0}
+        run: |
+          conda env update --file examples/environment.yaml
+
+      - name: Additional info about the build
+        shell: bash -l {0}
+        run: |
+          uname -a
+          df -h
+          ulimit -a
+
+      - name: Make oe_license.txt file from GH org secret "OE_LICENSE"
+        shell: bash
+        env:
+          OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+        run: |
+          echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+
+      - name: Environment Information
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+
+      - name: Install package
+        shell: bash -l {0}
+        run: |
+          python setup.py develop --no-deps
+
+      - name: Run example scripts without OE
+        shell: bash -l {0}
+        run: |
+          if [[ "$RDKIT" == false ]]; then
+            PYTEST_ARGS+=" --ignore=examples/check_dataset_parameter_coverage"
+            PYTEST_ARGS+=" --ignore=examples/QCArchive_interface"
+          fi
+          pytest $PYTEST_ARGS openff/toolkit/tests/test_examples.py
+
+      - name: Run example notebooks
+        shell: bash -l {0}
+        run: |
+          pytest $NB_ARGS examples/
+
+
+      # - name: Check openff-examples list is complete and correct
+      #   shell: bash -l {0}
+      #   run: |
+      #     # LS="$(/bin/ls examples --ignore='deprecated' --ignore='*.*' -1 | sort)"
+      #     FIND="$(find openff/examples -mindepth 1 -maxdepth 1 -type d ! -name deprecated | sed -e 's/^openff\/examples\///' | sort)"
+      #     EXAMPLES="$(openff-examples list | sort)"
+
+      #     if [ "$FIND" == "$EXAMPLES" ]; then
+      #       echo 'openff-examples list works!'
+      #     else
+      #       echo 'openff-examples list does not match ls examples.'
+      #       echo 'Output of `openff-examples list | sort`:'
+      #       echo "$EXAMPLES"
+      #       echo 'Output of `find openff/examples -mindepth 1 -maxdepth 1 -type d ! -name deprecated -printf '%f\n' | sort`:'
+      #       echo "$FIND"
+      #       false
+      #     fi
+
+      # - name: Run example notebooks
+      #   shell: bash -l {0}
+      #   run: |
+      #     NOTEBOOKS=( $(openff-examples list) )
+
+      #     openff-examples install --update-environment ${NOTEBOOKS[0]}
+      #     pytest $NB_ARGS ${NOTEBOOKS[0]}/
+
+      #     conda list
+
+      #     for notebook in ${NOTEBOOKS[@]:1}; do
+      #       openff-examples install $notebook
+      #       pytest $NB_ARGS $notebook/
+      #     done
+
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true
+

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 2
 
       - uses: conda-incubator/setup-miniconda@v2
-        name: Install only RDKit
+        name: Install with only RDKit
         if: ${{ matrix.cfg.rdkit == 'TRUE' && matrix.cfg.openeye == 'FALSE' }}
         with:
           python-version: ${{ matrix.cfg.python-version }}
@@ -98,7 +98,7 @@ jobs:
           conda info
           conda list
 
-      - name: Run example scripts without OE
+      - name: Run example scripts
         shell: bash -l {0}
         run: |
           if [[ "$RDKIT" == false ]]; then
@@ -125,4 +125,3 @@ jobs:
         with:
           file: ./coverage.xml
           fail_ci_if_error: true
-

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -73,6 +73,11 @@ jobs:
         run: |
           conda env update --file examples/environment.yaml --name test
 
+          # Remove rdkit if it is not being tested, as it is a dependency of openmmforcefields
+          if [[ "$RDKIT" == false ]]; then
+            conda remove --force rdkit
+          fi
+
       - name: Additional info about the build
         shell: bash -l {0}
         run: |
@@ -90,6 +95,8 @@ jobs:
       - name: Install package
         shell: bash -l {0}
         run: |
+          # Remove the packaged openff-toolkit, installed as a dependency of openmmforcefields
+          conda remove --force openff-toolkit
           python setup.py develop --no-deps
 
       - name: Environment Information
@@ -111,14 +118,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest $NB_ARGS examples
-
-      - name: Conda tree information
-        shell: bash -l {0}
-        run: |
-          conda install -c conda-forge conda-tree
-          conda tree deptree
-          conda tree leaves
-          conda tree whoneeds rdkit
 
       - name: Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -87,16 +87,16 @@ jobs:
         run: |
           echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
 
+      - name: Install package
+        shell: bash -l {0}
+        run: |
+          python setup.py develop --no-deps
+
       - name: Environment Information
         shell: bash -l {0}
         run: |
           conda info
           conda list
-
-      - name: Install package
-        shell: bash -l {0}
-        run: |
-          python setup.py develop --no-deps
 
       - name: Run example scripts without OE
         shell: bash -l {0}
@@ -111,6 +111,14 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest $NB_ARGS examples
+
+      - name: Conda tree information
+        shell: bash -l {0}
+        run: |
+          conda install -c conda-forge conda-tree
+          conda tree deptree
+          conda tree leaves
+          conda tree whoneeds rdkit
 
       - name: Codecov
         uses: codecov/codecov-action@v1

--- a/examples/environment.yaml
+++ b/examples/environment.yaml
@@ -16,4 +16,3 @@ dependencies:
   - mdtraj
   - numpy
   - openmm
-  - rdkit

--- a/examples/environment.yaml
+++ b/examples/environment.yaml
@@ -1,0 +1,19 @@
+name: offtk-examples
+channels:
+  - conda-forge
+  - bioconda
+
+# These dependencies are in addition to the toolkit itself
+dependencies:
+  - nglview
+  - notebook
+  - gromacs
+  - qcelemental
+  - qcportal
+  - qcengine
+  - openmmforcefields
+  # Below are dependencies of the toolkit; they are listed here as a reference
+  - mdtraj
+  - numpy
+  - openmm
+  - rdkit

--- a/examples/visualization/visualization.ipynb
+++ b/examples/visualization/visualization.ipynb
@@ -199,7 +199,11 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -210,7 +214,6 @@
     }
    ],
    "source": [
-    "# NBVAL_SKIP\n",
     "try:\n",
     "    m.visualize(backend=\"nglview\")  # this will fail because we have no conformers yet\n",
     "except ValueError as excinfo:\n",
@@ -228,7 +231,11 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -246,7 +253,6 @@
     }
    ],
    "source": [
-    "# NBVAL_SKIP\n",
     "m.generate_conformers()\n",
     "m.visualize(backend=\"nglview\")"
    ]
@@ -261,7 +267,11 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "nbval-skip"
+    ]
+   },
    "outputs": [
     {
      "data": {
@@ -279,7 +289,6 @@
     }
    ],
    "source": [
-    "# NBVAL_SKIP\n",
     "n = Molecule.from_smiles(\"c1ccccc1\")\n",
     "n.generate_conformers()\n",
     "n"
@@ -309,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In #888, I explored ways to improve the user experience of using examples. So began a journey across workflows, through CLI development, and into the depths of package management. Much was discovered, and this PR applies some of the lessons thusly learned.

Previously, examples were tested as a part of the general testing CI. This elongated execution times of CI. In addition, examples were tested with only the dependencies of the toolkit (and the testing infrastructure), meaning that notebooks with external dependencies were skipped.

This PR adds a new CI workflow that tests all of the examples, in parallel with other tests, with their dependencies. It also makes the dependencies of the examples available to users as a Conda `environment.yaml` file in the examples directory. In addition, it converts several comments that are used to control testing of individual notebook cells into metadata tags. This is described in the [`nbval` docs](https://nbval.readthedocs.io/en/latest/#Using-tags-instead-of-comments).

- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
