### PR TITLE
Find latest release tag for deployment tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -102,7 +102,7 @@ jobs:
           # Go up one directory to ensure that we don't just load the OFFTK from the checked-out repo
           cd ../
 
-          export LATEST_TAG=$(git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -v "rc" | tail -1 | sed 's/refs\/tags\///')
+          export LATEST_TAG=$(git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -E "([0-9]+)\.([0-9]+)\.([0-9]+)$" | tail -1 | sed 's/refs\/tags\///')
           export FOUND_VER=$(python -c "import openff.toolkit; print(openff.toolkit.__version__)")
 
           echo "Latest tag is"
@@ -120,8 +120,8 @@ jobs:
       - name: Test the package
         shell: bash -l {0}
         run: |
-          export LATEST_TAG=$(git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -v "rc" | tail -1 | sed 's/refs\/tags\///')
           # Checkout the state of the repo as of the last release
+          export LATEST_TAG=$(git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -E "([0-9]+)\.([0-9]+)\.([0-9]+)$" | tail -1 | sed 's/refs\/tags\///')
           git fetch --tags
           git checkout tags/$LATEST_TAG
           git log -1 | cat


### PR DESCRIPTION
Fixes #941

The logic I added originally wasn't great - all it did was grab the latest tag that did not have `rc` in its name. This would have failed if i.e. we did a beta release and it was the most recent tag. I have updated this logic to instead grab the latest tag matching a semver-like regex pattern. This is what it looks like on my machine:

```shell
$ git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -E "([0-9]+)\.([0-9]+)\.([0-9]+)$" | tail -1 | sed 's/refs\/tags\///'
0.9.2
```

This should ignore anything ending in `rc` (i.e. `1.0.0rc`) anything not semver (`latest`), and work for double-digit minor versions (`0.10.0` coming soon). Dropping the `tail -n 1` and comparing with and without the `grep` demonstrates this should work for most versions we might tag:


```
$ git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | sed 's/refs\/tags\///'
0.0.1
0.0.2
0.0.3
0.0.4
0.1
0.1.0
0.2.0
0.2.1
0.2.2
0.3.0
0.4.0
0.4.1
0.5.0
0.5.1
0.6.0
0.7.0
0.7.1
0.7.2
0.7.2rc1  # <---
0.8.0
0.8.1
0.8.2
0.8.3
0.8.4
0.9.0
0.9.0rc1  # <---
0.9.1
0.9.2
latest  # <---
$ git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -E "([0-9]+)\.([0-9]+)\.([0-9]+)$" | sed 's/refs\/tags\///'
0.0.1
0.0.2
0.0.3
0.0.4
0.1.0
0.2.0
0.2.1
0.2.2
0.3.0
0.4.0
0.4.1
0.5.0
0.5.1
0.6.0
0.7.0
0.7.1
0.7.2
0.8.0
0.8.1
0.8.2
0.8.3
0.8.4
0.9.0
0.9.1
0.9.2
```

Play with it [here](regexr.com/5t8om), taken somewhat from a [fuller](https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39) pattern.

There may be a [cleaner way](https://github.com/openforcefield/openff-toolkit/issues/286#issuecomment-825680944) to do this using the a GitHub API, but I could not get it working quickly.


- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
