### PR TITLE
Lazy load networkx

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -3058,6 +3058,8 @@ class FrozenMolecule(Serializable):
         # Here we should work out what data type we have, also deal with lists?
         def to_networkx(data):
             """For the given data type, return the networkx graph"""
+            import networkx as nx
+
             from openff.toolkit.topology import TopologyMolecule
 
             if strip_pyrimidal_n_atom_stereo:
@@ -3082,18 +3084,8 @@ class FrozenMolecule(Serializable):
                     )
                 return ref_mol.to_networkx()
 
-            elif data.__class__.__name__ == "Graph":
-                # Defer loading networkx (slow) until it's needed
-                import networkx as nx
-
-                # If the class is named "Graph", make sure it's a networkx.Graph
-                if isinstance(data, nx.Graph):
-                    return data
-                else:
-                    raise NotImplementedError(
-                        f"Found data type {type(data)} that is named 'Graph'"
-                        "but it not a networkx.Graph"
-                    )
+            elif isinstance(data, nx.Graph):
+                return data
 
             else:
                 raise NotImplementedError(

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -40,7 +40,6 @@ from collections import OrderedDict
 from copy import deepcopy
 from typing import Optional, Union
 
-import networkx as nx
 import numpy as np
 from simtk import unit
 from simtk.openmm.app import Element, element
@@ -3082,14 +3081,25 @@ class FrozenMolecule(Serializable):
                         SMARTS, toolkit_registry=toolkit_registry
                     )
                 return ref_mol.to_networkx()
-            elif isinstance(data, nx.Graph):
-                return data
+
+            elif data.__class__.__name__ == "Graph":
+                # Defer loading networkx (slow) until it's needed
+                import networkx as nx
+
+                # If the class is named "Graph", make sure it's a networkx.Graph
+                if isinstance(data, nx.Graph):
+                    return data
+                else:
+                    raise NotImplementedError(
+                        f"Found data type {type(data)} that is named 'Graph'"
+                        "but it not a networkx.Graph"
+                    )
 
             else:
                 raise NotImplementedError(
                     f"The input type {type(data)} is not supported,"
                     f"please supply an openff.toolkit.topology.molecule.Molecule,"
-                    f"openff.toolkit.topology.topology.TopologyMolecule or networkx "
+                    f"openff.toolkit.topology.topology.TopologyMolecule or networkx.Graph "
                     f"representation of the molecule."
                 )
 


### PR DESCRIPTION
Whenever `Molecule` is imported , `import networkx as nx` is also called, whether or not it is needed for functionality. It's one of the slower imports, so I lazy-loading it can save ~0.15 seconds of import time in what I presume is a significant number of our users' workflows.

Before:
![image](https://user-images.githubusercontent.com/7935382/123325529-bbf2d480-d4fd-11eb-832e-8ffd0621c673.png)

After:
![image](https://user-images.githubusercontent.com/7935382/123325576-ca40f080-d4fd-11eb-85a7-4667804f55e5.png)


- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
