### PR TITLE
Move XML snippets in test_forcefield.py to module level

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -80,6 +80,10 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   Several tests modules used functions from test_forcefield.py that created an OpenFF Molecule
   without a toolkit. These functions are now in their own module so they can be imported directly,
   without the overhead of going through test_forcefield.
+- [PR #997](https://github.com/openforcefield/openff-toolkit/pull/997):
+  Several XML snippets in `test_forcefield.py` that were scattered around inside of classes and
+  functions are now moved to the module level.
+
 
 ## 0.9.2 Minor feature and bugfix release
 

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -75,11 +75,6 @@ from openff.toolkit.utils.toolkits import (
 # GLOBAL CONSTANTS
 # ======================================================================
 
-# File paths.
-TIP3P_SDF_FILE_PATH = get_data_file_path(
-    os.path.join("systems", "monomers", "water.sdf")
-)
-
 XML_FF_GENERICS = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <Bonds version="0.3">
@@ -102,8 +97,13 @@ XML_FF_GENERICS = """<?xml version='1.0' encoding='ASCII'?>
 </SMIRNOFF>
 """
 
-simple_xml_ff = str.encode(
-    """<?xml version='1.0' encoding='ASCII'?>
+xml_without_section_version = """<?xml version="1.0" encoding="ASCII"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <ToolkitAM1BCC/>
+</SMIRNOFF>
+"""
+
+xml_simple_ff = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
   <Bonds version="0.3">
     <Bond smirks="[#6X4:1]-[#6X4:2]" id="b1" k="620.0 * kilocalories_per_mole/angstrom**2" length="1.526 * angstrom"/>
@@ -131,7 +131,6 @@ simple_xml_ff = str.encode(
   <ToolkitAM1BCC version="0.3"/>
 </SMIRNOFF>
 """
-)
 
 xml_ff_w_comments = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
@@ -166,6 +165,13 @@ xml_ff_w_comments = """<?xml version='1.0' encoding='ASCII'?>
 </SMIRNOFF>
 """
 
+xml_missing_torsion = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <ProperTorsions version="0.3" potential="k*(1+cos(periodicity*theta-phase))">
+    <Proper smirks="[#99:1]-[#99X4:2]-[#99:3]-[#99:4]" id="t1" idivf1="1" k1="0.156 * kilocalories_per_mole" periodicity1="3" phase1="0.0 * degree"/>
+  </ProperTorsions>
+</SMIRNOFF>
+"""
 
 xml_ff_w_cosmetic_elements = """<?xml version='1.0' encoding='ASCII'?>
 <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
@@ -339,6 +345,359 @@ xml_ff_virtual_sites_monovalent_match_once = """<?xml version="1.0" encoding="ut
     </VirtualSites>
 </SMIRNOFF>
 """
+
+xml_tip5p = """<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <LibraryCharges version="0.3">
+            <LibraryCharge name="tip5p" smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]" charge1="0.*elementary_charge" charge2="0.*elementary_charge" charge3="0.*elementary_charge"/>
+    </LibraryCharges>
+    <vdW version="0.3" potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" switch_width="1.0 * angstrom" cutoff="9.0 * angstrom" method="cutoff">
+            <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" epsilon="0. * mole**-1 * kilojoule" id="n35" sigma="1 * nanometer"/>
+            <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" epsilon="0.66944 * mole**-1 * kilojoule" id="n35" sigma="0.312 * nanometer"/>
+    </vdW>
+     <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
+        <Bond smirks="[#1:1]-[#8X2H2+0:2]-[#1]" length="0.9572 * angstrom" k="462750.4 * nanometer**-2 * mole**-1 * kilojoule" id="b1" />   
+    </Bonds>
+    <Angles version="0.3" potential="harmonic">
+        <Angle smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]" angle="1.82421813418 * radian" k="836.8 * mole**-1 * radian**-2 * kilojoule" id="a1" />
+    </Angles>
+    <VirtualSites version="0.3" exclusion_policy="parents">
+        <VirtualSite
+            type="DivalentLonePair"
+            name="EP"
+            smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]"
+            distance="0.70 * angstrom"
+            charge_increment1="0.1205*elementary_charge"
+            charge_increment2="0.0*elementary_charge"
+            charge_increment3="0.1205*elementary_charge"
+            sigma="1.0*angstrom"
+            epsilon="0.0*kilocalories_per_mole"
+            outOfPlaneAngle="54.71384225*degree"
+            match="all_permutations" >
+        </VirtualSite>
+    </VirtualSites>
+    <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0" switch_width="0.0 * angstrom" cutoff="9.0 * angstrom"/>
+  <Constraints version="0.3">
+    <Constraint smirks="[#1:1]-[#8X2H2+0:2]-[#1]" id="c1" distance="0.9572 * angstrom"/>
+    <Constraint smirks="[#1:1]-[#8X2H2+0]-[#1:2]" id="c2" distance="1.5139006545247014 * angstrom"/>
+  </Constraints>
+</SMIRNOFF>
+"""
+
+xml_gbsa_ff = """<?xml version='1.0' encoding='ASCII'?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <GBSA version="0.3" gb_model="HCT" solvent_dielectric="78.5" solute_dielectric="1" sa_model="None" surface_area_penalty="5.4*calories/mole/angstroms**2" solvent_radius="1.4*angstroms">
+          <Atom smirks="[*:1]" radius="0.15*nanometer" scale="0.8"/>
+    </GBSA>
+</SMIRNOFF>
+"""
+
+xml_charge_increment_model_ff_no_missing_cis = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
+  <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
+    <ChargeIncrement smirks="[#6X4:1]-[#8:2]" charge_increment1="-0.06*elementary_charge" charge_increment2="0.06*elementary_charge"/>
+    <ChargeIncrement smirks="[#6X4:1]-[#1:2]" charge_increment1="-0.01*elementary_charge" charge_increment2="0.01*elementary_charge"/>
+    <ChargeIncrement smirks="[C:1][C:2][O:3]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge"/>
+  </ChargeIncrementModel>
+</SMIRNOFF>"""
+
+xml_charge_increment_model_ff_one_less_ci = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
+  <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
+    <ChargeIncrement smirks="[#6X4:1]-[#8:2]" charge_increment1="-0.06*elementary_charge" charge_increment2="0.06*elementary_charge"/>
+    <ChargeIncrement smirks="[#6X4:1]-[#1:2]" charge_increment1="-0.01*elementary_charge"/>
+    <ChargeIncrement smirks="[C:1][C:2][O:3]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.1*elementary_charge"/>
+  </ChargeIncrementModel>
+</SMIRNOFF>"""
+
+xml_charge_increment_model_ff_ethanol = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
+  <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
+    <ChargeIncrement smirks="[#6X4:1]-[#8:2]" charge_increment1="-0.05*elementary_charge" charge_increment2="0.05*elementary_charge"/>
+    <ChargeIncrement smirks="[C:1][C:2][O:3]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge"/>
+  </ChargeIncrementModel>
+</SMIRNOFF>"""
+
+xml_charge_increment_model_ff_net_charge = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
+  <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
+    <ChargeIncrement smirks="[#6X3:1]-[#8X1-1:2]" charge_increment1="-0.05*elementary_charge" charge_increment2="0.05*elementary_charge"/>
+    <ChargeIncrement smirks="[#6X3:1]=[#8X1:2]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.2*elementary_charge"/>
+  </ChargeIncrementModel>
+</SMIRNOFF>"""
+
+xml_charge_increment_model_ff_override = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
+  <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
+    <ChargeIncrement smirks="[#1:1]-[#6:2]([#1:3])([#1:4])" charge_increment1="0.123*elementary_charge" charge_increment2="0.369*elementary_charge" charge_increment3="-0.123*elementary_charge" charge_increment4="0.123*elementary_charge"/>
+    <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])([#1:4])" charge_increment1="0.3*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge" charge_increment4="-0.1*elementary_charge"/>
+  </ChargeIncrementModel>
+</SMIRNOFF>"""
+
+xml_charge_increment_model_ff_both_apply = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
+  <ChargeIncrementModel version="0.3" number_of_conformers="0" partial_charge_method="formal_charge">
+    <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])([#1:4])" charge_increment1="0.3*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge" charge_increment4="-0.1*elementary_charge"/>
+    <ChargeIncrement smirks="[#6X4:1][#6X4:2][#8]" charge_increment1="0.05*elementary_charge" charge_increment2="-0.05*elementary_charge"/>
+  </ChargeIncrementModel>
+</SMIRNOFF>"""
+
+xml_charge_increment_model_ff_match_once = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
+  <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
+    <ChargeIncrement smirks="[#6X4:1]([#1:2])[#6][#8]" charge_increment1="0.1*elementary_charge" charge_increment2="-0.1*elementary_charge"/>
+  </ChargeIncrementModel>
+</SMIRNOFF>"""
+
+xml_charge_increment_model_ff_match_two = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
+  <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
+    <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])[#6][#8]" charge_increment1="0.1*elementary_charge" charge_increment2="-0.05*elementary_charge" charge_increment3="-0.05*elementary_charge"/>
+  </ChargeIncrementModel>
+</SMIRNOFF>"""
+
+xml_charge_increment_model_ff_match_all = """
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+  <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
+  <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
+    <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])([#1:4])" charge_increment1="0.3*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge" charge_increment4="-0.1*elementary_charge"/>
+  </ChargeIncrementModel>
+</SMIRNOFF>"""
+
+xml_ff_virtual_sites_bondcharge_match_once = """<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
+      <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
+    </Bonds>
+    <VirtualSites version="0.3">
+        <VirtualSite
+            type="BondCharge"
+            name="EP"
+            smirks="[*:1]~[*:2]"
+            distance="0.1*angstrom"
+            charge_increment1="0.1*elementary_charge"
+            charge_increment2="0.1*elementary_charge"
+            sigma="0.1*angstrom"
+            epsilon="0.1*kilocalories_per_mole"
+            match="once" >
+        </VirtualSite>
+        <VirtualSite
+            type="BondCharge"
+            name="EP"
+            smirks="[#7:1]~[#7:2]"
+            distance="0.2*angstrom"
+            charge_increment1="0.2*elementary_charge"
+            charge_increment2="0.2*elementary_charge"
+            sigma="0.2*angstrom"
+            epsilon="0.2*kilocalories_per_mole"
+            match="all_permutations" >
+        </VirtualSite>
+        <VirtualSite
+            type="BondCharge"
+            name="EP"
+            smirks="[#7:1]~[#7:2]"
+            distance="0.2*nanometers"
+            charge_increment1="0.2*elementary_charge"
+            charge_increment2="0.2*elementary_charge"
+            sigma="0.2*angstrom"
+            epsilon="0.2*kilocalories_per_mole"
+            match="once" >
+        </VirtualSite>
+    </VirtualSites>
+</SMIRNOFF>
+"""
+
+xml_ff_virtual_sites_bondcharge_match_all = """<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
+      <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
+    </Bonds>
+    <VirtualSites version="0.3">
+        <VirtualSite
+            type="BondCharge"
+            name="EP"
+            smirks="[*:1]~[*:2]"
+            distance="0.1*angstrom"
+            charge_increment1="0.1*elementary_charge"
+            charge_increment2="0.1*elementary_charge"
+            sigma="0.1*angstrom"
+            epsilon="0.1*kilocalories_per_mole"
+            match="once" >
+        </VirtualSite>
+        <VirtualSite
+            type="BondCharge"
+            name="EP"
+            smirks="[#7:1]~[#7:2]"
+            distance="0.2*angstrom"
+            charge_increment1="0.2*elementary_charge"
+            charge_increment2="0.2*elementary_charge"
+            sigma="0.2*angstrom"
+            epsilon="0.2*kilocalories_per_mole"
+            match="once" >
+        </VirtualSite>
+        <VirtualSite
+            type="BondCharge"
+            name="EP"
+            smirks="[#7:1]~[#7:2]"
+            distance="0.2*angstrom"
+            charge_increment1="0.2*elementary_charge"
+            charge_increment2="0.2*elementary_charge"
+            sigma="0.2*angstrom"
+            epsilon="0.2*kilocalories_per_mole"
+            match="all_permutations" >
+        </VirtualSite>
+    </VirtualSites>
+</SMIRNOFF>
+"""
+
+xml_ff_virtual_sites_bondcharge_match_once_two_names = """<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
+      <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
+    </Bonds>
+    <VirtualSites version="0.3">
+        <VirtualSite
+            type="BondCharge"
+            name="EP1"
+            smirks="[*:1]~[*:2]"
+            distance="0.1*angstrom"
+            charge_increment1="0.1*elementary_charge"
+            charge_increment2="0.1*elementary_charge"
+            sigma="0.1*angstrom"
+            epsilon="0.1*kilocalories_per_mole"
+            match="once" >
+        </VirtualSite>
+        <VirtualSite
+            type="BondCharge"
+            name="EP2"
+            smirks="[*:1]~[*:2]"
+            distance="0.2*angstrom"
+            charge_increment1="0.2*elementary_charge"
+            charge_increment2="0.2*elementary_charge"
+            sigma="0.2*angstrom"
+            epsilon="0.2*kilocalories_per_mole"
+            match="once" >
+        </VirtualSite>
+    </VirtualSites>
+</SMIRNOFF>
+"""
+
+xml_ff_virtual_sites_monovalent_match_once = """<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
+      <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
+    </Bonds>
+    <VirtualSites version="0.3">
+        <VirtualSite
+            type="MonovalentLonePair"
+            name="EP"
+            smirks="[#8:1]~[#6:2]~[#6:3]"
+            distance="0.1*angstrom"
+            charge_increment1="0.1*elementary_charge"
+            charge_increment2="0.1*elementary_charge"
+            charge_increment3="0.1*elementary_charge"
+            sigma="0.1*angstrom"
+            epsilon="0.1*kilocalories_per_mole"
+            inPlaneAngle="110.*degree"
+            outOfPlaneAngle="41*degree"
+            match="once" >
+        </VirtualSite>
+        <VirtualSite
+            type="MonovalentLonePair"
+            name="EP"
+            smirks="[#8:1]=[#6:2]-[#6:3]"
+            distance="0.2*angstrom"
+            charge_increment1="0.2*elementary_charge"
+            charge_increment2="0.2*elementary_charge"
+            charge_increment3="0.2*elementary_charge"
+            sigma="0.2*angstrom"
+            epsilon="0.2*kilocalories_per_mole"
+            inPlaneAngle="120.*degree"
+            outOfPlaneAngle="42*degree"
+            match="once" >
+        </VirtualSite>
+    </VirtualSites>
+</SMIRNOFF>
+"""
+
+xml_ff_virtual_sites_divalent_match_all = """<?xml version="1.0" encoding="ASCII"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
+      <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
+    </Bonds>
+    <VirtualSites version="0.3">
+        <VirtualSite
+            type="DivalentLonePair"
+            name="EP"
+            smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]"
+            distance="0.70 * angstrom"
+            charge_increment1="0.241*elementary_charge"
+            charge_increment2="0.0*elementary_charge"
+            charge_increment3="0.241*elementary_charge"
+            sigma="3.12*angstrom"
+            epsilon="0.16*kilocalories_per_mole"
+            outOfPlaneAngle="54.71384225*degree"
+            match="all_permutations" >
+        </VirtualSite>
+    </VirtualSites>
+</SMIRNOFF>
+"""
+
+xml_ff_virtual_sites_trivalent_match_once = """<?xml version="1.0" encoding="ASCII"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
+      <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
+    </Bonds>
+    <VirtualSites version="0.3">
+        <VirtualSite
+            type="TrivalentLonePair"
+            name="EP"
+            smirks="[*:1]-[#7X3:2](-[*:3])-[*:4]"
+            distance="0.50 * angstrom"
+            charge_increment1="0.0*elementary_charge"
+            charge_increment2="1.0*elementary_charge"
+            charge_increment3="0.0*elementary_charge"
+            charge_increment4="0.0*elementary_charge"
+            sigma="0.0*angstrom"
+            epsilon="0.0*kilocalories_per_mole"
+            match="once" >
+        </VirtualSite>
+    </VirtualSites>
+</SMIRNOFF>
+"""
+
+xml_ff_virtual_sites_trivalent_match_all = """
+<?xml version="1.0" encoding="ASCII"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
+      <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
+    </Bonds>
+    <VirtualSites version="0.3">
+        <VirtualSite
+            type="TrivalentLonePair"
+            name="EP"
+            smirks="[*:1]-[#7X3:2]-([*:3])-[*:4]"
+            distance="0.70 * angstrom"
+            charge_increment1="0.1*elementary_charge"
+            charge_increment2="0.1*elementary_charge"
+            charge_increment3="0.1*elementary_charge"
+            charge_increment4="0.1*elementary_charge"
+            sigma="0.1*angstrom"
+            epsilon="0.1*kilocalories_per_mole"
+            match="once" >
+        </VirtualSite>
+    </VirtualSites>
+</SMIRNOFF>
+"""
+
 
 # ======================================================================
 # TEST UTILITY FUNCTIONS
@@ -677,7 +1036,7 @@ class TestForceField:
         forcefield = ForceField(iter(urls))
 
     def test_create_forcefield_from_xml_string(self):
-        forcefield = ForceField(simple_xml_ff)
+        forcefield = ForceField(xml_simple_ff)
         assert len(forcefield._parameter_handlers["Bonds"]._parameters) == 3
         assert len(forcefield._parameter_handlers["Angles"]._parameters) == 2
         assert len(forcefield._parameter_handlers["ProperTorsions"]._parameters) == 3
@@ -715,7 +1074,7 @@ class TestForceField:
         """
         import pickle
 
-        forcefield_1 = ForceField(simple_xml_ff)
+        forcefield_1 = ForceField(xml_simple_ff)
         pickled = pickle.dumps(forcefield_1)
         forcefield_2 = pickle.loads(pickled)
         assert forcefield_1.to_string() == forcefield_2.to_string()
@@ -739,7 +1098,7 @@ class TestForceField:
         """
         Test writing a ForceField to an XML string
         """
-        forcefield_1 = ForceField(simple_xml_ff)
+        forcefield_1 = ForceField(xml_simple_ff)
         string_1 = forcefield_1.to_string("XML")
         forcefield_2 = ForceField(string_1)
         string_2 = forcefield_2.to_string("XML")
@@ -822,7 +1181,7 @@ class TestForceField:
         # These files will be deleted once garbage collection runs (end of this function)
         iofile1 = NamedTemporaryFile(suffix="." + file_path_extension)
         iofile2 = NamedTemporaryFile(suffix="." + file_path_extension)
-        forcefield_1 = ForceField(simple_xml_ff)
+        forcefield_1 = ForceField(xml_simple_ff)
         forcefield_1.to_file(iofile1.name, io_format=specified_format)
         forcefield_2 = ForceField(iofile1.name)
         forcefield_2.to_file(iofile2.name, io_format=specified_format)
@@ -908,18 +1267,13 @@ class TestForceField:
             match="Missing version while trying to construct "
             "<class 'openff.toolkit.typing.engines."
             "smirnoff.parameters.ToolkitAM1BCCHandler'>.",
-        ) as excinfo:
-            ff = ForceField(
-                '<?xml version="1.0" encoding="ASCII"?>'
-                '<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">'
-                "  <ToolkitAM1BCC/>"
-                "</SMIRNOFF>"
-            )
+        ):
+            ForceField(xml_without_section_version)
 
     def test_load_two_sources(self):
         """Test loading data from two SMIRNOFF data sources"""
         ff = ForceField(
-            simple_xml_ff, xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True
+            xml_simple_ff, xml_ff_w_cosmetic_elements, allow_cosmetic_attributes=True
         )
         assert len(ff.get_parameter_handler("Bonds").parameters) == 5
 
@@ -960,28 +1314,21 @@ class TestForceField:
 
     def test_load_two_sources_incompatible_tags(self):
         """Test loading data from two SMIRNOFF data sources which have incompatible physics"""
-        # Make an XML force field with a modifiedvdW 1-4 scaling factor
+        # Make an XML force field with a modified vdW 1-4 scaling factor
         nonstandard_xml_ff = xml_ff_w_comments.replace('scale14="0.5"', 'scale14="1.0"')
         with pytest.raises(
             IncompatibleParameterError,
             match="handler value: 0.5, incompatible value: 1.0",
-        ) as excinfo:
-            ff = ForceField(simple_xml_ff, nonstandard_xml_ff)
+        ):
+            ForceField(xml_simple_ff, nonstandard_xml_ff)
 
     def test_gbsahandler_sa_model_none(self):
         """
         Ensure that string values of "None" are correctly interpreted in the GBSAHandler's sa_model field
         """
-        gbsa_ff_xml = """<?xml version='1.0' encoding='ASCII'?>
-<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-    <GBSA version="0.3" gb_model="HCT" solvent_dielectric="78.5" solute_dielectric="1" sa_model="None" surface_area_penalty="5.4*calories/mole/angstroms**2" solvent_radius="1.4*angstroms">
-          <Atom smirks="[*:1]" radius="0.15*nanometer" scale="0.8"/>
-    </GBSA>
-</SMIRNOFF>
-"""
         from openff.toolkit.typing.engines.smirnoff import ForceField
 
-        ff = ForceField(gbsa_ff_xml)
+        ForceField(xml_gbsa_ff)
 
     @pytest.mark.parametrize(
         "toolkit_registry,registry_description", toolkit_registries
@@ -1057,15 +1404,7 @@ class TestForceField:
             UnassignedProperTorsionParameterException,
         )
 
-        forcefield = ForceField(
-            """
-<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-  <ProperTorsions version="0.3" potential="k*(1+cos(periodicity*theta-phase))">
-    <Proper smirks="[#99:1]-[#99X4:2]-[#99:3]-[#99:4]" id="t1" idivf1="1" k1="0.156 * kilocalories_per_mole" periodicity1="3" phase1="0.0 * degree"/>
-  </ProperTorsions>
-</SMIRNOFF>
-"""
-        )
+        forcefield = ForceField(xml_missing_torsion)
         pdbfile = app.PDBFile(get_data_file_path("systems/test_systems/1_ethanol.pdb"))
         molecules = [create_ethanol()]
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
@@ -1073,8 +1412,8 @@ class TestForceField:
             UnassignedProperTorsionParameterException,
             match="- Topology indices [(]5, 0, 1, 6[)]: "
             r"names and elements [(](H\d+)? H[)], [(](C\d+)? C[)], [(](C\d+)? C[)], [(](H\d+)? H[)],",
-        ) as excinfo:
-            omm_system = forcefield.create_openmm_system(topology)
+        ):
+            forcefield.create_openmm_system(topology)
 
     @pytest.mark.parametrize(
         "toolkit_registry,registry_description", toolkit_registries
@@ -1575,7 +1914,7 @@ class TestForceField:
     )
     def test_deregister_parameter_handler(self, to_deregister):
         """Ensure that ForceField.deregister_parameter_handler behaves correctly"""
-        ff = ForceField(simple_xml_ff)
+        ff = ForceField(xml_simple_ff)
         # Make sure the handler is present in the test force field
         handler_found = False
         for handler in ff._parameter_handlers.values():
@@ -1661,233 +2000,6 @@ trivalent_parameters_args = []
 
 
 class TestForceFieldVirtualSites:
-
-    xml_ff_virtual_sites_bondcharge_match_once = """<?xml version="1.0" encoding="utf-8"?>
-    <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-        <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
-          <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
-        </Bonds>
-        <VirtualSites version="0.3">
-            <VirtualSite
-                type="BondCharge"
-                name="EP"
-                smirks="[*:1]~[*:2]"
-                distance="0.1*angstrom"
-                charge_increment1="0.1*elementary_charge"
-                charge_increment2="0.1*elementary_charge"
-                sigma="0.1*angstrom"
-                epsilon="0.1*kilocalories_per_mole"
-                match="once" >
-            </VirtualSite>
-            <VirtualSite
-                type="BondCharge"
-                name="EP"
-                smirks="[#7:1]~[#7:2]"
-                distance="0.2*angstrom"
-                charge_increment1="0.2*elementary_charge"
-                charge_increment2="0.2*elementary_charge"
-                sigma="0.2*angstrom"
-                epsilon="0.2*kilocalories_per_mole"
-                match="all_permutations" >
-            </VirtualSite>
-            <VirtualSite
-                type="BondCharge"
-                name="EP"
-                smirks="[#7:1]~[#7:2]"
-                distance="0.2*nanometers"
-                charge_increment1="0.2*elementary_charge"
-                charge_increment2="0.2*elementary_charge"
-                sigma="0.2*angstrom"
-                epsilon="0.2*kilocalories_per_mole"
-                match="once" >
-            </VirtualSite>
-        </VirtualSites>
-    </SMIRNOFF>
-    """
-
-    xml_ff_virtual_sites_bondcharge_match_all = """<?xml version="1.0" encoding="utf-8"?>
-    <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-        <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
-          <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
-        </Bonds>
-        <VirtualSites version="0.3">
-            <VirtualSite
-                type="BondCharge"
-                name="EP"
-                smirks="[*:1]~[*:2]"
-                distance="0.1*angstrom"
-                charge_increment1="0.1*elementary_charge"
-                charge_increment2="0.1*elementary_charge"
-                sigma="0.1*angstrom"
-                epsilon="0.1*kilocalories_per_mole"
-                match="once" >
-            </VirtualSite>
-            <VirtualSite
-                type="BondCharge"
-                name="EP"
-                smirks="[#7:1]~[#7:2]"
-                distance="0.2*angstrom"
-                charge_increment1="0.2*elementary_charge"
-                charge_increment2="0.2*elementary_charge"
-                sigma="0.2*angstrom"
-                epsilon="0.2*kilocalories_per_mole"
-                match="once" >
-            </VirtualSite>
-            <VirtualSite
-                type="BondCharge"
-                name="EP"
-                smirks="[#7:1]~[#7:2]"
-                distance="0.2*angstrom"
-                charge_increment1="0.2*elementary_charge"
-                charge_increment2="0.2*elementary_charge"
-                sigma="0.2*angstrom"
-                epsilon="0.2*kilocalories_per_mole"
-                match="all_permutations" >
-            </VirtualSite>
-        </VirtualSites>
-    </SMIRNOFF>
-    """
-
-    xml_ff_virtual_sites_bondcharge_match_once_two_names = """<?xml version="1.0" encoding="utf-8"?>
-    <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-        <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
-          <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
-        </Bonds>
-        <VirtualSites version="0.3">
-            <VirtualSite
-                type="BondCharge"
-                name="EP1"
-                smirks="[*:1]~[*:2]"
-                distance="0.1*angstrom"
-                charge_increment1="0.1*elementary_charge"
-                charge_increment2="0.1*elementary_charge"
-                sigma="0.1*angstrom"
-                epsilon="0.1*kilocalories_per_mole"
-                match="once" >
-            </VirtualSite>
-            <VirtualSite
-                type="BondCharge"
-                name="EP2"
-                smirks="[*:1]~[*:2]"
-                distance="0.2*angstrom"
-                charge_increment1="0.2*elementary_charge"
-                charge_increment2="0.2*elementary_charge"
-                sigma="0.2*angstrom"
-                epsilon="0.2*kilocalories_per_mole"
-                match="once" >
-            </VirtualSite>
-        </VirtualSites>
-    </SMIRNOFF>
-    """
-
-    xml_ff_virtual_sites_monovalent_match_once = """<?xml version="1.0" encoding="utf-8"?>
-    <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-        <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
-          <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
-        </Bonds>
-        <VirtualSites version="0.3">
-            <VirtualSite
-                type="MonovalentLonePair"
-                name="EP"
-                smirks="[#8:1]~[#6:2]~[#6:3]"
-                distance="0.1*angstrom"
-                charge_increment1="0.1*elementary_charge"
-                charge_increment2="0.1*elementary_charge"
-                charge_increment3="0.1*elementary_charge"
-                sigma="0.1*angstrom"
-                epsilon="0.1*kilocalories_per_mole"
-                inPlaneAngle="110.*degree"
-                outOfPlaneAngle="41*degree"
-                match="once" >
-            </VirtualSite>
-            <VirtualSite
-                type="MonovalentLonePair"
-                name="EP"
-                smirks="[#8:1]=[#6:2]-[#6:3]"
-                distance="0.2*angstrom"
-                charge_increment1="0.2*elementary_charge"
-                charge_increment2="0.2*elementary_charge"
-                charge_increment3="0.2*elementary_charge"
-                sigma="0.2*angstrom"
-                epsilon="0.2*kilocalories_per_mole"
-                inPlaneAngle="120.*degree"
-                outOfPlaneAngle="42*degree"
-                match="once" >
-            </VirtualSite>
-        </VirtualSites>
-    </SMIRNOFF>
-    """
-
-    xml_ff_virtual_sites_divalent_match_all = """<?xml version="1.0" encoding="ASCII"?>
-    <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-        <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
-          <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
-        </Bonds>
-        <VirtualSites version="0.3">
-            <VirtualSite
-                type="DivalentLonePair"
-                name="EP"
-                smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]"
-                distance="0.70 * angstrom"
-                charge_increment1="0.241*elementary_charge"
-                charge_increment2="0.0*elementary_charge"
-                charge_increment3="0.241*elementary_charge"
-                sigma="3.12*angstrom"
-                epsilon="0.16*kilocalories_per_mole"
-                outOfPlaneAngle="54.71384225*degree"
-                match="all_permutations" >
-            </VirtualSite>
-        </VirtualSites>
-    </SMIRNOFF>
-    """
-
-    xml_ff_virtual_sites_trivalent_match_once = """<?xml version="1.0" encoding="ASCII"?>
-    <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-        <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
-          <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
-        </Bonds>
-        <VirtualSites version="0.3">
-            <VirtualSite
-                type="TrivalentLonePair"
-                name="EP"
-                smirks="[*:1]-[#7X3:2](-[*:3])-[*:4]"
-                distance="0.50 * angstrom"
-                charge_increment1="0.0*elementary_charge"
-                charge_increment2="1.0*elementary_charge"
-                charge_increment3="0.0*elementary_charge"
-                charge_increment4="0.0*elementary_charge"
-                sigma="0.0*angstrom"
-                epsilon="0.0*kilocalories_per_mole"
-                match="once" >
-            </VirtualSite>
-        </VirtualSites>
-    </SMIRNOFF>
-    """
-
-    xml_ff_virtual_sites_trivalent_match_all = """
-    <?xml version="1.0" encoding="ASCII"?>
-    <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-        <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
-          <Bond smirks="[*:1]~[*:2]" id="b999" k="500.0 * kilocalories_per_mole/angstrom**2" length="1.1 * angstrom"/>
-        </Bonds>
-        <VirtualSites version="0.3">
-            <VirtualSite
-                type="TrivalentLonePair"
-                name="EP"
-                smirks="[*:1]-[#7X3:2]-([*:3])-[*:4]"
-                distance="0.70 * angstrom"
-                charge_increment1="0.1*elementary_charge"
-                charge_increment2="0.1*elementary_charge"
-                charge_increment3="0.1*elementary_charge"
-                charge_increment4="0.1*elementary_charge"
-                sigma="0.1*angstrom"
-                epsilon="0.1*kilocalories_per_mole"
-                match="once" >
-            </VirtualSite>
-        </VirtualSites>
-    </SMIRNOFF>
-    """
-
     def _test_physical_parameters(self, tkr, xml, smi, assert_physics, mol=None):
 
         from simtk.openmm import NonbondedForce
@@ -2297,16 +2409,8 @@ class TestForceFieldChargeAssignment:
 
     def test_charge_increment_model_forward_and_reverse_ethanol(self):
         """Test application of ChargeIncrements to the same molecule with different orderings in the topology"""
-        test_charge_increment_model_ff = """
-        <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-          <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
-          <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
-            <ChargeIncrement smirks="[#6X4:1]-[#8:2]" charge_increment1="-0.05*elementary_charge" charge_increment2="0.05*elementary_charge"/>
-            <ChargeIncrement smirks="[C:1][C:2][O:3]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge"/>
-          </ChargeIncrementModel>
-        </SMIRNOFF>"""
         file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
-        ff = ForceField(file_path, test_charge_increment_model_ff)
+        ff = ForceField(file_path, xml_charge_increment_model_ff_ethanol)
         del ff._parameter_handlers["ToolkitAM1BCC"]
         top = Topology.from_molecules([create_ethanol(), create_reversed_ethanol()])
         sys = ff.create_openmm_system(top)
@@ -2345,29 +2449,11 @@ class TestForceFieldChargeAssignment:
         than tagged atom. We test this by making two equivalent (one with fully explicit CIs, the other with some
         implicit CIa) FFs and ensuring that both perform the same parameterization.
         """
-        test_charge_increment_model_ff_no_missing_cis = """
-        <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-          <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
-          <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
-            <ChargeIncrement smirks="[#6X4:1]-[#8:2]" charge_increment1="-0.06*elementary_charge" charge_increment2="0.06*elementary_charge"/>
-            <ChargeIncrement smirks="[#6X4:1]-[#1:2]" charge_increment1="-0.01*elementary_charge" charge_increment2="0.01*elementary_charge"/>
-            <ChargeIncrement smirks="[C:1][C:2][O:3]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge"/>
-          </ChargeIncrementModel>
-        </SMIRNOFF>"""
-        test_charge_increment_model_ff_one_less_ci = """
-        <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-          <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
-          <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
-            <ChargeIncrement smirks="[#6X4:1]-[#8:2]" charge_increment1="-0.06*elementary_charge" charge_increment2="0.06*elementary_charge"/>
-            <ChargeIncrement smirks="[#6X4:1]-[#1:2]" charge_increment1="-0.01*elementary_charge"/>
-            <ChargeIncrement smirks="[C:1][C:2][O:3]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.1*elementary_charge"/>
-          </ChargeIncrementModel>
-        </SMIRNOFF>"""
         # Make a FF from each OFFXML string
         file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
-        ff1 = ForceField(file_path, test_charge_increment_model_ff_one_less_ci)
+        ff1 = ForceField(file_path, xml_charge_increment_model_ff_one_less_ci)
         del ff1._parameter_handlers["ToolkitAM1BCC"]
-        ff2 = ForceField(file_path, test_charge_increment_model_ff_no_missing_cis)
+        ff2 = ForceField(file_path, xml_charge_increment_model_ff_no_missing_cis)
         del ff2._parameter_handlers["ToolkitAM1BCC"]
         top = Topology.from_molecules([create_ethanol()])
         # Make a system from each FF
@@ -2455,16 +2541,8 @@ class TestForceFieldChargeAssignment:
         """Test application of charge increments on a molecule with a net charge"""
         from simtk import unit
 
-        test_charge_increment_model_ff = """
-        <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-          <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
-          <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
-            <ChargeIncrement smirks="[#6X3:1]-[#8X1-1:2]" charge_increment1="-0.05*elementary_charge" charge_increment2="0.05*elementary_charge"/>
-            <ChargeIncrement smirks="[#6X3:1]=[#8X1:2]" charge_increment1="0.2*elementary_charge" charge_increment2="-0.2*elementary_charge"/>
-          </ChargeIncrementModel>
-        </SMIRNOFF>"""
         file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
-        ff = ForceField(file_path, test_charge_increment_model_ff)
+        ff = ForceField(file_path, xml_charge_increment_model_ff_net_charge)
         del ff._parameter_handlers["ToolkitAM1BCC"]
 
         acetate = create_acetate()
@@ -2487,17 +2565,10 @@ class TestForceFieldChargeAssignment:
         ethanol = create_ethanol()
         top = ethanol.to_topology()
 
+        file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
         # Test a charge increment that matches all C-H bonds at once
         # (this should be applied once: C0-H3-H4-H5)
-        test_charge_increment_model_ff = """
-        <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-          <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
-          <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
-            <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])([#1:4])" charge_increment1="0.3*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge" charge_increment4="-0.1*elementary_charge"/>
-          </ChargeIncrementModel>
-        </SMIRNOFF>"""
-        file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
-        ff = ForceField(file_path, test_charge_increment_model_ff)
+        ff = ForceField(file_path, xml_charge_increment_model_ff_match_all)
         del ff._parameter_handlers["ToolkitAM1BCC"]
 
         sys = ff.create_openmm_system(top)
@@ -2523,15 +2594,7 @@ class TestForceFieldChargeAssignment:
 
         # Test a charge increment that matches two C-H bonds at a time
         # (this should be applied 3 times: C0-H3-H4, C0-H3-H5, C0-H4-H5)
-        test_charge_increment_model_ff = """
-        <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-          <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
-          <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
-            <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])[#6][#8]" charge_increment1="0.1*elementary_charge" charge_increment2="-0.05*elementary_charge" charge_increment3="-0.05*elementary_charge"/>
-          </ChargeIncrementModel>
-        </SMIRNOFF>"""
-        file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
-        ff = ForceField(file_path, test_charge_increment_model_ff)
+        ff = ForceField(file_path, xml_charge_increment_model_ff_match_two)
         del ff._parameter_handlers["ToolkitAM1BCC"]
 
         sys = ff.create_openmm_system(top)
@@ -2557,15 +2620,7 @@ class TestForceFieldChargeAssignment:
 
         # Test a charge increment that matches ONE C-H bond at a time
         # (this should be applied three times: C0-H3, C0-H4, C0-H5)
-        test_charge_increment_model_ff = """
-        <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-          <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
-          <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
-            <ChargeIncrement smirks="[#6X4:1]([#1:2])[#6][#8]" charge_increment1="0.1*elementary_charge" charge_increment2="-0.1*elementary_charge"/>
-          </ChargeIncrementModel>
-        </SMIRNOFF>"""
-        file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
-        ff = ForceField(file_path, test_charge_increment_model_ff)
+        ff = ForceField(file_path, xml_charge_increment_model_ff_match_once)
         del ff._parameter_handlers["ToolkitAM1BCC"]
 
         sys = ff.create_openmm_system(top)
@@ -2594,16 +2649,8 @@ class TestForceFieldChargeAssignment:
         same atoms, regardless of order"""
         from simtk import unit
 
-        test_charge_increment_model_ff = """
-        <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-          <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
-          <ChargeIncrementModel version="0.3" number_of_conformers="1" partial_charge_method="formal_charge">
-            <ChargeIncrement smirks="[#1:1]-[#6:2]([#1:3])([#1:4])" charge_increment1="0.123*elementary_charge" charge_increment2="0.369*elementary_charge" charge_increment3="-0.123*elementary_charge" charge_increment4="0.123*elementary_charge"/>
-            <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])([#1:4])" charge_increment1="0.3*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge" charge_increment4="-0.1*elementary_charge"/>
-          </ChargeIncrementModel>
-        </SMIRNOFF>"""
         file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
-        ff = ForceField(file_path, test_charge_increment_model_ff)
+        ff = ForceField(file_path, xml_charge_increment_model_ff_override)
         del ff._parameter_handlers["ToolkitAM1BCC"]
 
         ethanol = create_ethanol()
@@ -2634,16 +2681,8 @@ class TestForceFieldChargeAssignment:
         a partially-overlapping set of atoms"""
         from simtk import unit
 
-        test_charge_increment_model_ff = """
-        <SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-          <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" cutoff="9.0 * angstrom"/>
-          <ChargeIncrementModel version="0.3" number_of_conformers="0" partial_charge_method="formal_charge">
-            <ChargeIncrement smirks="[#6X4:1]([#1:2])([#1:3])([#1:4])" charge_increment1="0.3*elementary_charge" charge_increment2="-0.1*elementary_charge" charge_increment3="-0.1*elementary_charge" charge_increment4="-0.1*elementary_charge"/>
-            <ChargeIncrement smirks="[#6X4:1][#6X4:2][#8]" charge_increment1="0.05*elementary_charge" charge_increment2="-0.05*elementary_charge"/>
-          </ChargeIncrementModel>
-        </SMIRNOFF>"""
         file_path = get_data_file_path("test_forcefields/test_forcefield.offxml")
-        ff = ForceField(file_path, test_charge_increment_model_ff)
+        ff = ForceField(file_path, xml_charge_increment_model_ff_both_apply)
         del ff._parameter_handlers["ToolkitAM1BCC"]
 
         ethanol = create_ethanol()
@@ -3738,48 +3777,9 @@ class TestForceFieldParameterAssignment:
         )
 
     def test_tip5p_dimer_energy(self):
-        """ """
-
-        tip5p_offxml = """<?xml version="1.0" encoding="utf-8"?>
-<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
-    <LibraryCharges version="0.3">
-            <LibraryCharge name="tip5p" smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]" charge1="0.*elementary_charge" charge2="0.*elementary_charge" charge3="0.*elementary_charge"/>
-    </LibraryCharges>
-    <vdW version="0.3" potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" switch_width="1.0 * angstrom" cutoff="9.0 * angstrom" method="cutoff">
-            <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" epsilon="0. * mole**-1 * kilojoule" id="n35" sigma="1 * nanometer"/>
-            <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" epsilon="0.66944 * mole**-1 * kilojoule" id="n35" sigma="0.312 * nanometer"/>
-    </vdW>
-     <Bonds version="0.3" potential="harmonic" fractional_bondorder_method="AM1-Wiberg" fractional_bondorder_interpolation="linear">
-        <Bond smirks="[#1:1]-[#8X2H2+0:2]-[#1]" length="0.9572 * angstrom" k="462750.4 * nanometer**-2 * mole**-1 * kilojoule" id="b1" />   
-    </Bonds>
-    <Angles version="0.3" potential="harmonic">
-        <Angle smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]" angle="1.82421813418 * radian" k="836.8 * mole**-1 * radian**-2 * kilojoule" id="a1" />
-    </Angles>
-    <VirtualSites version="0.3" exclusion_policy="parents">
-        <VirtualSite
-            type="DivalentLonePair"
-            name="EP"
-            smirks="[#1:1]-[#8X2H2+0:2]-[#1:3]"
-            distance="0.70 * angstrom"
-            charge_increment1="0.1205*elementary_charge"
-            charge_increment2="0.0*elementary_charge"
-            charge_increment3="0.1205*elementary_charge"
-            sigma="1.0*angstrom"
-            epsilon="0.0*kilocalories_per_mole"
-            outOfPlaneAngle="54.71384225*degree"
-            match="all_permutations" >
-        </VirtualSite>
-    </VirtualSites>
-    <Electrostatics version="0.3" method="PME" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0" switch_width="0.0 * angstrom" cutoff="9.0 * angstrom"/>
-  <Constraints version="0.3">
-    <Constraint smirks="[#1:1]-[#8X2H2+0:2]-[#1]" id="c1" distance="0.9572 * angstrom"/>
-    <Constraint smirks="[#1:1]-[#8X2H2+0]-[#1:2]" id="c2" distance="1.5139006545247014 * angstrom"/>
-  </Constraints>
-</SMIRNOFF>
-"""
         from openff.toolkit.tests.utils import evaluate_molecules_off
 
-        off_ff = ForceField("test_forcefields/test_forcefield.offxml", tip5p_offxml)
+        off_ff = ForceField("test_forcefields/test_forcefield.offxml", xml_tip5p)
 
         molecule1 = create_water()
         molecule1.atoms[0].name = "O"


### PR DESCRIPTION
I am building tests off of the existing test suite and have found that the location of XML snippets is at best not consistent and at worst not import-able. Those defined at the module level are importable, as are those in classes (albeit with an extra step). Those defined inside of functions cannot be imported, as far as I know.

I moved everything to the module level, which decreases readability but adds uniformity and import-ability and the ability to keep things in sync across projects. (On that basis, there might be a better place to put this, like some test-facing data repo. Dumping everything here is fine, I think.). The major benefit is that when I write a test depending on i.e. a TIP5P XML snippet, I don't have to copy code, so there are no duplicates to keep in sync.

Everything passes locally and I also ran slow tests. This isn't really an API break since the test module isn't a part of the public API; I'm probably the only person that would be importing these things now. The diff and git history are/will be ugly, but squash-merging should make the history traversable enough to dig into the past.

Another approach might be to move each snippet into its own file, but that would be something like 20-30 files to track around. The readability is not much different either way, I don't think; it's content being in a different file or in a different location in the file.


-  [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
