### PR TITLE
[WIP] Fix atom ordering from_pdb_and_smiles and from_topology

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -4639,7 +4639,8 @@ class FrozenMolecule(Serializable):
         if topology.n_topology_molecules != 1:
             raise ValueError("Topology must contain exactly one molecule")
         molecule = [i for i in topology.reference_molecules][0]
-        return cls(molecule)
+        remapped_mol = molecule.remap(topology.topology_molecules[0]._ref_to_top_index)
+        return cls(remapped_mol)
 
     def to_topology(self):
         """

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -223,8 +223,8 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         # check isomorphic and get the mapping if true the mapping will be
         # Dict[pdb_index: offmol_index] sorted by pdb_index
         isomorphic, mapping = _cls.are_isomorphic(
-            pdbmol,
             offmol,
+            pdbmol,
             return_atom_map=True,
             aromatic_matching=False,
             formal_charge_matching=False,


### PR DESCRIPTION
- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)

```
from openff.toolkit.topology import Molecule

pdb_with_smiles = Molecule.from_pdb_and_smiles(
    "alanine_zw.pdb", 
    "C[C@H]([NH3+])C(=O)[O-]"
) 

#assert zw_l_alanine.is_isomorphic_with(pdb_with_smiles)

pdb_with_smiles.visualize(backend='nglview')
```

Current `master` branch scrambles the coordinates of the OFFMol that comes out of this. 

WIP because I still need to add tests. 

[alanine_zw.pdb.gz](https://github.com/openforcefield/openff-toolkit/files/6819415/alanine_zw.pdb.gz)
