### PR TITLE
Unpin docutils and depend on myst-parser>=0.14

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,9 +7,9 @@ dependencies:
     - numpydoc
     - nbsphinx
     - sphinx_bootstrap_theme
-    - myst-parser
-    - testpath ==0.3.1
-    - docutils ==0.16 # Temporary https://github.com/executablebooks/MyST-Parser/issues/343
+    - myst-parser>=0.14
+    - testpath==0.3.1
+    - docutils
     # conda build dependencies
     - python
     - setuptools


### PR DESCRIPTION
Docutils compatibility was fixed in myst-parser 0.13.6:
https://github.com/executablebooks/MyST-Parser/blob/master/CHANGELOG.md#0136---2021-04-10

Docutils was pinned to fix #902. This pin is no longer necessary.

- [x] Tag issue being addressed
