### PR TITLE
Initial implementation of atom metadata + tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - "master"
       - "maintenance/.+"
+      - "topology-biopolymer-refactor"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -7,6 +7,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 * `micro` increments represent bugfix releases or improvements in documentation
 
 ## Current Development
+- [PR #964](https://github.com/openforcefield/openff-toolkit/pull/964): Adds initial implementation
+  of atom metadata dictionaries. 
 
 ### Examples added
 

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -50,10 +50,10 @@ from openff.toolkit.topology import NotBondedError
 from openff.toolkit.topology.molecule import (
     Atom,
     FrozenMolecule,
+    InvalidAtomMetadataError,
     InvalidConformerError,
     Molecule,
     SmilesParsingError,
-    InvalidAtomMetadataError,
 )
 from openff.toolkit.utils import get_data_file_path
 from openff.toolkit.utils.toolkits import (

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -53,6 +53,7 @@ from openff.toolkit.topology.molecule import (
     InvalidConformerError,
     Molecule,
     SmilesParsingError,
+    InvalidAtomMetadataError
 )
 from openff.toolkit.utils import get_data_file_path
 from openff.toolkit.utils.toolkits import (
@@ -321,6 +322,37 @@ class TestAtom:
             assert atom.formal_charge == formal_charge
             assert atom.is_aromatic == is_aromatic
             assert atom.name == this_element.name
+
+    def test_atom_metadata(self):
+        """Test that atom metadata behaves as expected"""
+        metadata = {'resname':'ALA', 'resnum':1, 'chain':'3'}
+        # Create an atom with metadata
+
+        atom = Atom(6, 0, False, metadata=metadata)
+
+        assert atom.metadata == metadata
+
+        # Roundtrip that atom to/from dict
+        atom2 = Atom.from_dict(atom.to_dict())
+        assert atom.metadata == atom2.metadata
+
+        # Make an atom that initially has no metadata, then add the metadata and ensure that
+        # it's equivalent to the atom constructed with the same metadata initially
+        atom3 = Atom(6, 0, False)
+        assert atom3.metadata == {}
+
+        for key, val in metadata.items():
+            atom3.metadata[key] = val
+
+        assert atom3.metadata == metadata
+        assert atom3.to_dict() == atom.to_dict()
+
+        # Ensure that invalid types raise appropriate errors
+        with pytest.raises(InvalidAtomMetadataError, match='non-string key') as excinfo:
+            atom3.metadata[1] = 'one'
+        with pytest.raises(InvalidAtomMetadataError, match='non-string or integer value') as excinfo:
+            atom3.metadata['length'] = 3. * unit.angstrom
+
 
     def test_set_molecule(self):
         """Test appropriately setting a molecule with no errors"""

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -53,7 +53,7 @@ from openff.toolkit.topology.molecule import (
     InvalidConformerError,
     Molecule,
     SmilesParsingError,
-    InvalidAtomMetadataError
+    InvalidAtomMetadataError,
 )
 from openff.toolkit.utils import get_data_file_path
 from openff.toolkit.utils.toolkits import (
@@ -325,7 +325,7 @@ class TestAtom:
 
     def test_atom_metadata(self):
         """Test that atom metadata behaves as expected"""
-        metadata = {'resname':'ALA', 'resnum':1, 'chain':'3'}
+        metadata = {"resname": "ALA", "resnum": 1, "chain": "3"}
         # Create an atom with metadata
 
         atom = Atom(6, 0, False, metadata=metadata)
@@ -348,11 +348,12 @@ class TestAtom:
         assert atom3.to_dict() == atom.to_dict()
 
         # Ensure that invalid types raise appropriate errors
-        with pytest.raises(InvalidAtomMetadataError, match='non-string key') as excinfo:
-            atom3.metadata[1] = 'one'
-        with pytest.raises(InvalidAtomMetadataError, match='non-string or integer value') as excinfo:
-            atom3.metadata['length'] = 3. * unit.angstrom
-
+        with pytest.raises(InvalidAtomMetadataError, match="non-string key") as excinfo:
+            atom3.metadata[1] = "one"
+        with pytest.raises(
+            InvalidAtomMetadataError, match="non-string or integer value"
+        ) as excinfo:
+            atom3.metadata["length"] = 3.0 * unit.angstrom
 
     def test_set_molecule(self):
         """Test appropriately setting a molecule with no errors"""

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -227,6 +227,10 @@ class Atom(Particle):
             Either 'R' or 'S' for specified stereochemistry, or None for ambiguous stereochemistry
         name : str, optional, default=None
             An optional name to be associated with the atom
+        metadata : dict[str: (int, str)], default=None
+            An optional dictionary where keys are strings and values are strings or ints. This is intended
+            to record atom-level information used to inform hierarchy definition and iteration, such as
+            grouping atom by residue and chain.
 
         Examples
         --------
@@ -3242,6 +3246,10 @@ class FrozenMolecule(Serializable):
             Either 'R' or 'S' for specified stereochemistry, or None if stereochemistry is irrelevant
         name : str, optional, default=None
             An optional name for the atom
+        metadata : dict[str: (int, str)], default=None
+            An optional dictionary where keys are strings and values are strings or ints. This is intended
+            to record atom-level information used to inform hierarchy definition and iteration, such as
+            grouping atom by residue and chain.
 
         Returns
         -------
@@ -5496,6 +5504,10 @@ class Molecule(FrozenMolecule):
             Either 'R' or 'S' for specified stereochemistry, or None if stereochemistry is irrelevant
         name : str, optional, default=None
             An optional name for the atom
+        metadata : dict[str: (int, str)], default=None
+            An optional dictionary where keys are strings and values are strings or ints. This is intended
+            to record atom-level information used to inform hierarchy definition and iteration, such as
+            grouping atom by residue and chain.
 
         Returns
         -------

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -61,11 +61,16 @@ from openff.toolkit.utils.toolkits import (
     ToolkitWrapper,
     UndefinedStereochemistryError,
 )
-from openff.toolkit.utils.utils import MissingDependencyError, MessageException, requires_package
+from openff.toolkit.utils.utils import (
+    MissingDependencyError,
+    MessageException,
+    requires_package,
+)
 
 
 class NotAttachedToMoleculeError(MessageException):
     """Exception for when a component does not belong to a Molecule object, but is queried"""
+
 
 class InvalidAtomMetadataError(MessageException):
     """The program attempted to set atom metadata to an invalid type"""
@@ -154,6 +159,7 @@ class Particle(Serializable):
 # Atom
 # =============================================================================================
 
+
 class AtomMetadataDict(UserDict):
     def __init__(self, *args, **kwargs):
         self.data = {}
@@ -161,11 +167,16 @@ class AtomMetadataDict(UserDict):
 
     def __setitem__(self, key, value):
         if not isinstance(key, str):
-            raise InvalidAtomMetadataError(f"Attempted to set atom metadata with a non-string key. (key: {key}")
+            raise InvalidAtomMetadataError(
+                f"Attempted to set atom metadata with a non-string key. (key: {key}"
+            )
         if not isinstance(value, (str, int)):
-            raise InvalidAtomMetadataError(f"Attempted to set atom metadata with a non-string or integer "
-                                           f"value. (value: {value}")
+            raise InvalidAtomMetadataError(
+                f"Attempted to set atom metadata with a non-string or integer "
+                f"value. (value: {value}"
+            )
         super().__setitem__(key, value)
+
 
 class Atom(Particle):
     """
@@ -193,7 +204,7 @@ class Atom(Particle):
         name=None,
         molecule=None,
         stereochemistry=None,
-        metadata=None
+        metadata=None,
     ):
         """
         Create an immutable Atom object.
@@ -247,7 +258,6 @@ class Atom(Particle):
         else:
             self._metadata = AtomMetadataDict(metadata)
 
-
     # TODO: We can probably avoid an explicit call and determine this dynamically
     #   from self._molecule (maybe caching the result) to get rid of some bookkeeping.
     def add_bond(self, bond):
@@ -295,14 +305,12 @@ class Atom(Particle):
         """Create an Atom from a dict representation."""
         return cls(**atom_dict)
 
-
     @property
     def metadata(self):
         """
         The atom's metadata dictionary
         """
         return self._metadata
-
 
     @property
     def formal_charge(self):
@@ -2072,17 +2080,17 @@ class FrozenMolecule(Serializable):
         """
         return hash(self.to_smiles())
 
-    #@cached_property
+    # @cached_property
     def ordered_connection_table_hash(self):
         if self._ordered_connection_table_hash is not None:
             return self._ordered_connection_table_hash
-        
-        id = ''
+
+        id = ""
         for atom in self.atoms:
-            id += f'{atom.element.symbol}_{atom.formal_charge}_{atom.stereochemistry}__'
+            id += f"{atom.element.symbol}_{atom.formal_charge}_{atom.stereochemistry}__"
         for bond in self.bonds:
-            id += f'{bond.bond_order}_{bond.stereochemistry}_{bond.atom1_index}_{bond.atom2_index}__'
-        #return hash(id)
+            id += f"{bond.bond_order}_{bond.stereochemistry}_{bond.atom1_index}_{bond.atom2_index}__"
+        # return hash(id)
         self._ordered_connection_table_hash = hash(id)
         return self._ordered_connection_table_hash
 
@@ -3080,8 +3088,8 @@ class FrozenMolecule(Serializable):
         self._rings = None
         self._ordered_connection_table_hash = None
         for atom in self.atoms:
-            if 'molecule_atom_index' in atom.__dict__:
-                del atom.__dict__['molecule_atom_index']
+            if "molecule_atom_index" in atom.__dict__:
+                del atom.__dict__["molecule_atom_index"]
 
     def to_networkx(self):
         """Generate a NetworkX undirected graph from the Molecule.
@@ -3211,7 +3219,13 @@ class FrozenMolecule(Serializable):
         return rotatable_bonds
 
     def _add_atom(
-        self, atomic_number, formal_charge, is_aromatic, stereochemistry=None, name=None, metadata=None
+        self,
+        atomic_number,
+        formal_charge,
+        is_aromatic,
+        stereochemistry=None,
+        name=None,
+        metadata=None,
     ):
         """
         Add an atom
@@ -5118,9 +5132,11 @@ class FrozenMolecule(Serializable):
 
         return new_molecule
 
-    def to_openeye(self,
-                   toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
-                   aromaticity_model=DEFAULT_AROMATICITY_MODEL):
+    def to_openeye(
+        self,
+        toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
+        aromaticity_model=DEFAULT_AROMATICITY_MODEL,
+    ):
         """
         Create an OpenEye molecule
 
@@ -5150,7 +5166,7 @@ class FrozenMolecule(Serializable):
         >>> oemol = molecule.to_openeye()
 
         """
-        #toolkit = OpenEyeToolkitWrapper()
+        # toolkit = OpenEyeToolkitWrapper()
         return toolkit_registry.to_openeye(self, aromaticity_model=aromaticity_model)
 
     def _construct_angles(self):
@@ -5457,7 +5473,13 @@ class Molecule(FrozenMolecule):
 
     # TODO: Change this to add_atom(Atom) to improve encapsulation and extensibility?
     def add_atom(
-        self, atomic_number, formal_charge, is_aromatic, stereochemistry=None, name=None, metadata=None
+        self,
+        atomic_number,
+        formal_charge,
+        is_aromatic,
+        stereochemistry=None,
+        name=None,
+        metadata=None,
     ):
         """
         Add an atom
@@ -5504,7 +5526,7 @@ class Molecule(FrozenMolecule):
             is_aromatic,
             stereochemistry=stereochemistry,
             name=name,
-            metadata=metadata
+            metadata=metadata,
         )
         return atom_index
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -38,18 +38,15 @@ import warnings
 from collections import OrderedDict, UserDict
 from copy import deepcopy
 from typing import Optional, Union
-from cached_property import cached_property
 
 import networkx as nx
 import numpy as np
+from cached_property import cached_property
 from simtk import unit
 from simtk.openmm.app import Element, element
 
 import openff.toolkit
-from openff.toolkit.utils import (
-    quantity_to_string,
-    string_to_quantity,
-)
+from openff.toolkit.utils import quantity_to_string, string_to_quantity
 from openff.toolkit.utils.serialization import Serializable
 from openff.toolkit.utils.toolkits import (
     DEFAULT_AROMATICITY_MODEL,
@@ -62,8 +59,8 @@ from openff.toolkit.utils.toolkits import (
     UndefinedStereochemistryError,
 )
 from openff.toolkit.utils.utils import (
-    MissingDependencyError,
     MessageException,
+    MissingDependencyError,
     requires_package,
 )
 

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -65,9 +65,9 @@ from collections import defaultdict
 from distutils.spawn import find_executable
 from functools import wraps
 from typing import TYPE_CHECKING, List, Optional, Tuple
-from cachetools import LRUCache, cached
 
 import numpy as np
+from cachetools import LRUCache, cached
 from simtk import unit
 
 from openff.toolkit.utils.utils import (
@@ -4569,7 +4569,6 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         # else:
         #    # Only the OEAroModel_MDL is supported for now
         #    raise ValueError("Unknown aromaticity model: {}".aromaticity_models)
-
         # Set up query.
         qmol = Chem.MolFromSmarts(smirks)  # cannot catch the error
         if qmol is None:

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -169,7 +169,10 @@ class AntechamberNotFoundError(MessageException):
 # UTILITY FUNCTIONS
 # =============================================================================================
 
-def mol_to_ctab_and_aro_key(self, molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
+
+def mol_to_ctab_and_aro_key(
+    self, molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL
+):
     return f"{molecule.ordered_connection_table_hash()}-{aromaticity_model}"
 
 
@@ -1491,9 +1494,8 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         return molecule
 
-
-
     to_openeye_cache = LRUCache(maxsize=4096)
+
     @cached(to_openeye_cache, key=mol_to_ctab_and_aro_key)
     def to_openeye(self, molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
         """
@@ -2685,13 +2687,13 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
         # OEPrepareSearch will clobber our desired aromaticity model if we don't sync up mol and qmol ahead of time
         # Prepare molecule
-        #oechem.OEClearAromaticFlags(mol)
-        #oechem.OEAssignAromaticFlags(mol, oearomodel)
+        # oechem.OEClearAromaticFlags(mol)
+        # oechem.OEAssignAromaticFlags(mol, oearomodel)
 
         # If aromaticity model was provided, prepare query molecule
         oechem.OEClearAromaticFlags(qmol)
         oechem.OEAssignAromaticFlags(qmol, oearomodel)
-        #oechem.OEAssignHybridization(mol)
+        # oechem.OEAssignHybridization(mol)
         oechem.OEAssignHybridization(qmol)
 
         # Build list of matches
@@ -4211,6 +4213,7 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         return offmol
 
     to_rdkit_cache = LRUCache(maxsize=4096)
+
     @cached(to_rdkit_cache, key=mol_to_ctab_and_aro_key)
     def to_rdkit(self, molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
         """
@@ -4558,12 +4561,12 @@ class RDKitToolkitWrapper(ToolkitWrapper):
         from rdkit import Chem
 
         # Make a copy of the molecule
-        #rdmol = Chem.Mol(rdmol)
+        # rdmol = Chem.Mol(rdmol)
         # Use designated aromaticity model
-        #if aromaticity_model == "OEAroModel_MDL":
+        # if aromaticity_model == "OEAroModel_MDL":
         #    Chem.SanitizeMol(rdmol, Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY)
         #    Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
-        #else:
+        # else:
         #    # Only the OEAroModel_MDL is supported for now
         #    raise ValueError("Unknown aromaticity model: {}".aromaticity_models)
 


### PR DESCRIPTION
- [x] Initial implementation of atom-level metadata fields.
- [ ] ~Build metadata dictionary using pydantic~ After discussion with @mattwthompson @lilyminium and @ijpulidos, we decided NOT to do the initial implementation of this dictionary in pydantic. Until we know more about the problem domain and how these fields will be used, we need to be able to change the design of this dict. So for now we're implementing it as a subclass of `UserDict`
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
