### PR TITLE
Fix for "test_overwrite_bond_orders failure in CI #994"

### DIFF
--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -4240,7 +4240,10 @@ class TestForceFieldParameterAssignment:
         for bond1, bond2 in zip(
             omm_sys_top.topology_bonds, mod_omm_sys_top.topology_bonds
         ):
-            assert bond1.bond.fractional_bond_order == bond2.bond.fractional_bond_order
+            # 'approx()' because https://github.com/openforcefield/openff-toolkit/issues/994
+            assert bond1.bond.fractional_bond_order == pytest.approx(
+                bond2.bond.fractional_bond_order
+            )
 
     def test_fractional_bond_order_ignore_existing_confs(self):
         """Test that previously-defined bond orders in the topology are overwritten"""


### PR DESCRIPTION
One-line fix for https://github.com/openforcefield/openff-toolkit/issues/994

Was getting CI failures because 0.98247694 != 0.9824771 when the test doesn't need to be that precise.

Replaced an exact float test with a pytest.approx() test.

The releative error is 1E-07, which is less than approx()'s default of 1E-6.