### PR TITLE
Make `isort` and `black` compatible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ omit =
 max-line-length = 119
 
 [isort]
+profile=black
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
With the previous configuration, it was possible to get into a loop where formatting with `isort` or `black` would break the formatting done by the other tool. This seems to occur when there are line comments in between imports from different packages; `black` would insert empty lines before comments, and `isort` would remove them. See commits d007874, 492383f, and ccabc9e in #888 for an example of this happening. `isort` has a configuration option for `black` compatibility which prevents these loops. This is enabled in this PR.