### PR TITLE
Use mamba for CI checks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,6 +70,9 @@ jobs:
           activate-environment: test
           environment-file: devtools/conda-envs/test_env.yaml
           auto-activate-base: false
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
       - uses: conda-incubator/setup-miniconda@v2.1.1
         name: Install only RDKit
         if: ${{ matrix.cfg.rdkit == 'TRUE' && matrix.cfg.openeye == 'FALSE' }}
@@ -78,6 +81,9 @@ jobs:
           activate-environment: test
           environment-file: devtools/conda-envs/rdkit.yaml
           auto-activate-base: false
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
       - uses: conda-incubator/setup-miniconda@v2.1.1
         name: Install with OpenEye toolkits
         if: ${{ matrix.cfg.rdkit == 'FALSE' && matrix.cfg.openeye == 'TRUE' }}
@@ -86,6 +92,9 @@ jobs:
           activate-environment: test
           environment-file: devtools/conda-envs/openeye.yaml
           auto-activate-base: false
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
 
       - name: Additional info about the build
         shell: bash -l {0}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -57,6 +57,9 @@ jobs:
           activate-environment: test
           environment-file: devtools/conda-envs/conda.yaml
           auto-activate-base: false
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
       - uses: conda-incubator/setup-miniconda@v2.1.1
         name: Install from conda with OpenEye
         if: ${{ matrix.cfg.openeye == 'true' }}
@@ -65,6 +68,9 @@ jobs:
           activate-environment: test
           environment-file: devtools/conda-envs/conda_oe.yaml
           auto-activate-base: false
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
 
       - name: Additional info about the build
         shell: bash -l {0}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install additional example dependencies
         shell: bash -l {0}
         run: |
-          conda env update --file examples/environment.yaml --name test
+          mamba env update --file examples/environment.yaml --name test
 
           # Remove rdkit if it is not being tested, as it is a dependency of openmmforcefields
           if [[ "$RDKIT" == false ]]; then

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -59,6 +59,9 @@ jobs:
           activate-environment: test
           environment-file: devtools/conda-envs/rdkit.yaml
           auto-activate-base: false
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
       - uses: conda-incubator/setup-miniconda@v2.1.1
         name: Install with OpenEye toolkits
         if: ${{ matrix.cfg.rdkit == 'FALSE' && matrix.cfg.openeye == 'TRUE' }}
@@ -67,6 +70,9 @@ jobs:
           activate-environment: test
           environment-file: devtools/conda-envs/openeye.yaml
           auto-activate-base: false
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
 
       - name: Install additional example dependencies
         shell: bash -l {0}


### PR DESCRIPTION
We've had slow CI for a long time. Conda takes more than 8 minutes just to install dependencies in CI. With Mamba, entire documentation builds can complete in about 5 on RTD. Conda incubator supports Mamba, and I've been using this approach without any problems on the theme repo, so maybe it helps here.
