### PR TITLE
Make OFFXML output default to use 4 tabs instead of spaces

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -22,6 +22,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Behavior changed
 
+- [PR #1046](https://github.com/openforcefield/openforcefield/pull/1046): Changes OFFXML output to
+  replace tabs with 4 spaces to standardize representation in different text viewers. 
 - [PR #1036](https://github.com/openforcefield/openforcefield/pull/1036): SMARTS matching
   logic for library charges was updated to use only one unique match. No adverse side effects
   were found in testing, but could bad behavior may possibly exist in some unknown caes.

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -1121,8 +1121,8 @@ class TestForceField:
         forcefield_1 = ForceField(xml_simple_ff)
         string_1 = forcefield_1.to_string("XML")
         # Ensure that we have spaces instead of tabs
-        assert '    ' in string_1
-        assert '\t' not in string_1
+        assert "    " in string_1
+        assert "\t" not in string_1
         forcefield_2 = ForceField(string_1)
         string_2 = forcefield_2.to_string("XML")
         assert string_1 == string_2

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -1120,6 +1120,9 @@ class TestForceField:
         """
         forcefield_1 = ForceField(xml_simple_ff)
         string_1 = forcefield_1.to_string("XML")
+        # Ensure that we have spaces instead of tabs
+        assert '    ' in string_1
+        assert '\t' not in string_1
         forcefield_2 = ForceField(string_1)
         string_2 = forcefield_2.to_string("XML")
         assert string_1 == string_2

--- a/openff/toolkit/typing/engines/smirnoff/io.py
+++ b/openff/toolkit/typing/engines/smirnoff/io.py
@@ -292,6 +292,4 @@ class XMLParameterIOHandler(ParameterIOHandler):
             del smirnoff_data["SMIRNOFF"][key]
             smirnoff_data["SMIRNOFF"][key] = value
 
-        return xmltodict.unparse(smirnoff_data,
-                                 pretty=True,
-                                 indent=' '*4)
+        return xmltodict.unparse(smirnoff_data, pretty=True, indent=" " * 4)

--- a/openff/toolkit/typing/engines/smirnoff/io.py
+++ b/openff/toolkit/typing/engines/smirnoff/io.py
@@ -292,4 +292,6 @@ class XMLParameterIOHandler(ParameterIOHandler):
             del smirnoff_data["SMIRNOFF"][key]
             smirnoff_data["SMIRNOFF"][key] = value
 
-        return xmltodict.unparse(smirnoff_data, pretty=True)
+        return xmltodict.unparse(smirnoff_data,
+                                 pretty=True,
+                                 indent=' '*4)


### PR DESCRIPTION
- [x] Resolves the root cause of https://github.com/openforcefield/openff-forcefields/issues/15
- [x] Makes toolkit output conform to the desired whitespace convention from [the force field release process](https://github.com/openforcefield/openff-forcefields/wiki/Release-Process)
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
