### PR TITLE
Update version checks in CI

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -105,7 +105,7 @@ jobs:
           # Go up one directory to ensure that we don't just load the OFFTK from the checked-out repo
           cd ../
 
-          export LATEST_TAG=$(git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -E "([0-9]+)\.([0-9]+)\.([0-9]+)$" | tail -1 | sed 's/refs\/tags\///')
+          export LATEST_TAG=$(git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -E "([0-9]+)\.([0-9]+)\.([0-9]+)$" | sort --version-sort | tail -1 | sed 's/refs\/tags\///')
           export FOUND_VER=$(python -c "import openff.toolkit; print(openff.toolkit.__version__)")
 
           echo "Latest tag is"

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -49,7 +49,7 @@ jobs:
 
         # Find the tag of the last release (excluding RCs)
         # TODO: Make this a variable that can be passed through from trigger and/or allow RC
-        export LATEST_TAG=$(git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -v "rc" | tail -1 | sed 's/refs\/tags\///')
+          export LATEST_TAG=$(git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -E "([0-9]+)\.([0-9]+)\.([0-9]+)$" | sort --version-sort | tail -1 | sed 's/refs\/tags\///')
 
         echo $LATEST_TAG
 


### PR DESCRIPTION
The current "latest version finder" lines in our CI aren't sorting versions correctly (`0.10.0` appears next to `0.1.0` instead of after `0.9.2`)