### PR TITLE
Merge toolkit caching into topology biopolymer refactor

### DIFF
--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -24,6 +24,7 @@ dependencies:
   - openmm
   - openff-forcefields
   - smirnoff99Frosst
+  - cachetools
   - pyyaml
   - toml
   - bson

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -23,6 +23,7 @@ dependencies:
   - openmm
   - openff-forcefields
   - smirnoff99Frosst
+  - cachetools
   - pyyaml
   - toml
   - bson

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -25,6 +25,7 @@ dependencies:
   - openmm
   - openff-forcefields
   - smirnoff99Frosst
+  - cachetools
   - pyyaml
   - toml
   - bson

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -38,6 +38,7 @@ import warnings
 from collections import OrderedDict
 from copy import deepcopy
 from typing import Optional, Union
+from cached_property import cached_property
 
 import networkx as nx
 import numpy as np
@@ -459,7 +460,7 @@ class Atom(Particle):
         # for vsite in self._vsites:
         #    yield vsite
 
-    @property
+    @cached_property
     def molecule_atom_index(self):
         """
         The index of this Atom within the the list of atoms in ``Molecules``.
@@ -2040,6 +2041,20 @@ class FrozenMolecule(Serializable):
         """
         return hash(self.to_smiles())
 
+    #@cached_property
+    def ordered_connection_table_hash(self):
+        if self._ordered_connection_table_hash is not None:
+            return self._ordered_connection_table_hash
+        
+        id = ''
+        for atom in self.atoms:
+            id += f'{atom.element.symbol}_{atom.formal_charge}_{atom.stereochemistry}__'
+        for bond in self.bonds:
+            id += f'{bond.bond_order}_{bond.stereochemistry}_{bond.atom1_index}_{bond.atom2_index}__'
+        #return hash(id)
+        self._ordered_connection_table_hash = hash(id)
+        return self._ordered_connection_table_hash
+
     @classmethod
     def from_dict(cls, molecule_dict):
         """
@@ -3032,6 +3047,10 @@ class FrozenMolecule(Serializable):
         self._cached_smiles = None
         # TODO: Clear fractional bond orders
         self._rings = None
+        self._ordered_connection_table_hash = None
+        for atom in self.atoms:
+            if 'molecule_atom_index' in atom.__dict__:
+                del atom.__dict__['molecule_atom_index']
 
     def to_networkx(self):
         """Generate a NetworkX undirected graph from the Molecule.
@@ -5062,8 +5081,9 @@ class FrozenMolecule(Serializable):
 
         return new_molecule
 
-    @OpenEyeToolkitWrapper.requires_toolkit()
-    def to_openeye(self, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
+    def to_openeye(self,
+                   toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+                   aromaticity_model=DEFAULT_AROMATICITY_MODEL):
         """
         Create an OpenEye molecule
 
@@ -5093,8 +5113,8 @@ class FrozenMolecule(Serializable):
         >>> oemol = molecule.to_openeye()
 
         """
-        toolkit = OpenEyeToolkitWrapper()
-        return toolkit.to_openeye(self, aromaticity_model=aromaticity_model)
+        #toolkit = OpenEyeToolkitWrapper()
+        return toolkit_registry.to_openeye(self, aromaticity_model=aromaticity_model)
 
     def _construct_angles(self):
         """

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -65,6 +65,7 @@ from collections import defaultdict
 from distutils.spawn import find_executable
 from functools import wraps
 from typing import TYPE_CHECKING, List, Optional, Tuple
+from cachetools import LRUCache, cached
 
 import numpy as np
 from simtk import unit
@@ -167,6 +168,10 @@ class AntechamberNotFoundError(MessageException):
 # =============================================================================================
 # UTILITY FUNCTIONS
 # =============================================================================================
+
+def mol_to_ctab_and_aro_key(self, molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
+    return f"{molecule.ordered_connection_table_hash()}-{aromaticity_model}"
+
 
 # =============================================================================================
 # CHEMINFORMATICS TOOLKIT WRAPPERS
@@ -1482,8 +1487,11 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         return molecule
 
-    @staticmethod
-    def to_openeye(molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
+
+
+    to_openeye_cache = LRUCache(maxsize=4096)
+    @cached(to_openeye_cache, key=mol_to_ctab_and_aro_key)
+    def to_openeye(self, molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
         """
         Create an OpenEye molecule using the specified aromaticity model
 
@@ -2653,6 +2661,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         # Make a copy of molecule so we don't influence original (probably safer than deepcopy per C Bayly)
         mol = oechem.OEMol(oemol)
+
         # Set up query
         qmol = oechem.OEQMol()
         if not oechem.OEParseSmarts(qmol, smarts):
@@ -2672,13 +2681,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         # OEPrepareSearch will clobber our desired aromaticity model if we don't sync up mol and qmol ahead of time
         # Prepare molecule
-        oechem.OEClearAromaticFlags(mol)
-        oechem.OEAssignAromaticFlags(mol, oearomodel)
+        #oechem.OEClearAromaticFlags(mol)
+        #oechem.OEAssignAromaticFlags(mol, oearomodel)
 
         # If aromaticity model was provided, prepare query molecule
         oechem.OEClearAromaticFlags(qmol)
         oechem.OEAssignAromaticFlags(qmol, oearomodel)
-        oechem.OEAssignHybridization(mol)
+        #oechem.OEAssignHybridization(mol)
         oechem.OEAssignHybridization(qmol)
 
         # Build list of matches
@@ -4175,8 +4184,9 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             offmol.partial_charges = None
         return offmol
 
-    @classmethod
-    def to_rdkit(cls, molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
+    to_rdkit_cache = LRUCache(maxsize=4096)
+    @cached(to_rdkit_cache, key=mol_to_ctab_and_aro_key)
+    def to_rdkit(self, molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
         """
         Create an RDKit molecule
 
@@ -4341,7 +4351,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
             raise RuntimeError(err_msg)
 
         # Copy bond stereo info from molecule to rdmol.
-        cls._assign_rdmol_bonds_stereo(molecule, rdmol)
+        self._assign_rdmol_bonds_stereo(molecule, rdmol)
 
         # Set coordinates if we have them
         if molecule._conformers:
@@ -4522,14 +4532,14 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         from rdkit import Chem
 
         # Make a copy of the molecule
-        rdmol = Chem.Mol(rdmol)
+        #rdmol = Chem.Mol(rdmol)
         # Use designated aromaticity model
-        if aromaticity_model == "OEAroModel_MDL":
-            Chem.SanitizeMol(rdmol, Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY)
-            Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
-        else:
-            # Only the OEAroModel_MDL is supported for now
-            raise ValueError("Unknown aromaticity model: {}".aromaticity_models)
+        #if aromaticity_model == "OEAroModel_MDL":
+        #    Chem.SanitizeMol(rdmol, Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY)
+        #    Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
+        #else:
+        #    # Only the OEAroModel_MDL is supported for now
+        #    raise ValueError("Unknown aromaticity model: {}".aromaticity_models)
 
         # Set up query.
         qmol = Chem.MolFromSmarts(smirks)  # cannot catch the error


### PR DESCRIPTION
We'll be collecting work on the biopolymer refactor in the `topology-biopolymer-refactor` branch. I'm putting the incomplete version of toolkit caching there first, since this functionality is needed to test the residue+atom name assignment machinery in a timely way.
