### PR TITLE
Better documentation for RDKit and OEChem substructure matching limit tests

### DIFF
--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -1659,7 +1659,7 @@ class TestOpenEyeToolkitWrapper:
     @pytest.mark.slow
     def test_max_substructure_matches_can_handle_large_molecule(self):
         """Test OpenEyeToolkitWrapper substructure search handles more than the default of MaxMatches = 1024
-        See https://github.com/openforcefield/openff-toolkit/pull/509
+        See https://github.com/openforcefield/openff-toolkit/pull/509 .
         """
 
         tk = OpenEyeToolkitWrapper()

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -1657,8 +1657,10 @@ class TestOpenEyeToolkitWrapper:
             )
 
     @pytest.mark.slow
-    def test_substructure_search_on_large_molecule(self):
-        """Test OpenEyeToolkitWrapper substructure search when a large number hits are found"""
+    def test_max_substructure_matches_can_handle_large_molecule(self):
+        """Test OpenEyeToolkitWrapper substructure search handles more than the default of MaxMatches = 1024
+        See https://github.com/openforcefield/openff-toolkit/pull/509
+        """
 
         tk = OpenEyeToolkitWrapper()
         smiles = "C" * 600
@@ -2804,9 +2806,10 @@ class TestRDKitToolkitWrapper:
             assert offatom.is_aromatic is rdatom.GetIsAromatic()
 
     @pytest.mark.slow
-    def test_substructure_search_on_large_molecule(self):
-        """Test RDKitToolkitWrapper substructure search when a large number hits are found"""
-
+    def test_max_substructure_matches_can_handle_large_molecule(self):
+        """Test RDKitToolkitWrapper substructure search handles more than the default of maxMatches = 1000
+        See https://github.com/openforcefield/openff-toolkit/pull/509 .
+        """
         tk = RDKitToolkitWrapper()
         smiles = "C" * 3000
         molecule = tk.from_smiles(smiles)


### PR DESCRIPTION
Better document the connection between substructure limit tests and #509 .

- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase

