### PR TITLE
Rename duplciate ParseError to SMILESParseError

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -78,7 +78,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   of the more significant fixes are:
   - RDKitToolkitWrapper's `from_file_obj()` now uses the same
     structure normaliation as `from_file()`.
-  - `from_smiles()` now raises an `openff.toolkit.utils.ParseError` if
+  - `from_smiles()` now raises an `openff.toolkit.utils.exceptions.SMILESParsingError` if
   the SMILES could not be parsed.
   - OEChem input and output files now raise an OSError if the file
   could not be opened.

--- a/openff/toolkit/tests/test_toolkit_io.py
+++ b/openff/toolkit/tests/test_toolkit_io.py
@@ -1156,7 +1156,7 @@ class BaseSmiles:
 
     def test_parse_bad_smiles(self):
         with pytest.raises(
-            exceptions.SMILESParsingError, match="Unable to parse the SMILES string"
+            exceptions.SMILESParseError, match="Unable to parse the SMILES string"
         ):
             mol = self.toolkit_wrapper.from_smiles("QWERT")
 

--- a/openff/toolkit/tests/test_toolkit_io.py
+++ b/openff/toolkit/tests/test_toolkit_io.py
@@ -1155,7 +1155,9 @@ class BaseSmiles:
         assert mol.n_bonds == 4
 
     def test_parse_bad_smiles(self):
-        with pytest.raises(ValueError, match="Unable to parse the SMILES string"):
+        with pytest.raises(
+            exceptions.SMILESParsingError, match="Unable to parse the SMILES string"
+        ):
             mol = self.toolkit_wrapper.from_smiles("QWERT")
 
     ### Copied from test_toolkits.py

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -15,7 +15,7 @@ __all__ = (
     "ChargeCalculationError",
     "InvalidIUPACNameError",
     "AntechamberNotFoundError",
-    "SMILESParsingError",
+    "SMILESParseError",
 )
 
 # =============================================================================================
@@ -111,5 +111,5 @@ class AntechamberNotFoundError(MessageException):
     """The antechamber executable was not found"""
 
 
-class SMILESParsingError(MessageException, ValueError):
+class SMILESParseError(MessageException, ValueError):
     """The record couple not be parsed into the given format"""

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -15,7 +15,7 @@ __all__ = (
     "ChargeCalculationError",
     "InvalidIUPACNameError",
     "AntechamberNotFoundError",
-    "ParseError",
+    "SMILESParsingError",
 )
 
 # =============================================================================================
@@ -111,5 +111,5 @@ class AntechamberNotFoundError(MessageException):
     """The antechamber executable was not found"""
 
 
-class ParseError(MessageException, ValueError):
+class SMILESParsingError(MessageException, ValueError):
     """The record couple not be parsed into the given format"""

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -33,7 +33,7 @@ from .exceptions import (
     GAFFAtomTypeWarning,
     InvalidIUPACNameError,
     LicenseError,
-    SMILESParsingError,
+    SMILESParseError,
     ToolkitUnavailableException,
     UndefinedStereochemistryError,
 )
@@ -1544,7 +1544,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         oemol = oechem.OEGraphMol()
         if not oechem.OESmilesToMol(oemol, smiles):
-            raise SMILESParsingError("Unable to parse the SMILES string")
+            raise SMILESParseError("Unable to parse the SMILES string")
         if not (hydrogens_are_explicit):
             result = oechem.OEAddExplicitHydrogens(oemol)
             if not result:

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -33,7 +33,7 @@ from .exceptions import (
     GAFFAtomTypeWarning,
     InvalidIUPACNameError,
     LicenseError,
-    ParseError,
+    SMILESParsingError,
     ToolkitUnavailableException,
     UndefinedStereochemistryError,
 )
@@ -1544,7 +1544,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         oemol = oechem.OEGraphMol()
         if not oechem.OESmilesToMol(oemol, smiles):
-            raise ParseError("Unable to parse the SMILES string")
+            raise SMILESParsingError("Unable to parse the SMILES string")
         if not (hydrogens_are_explicit):
             result = oechem.OEAddExplicitHydrogens(oemol)
             if not result:

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -26,7 +26,7 @@ from . import base_wrapper
 from .constants import DEFAULT_AROMATICITY_MODEL
 from .exceptions import (
     ChargeMethodUnavailableError,
-    SMILESParsingError,
+    SMILESParseError,
     ToolkitUnavailableException,
     UndefinedStereochemistryError,
 )
@@ -745,7 +745,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         rdmol = Chem.MolFromSmiles(smiles, sanitize=False)
         if rdmol is None:
-            raise SMILESParsingError("Unable to parse the SMILES string")
+            raise SMILESParseError("Unable to parse the SMILES string")
 
         # strip the atom map from the molecule if it has one
         # so we don't affect the sterochemistry tags

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -26,7 +26,7 @@ from . import base_wrapper
 from .constants import DEFAULT_AROMATICITY_MODEL
 from .exceptions import (
     ChargeMethodUnavailableError,
-    ParseError,
+    SMILESParsingError,
     ToolkitUnavailableException,
     UndefinedStereochemistryError,
 )
@@ -745,7 +745,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         rdmol = Chem.MolFromSmiles(smiles, sanitize=False)
         if rdmol is None:
-            raise ParseError("Unable to parse the SMILES string")
+            raise SMILESParsingError("Unable to parse the SMILES string")
 
         # strip the atom map from the molecule if it has one
         # so we don't affect the sterochemistry tags

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -45,7 +45,7 @@ __all__ = (
     "ChargeCalculationError",
     "InvalidIUPACNameError",
     "AntechamberNotFoundError",
-    "ParseError",
+    "SMILESParsingError",
     # base_wrapper
     "ToolkitWrapper",
     # builtin_wrapper
@@ -99,7 +99,7 @@ from .exceptions import (
     MessageException,
     MissingDependencyError,
     MissingPackageError,
-    ParseError,
+    SMILESParsingError,
     ToolkitUnavailableException,
     UndefinedStereochemistryError,
 )

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -45,7 +45,7 @@ __all__ = (
     "ChargeCalculationError",
     "InvalidIUPACNameError",
     "AntechamberNotFoundError",
-    "SMILESParsingError",
+    "SMILESParseError",
     # base_wrapper
     "ToolkitWrapper",
     # builtin_wrapper
@@ -99,7 +99,7 @@ from .exceptions import (
     MessageException,
     MissingDependencyError,
     MissingPackageError,
-    SMILESParsingError,
+    SMILESParseError,
     ToolkitUnavailableException,
     UndefinedStereochemistryError,
 )


### PR DESCRIPTION
See https://github.com/openforcefield/openff-toolkit/pull/1021#issuecomment-884258180 for context; in #1006 there was a `ParseError` added to `utils/exceptions.py` to handle failures in parsing SMILES strings in the toolkit wrappers. However, there's already a dedicated `ParseError` in the SMIRNOFF XML parsing code for handling failures there.

To fix this, in #1021 I moved them into their own exceptions, choosing to deprecating the SMIRNOFF `ParseError` and just remove the SMILES one. However, it would be much simpler to just prevent the SMILES one  from ever getting into a release, so I'm splitting this out from the other PR. **It would be great to sneak this into 0.10.0**, since it will prevent a soft API break from needing to take place in the following release. Again, since #1006 was merged after the previous release, this won't break any existing API.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
