### PR TITLE
Comment out template instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,19 +8,19 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
-Steps to reproduce the behavior. A minimal reproducing set of python commands is ideal.
+<!-- Steps to reproduce the behavior. A minimal reproducing set of python commands is ideal.
 
-If the problem involves a specific molecule or file, please upload that as well.
+If the problem involves a specific molecule or file, please upload that as well. -->
 
 **Output**
-The full error message (may be large, that's fine. Better to paste too much than too little.)
+<!-- The full error message (may be large, that's fine. Better to paste too much than too little.) -->
 
 **Computing environment (please complete the following information):**
  - Operating system
  - Output of running `conda list` 
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,13 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
~- [ ] Tag issue being addressed~
~- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)~
~- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable~
~- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase~
~- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)~

If the issue template instructions are comments, the user opening the issue/request can still see them, but once rendered they are invisible. It saves the conscientious bug reporter some keystrokes, and doesn't ruin the flow of the issue for the lazier ones (i.e. [me](https://github.com/openforcefield/openff-toolkit/issues/986))
