### PR TITLE
Remove collections.OrderedDict

### DIFF
--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -13,7 +13,6 @@ Tests for forcefield class
 import copy
 import itertools
 import os
-from collections import OrderedDict
 from tempfile import NamedTemporaryFile
 
 import numpy as np
@@ -2073,50 +2072,44 @@ class TestForceFieldVirtualSites:
 
     # First test that one vsite is added, and that the last parameter
     # is chosen over the top-most wildcard match
-    opts = OrderedDict(
-        {
-            "xml": xml_ff_virtual_sites_bondcharge_match_once,
-            "smi": None,
-            "assert_physics": (
-                (as_charge(+0.2), None, None),
-                (as_charge(+0.2), None, None),
-                (as_charge(-0.4), as_sigma(0.2), as_epsilon(0.2)),
-            ),
-            "mol": create_dinitrogen(),
-        }
-    )
+    opts = {
+        "xml": xml_ff_virtual_sites_bondcharge_match_once,
+        "smi": None,
+        "assert_physics": (
+            (as_charge(+0.2), None, None),
+            (as_charge(+0.2), None, None),
+            (as_charge(-0.4), as_sigma(0.2), as_epsilon(0.2)),
+        ),
+        "mol": create_dinitrogen(),
+    }
     bond_charge_parameters_args.append(opts)
 
     # Test the wildcard match at the top, which means the other parameters
     # should be skipped
-    opts = OrderedDict(
-        {
-            "xml": xml_ff_virtual_sites_bondcharge_match_once,
-            "smi": None,
-            "assert_physics": (
-                (as_charge(+0.1), None, None),
-                (as_charge(+0.1), None, None),
-                (as_charge(-0.2), as_sigma(0.1), as_epsilon(0.1)),
-            ),
-            "mol": create_dioxygen(),
-        }
-    )
+    opts = {
+        "xml": xml_ff_virtual_sites_bondcharge_match_once,
+        "smi": None,
+        "assert_physics": (
+            (as_charge(+0.1), None, None),
+            (as_charge(+0.1), None, None),
+            (as_charge(-0.2), as_sigma(0.1), as_epsilon(0.1)),
+        ),
+        "mol": create_dioxygen(),
+    }
     bond_charge_parameters_args.append(opts)
 
     # Test the wildcard match where match is 0-1 and 1-0, giving two particles
-    opts = OrderedDict(
-        {
-            "xml": xml_ff_virtual_sites_bondcharge_match_all,
-            "smi": None,
-            "assert_physics": (
-                (as_charge(+0.4), None, None),
-                (as_charge(+0.4), None, None),
-                (as_charge(-0.4), as_sigma(0.2), as_epsilon(0.2)),
-                (as_charge(-0.4), as_sigma(0.2), as_epsilon(0.2)),
-            ),
-            "mol": create_dinitrogen(),
-        }
-    )
+    opts = {
+        "xml": xml_ff_virtual_sites_bondcharge_match_all,
+        "smi": None,
+        "assert_physics": (
+            (as_charge(+0.4), None, None),
+            (as_charge(+0.4), None, None),
+            (as_charge(-0.4), as_sigma(0.2), as_epsilon(0.2)),
+            (as_charge(-0.4), as_sigma(0.2), as_epsilon(0.2)),
+        ),
+        "mol": create_dinitrogen(),
+    }
     bond_charge_parameters_args.append(opts)
 
     ############################################################################
@@ -2124,38 +2117,34 @@ class TestForceFieldVirtualSites:
     ############################################################################
 
     # Test that using different names allows for multiple virtual sites
-    opts = OrderedDict(
-        {
-            "xml": xml_ff_virtual_sites_bondcharge_match_once_two_names,
-            "smi": None,
-            "assert_physics": (
-                (as_charge(+0.3), None, None),
-                (as_charge(+0.3), None, None),
-                (as_charge(-0.2), as_sigma(0.1), as_epsilon(0.1)),
-                (as_charge(-0.4), as_sigma(0.2), as_epsilon(0.2)),
-            ),
-            "mol": create_dinitrogen(),
-        }
-    )
+    opts = {
+        "xml": xml_ff_virtual_sites_bondcharge_match_once_two_names,
+        "smi": None,
+        "assert_physics": (
+            (as_charge(+0.3), None, None),
+            (as_charge(+0.3), None, None),
+            (as_charge(-0.2), as_sigma(0.1), as_epsilon(0.1)),
+            (as_charge(-0.4), as_sigma(0.2), as_epsilon(0.2)),
+        ),
+        "mol": create_dinitrogen(),
+    }
     bond_charge_parameters_args.append(opts)
 
-    opts = OrderedDict(
-        {
-            "xml": xml_ff_virtual_sites_monovalent_match_once,
-            "smi": None,
-            "assert_physics": (
-                (as_charge(+0.2), None, None),
-                (as_charge(+0.2), None, None),
-                (as_charge(+0.2), None, None),
-                (as_charge(+0.0), None, None),
-                (as_charge(+0.0), None, None),
-                (as_charge(+0.0), None, None),
-                (as_charge(+0.0), None, None),
-                (as_charge(-0.6), as_sigma(0.2), as_epsilon(0.2)),
-            ),
-            "mol": create_acetaldehyde(),
-        }
-    )
+    opts = {
+        "xml": xml_ff_virtual_sites_monovalent_match_once,
+        "smi": None,
+        "assert_physics": (
+            (as_charge(+0.2), None, None),
+            (as_charge(+0.2), None, None),
+            (as_charge(+0.2), None, None),
+            (as_charge(+0.0), None, None),
+            (as_charge(+0.0), None, None),
+            (as_charge(+0.0), None, None),
+            (as_charge(+0.0), None, None),
+            (as_charge(-0.6), as_sigma(0.2), as_epsilon(0.2)),
+        ),
+        "mol": create_acetaldehyde(),
+    }
     monovalent_parameters_args.append(opts)
 
     ############################################################################
@@ -2163,40 +2152,36 @@ class TestForceFieldVirtualSites:
     ############################################################################
 
     # A TIP5P definition from OpenMM
-    opts = OrderedDict(
-        {
-            "xml": xml_ff_virtual_sites_divalent_match_all,
-            "smi": None,
-            "assert_physics": (
-                (as_charge(+0.4820), None, None),
-                (as_charge(+0.0000), None, None),
-                (as_charge(+0.4820), None, None),
-                (as_charge(-0.4820), as_sigma(3.12), as_epsilon(0.16)),
-                (as_charge(-0.4820), as_sigma(3.12), as_epsilon(0.16)),
-            ),
-            "mol": create_water(),
-        }
-    )
+    opts = {
+        "xml": xml_ff_virtual_sites_divalent_match_all,
+        "smi": None,
+        "assert_physics": (
+            (as_charge(+0.4820), None, None),
+            (as_charge(+0.0000), None, None),
+            (as_charge(+0.4820), None, None),
+            (as_charge(-0.4820), as_sigma(3.12), as_epsilon(0.16)),
+            (as_charge(-0.4820), as_sigma(3.12), as_epsilon(0.16)),
+        ),
+        "mol": create_water(),
+    }
     divalent_parameters_args.append(opts)
 
     ############################################################################
     # Trivalent virtual site test data
     ############################################################################
 
-    opts = OrderedDict(
-        {
-            "xml": xml_ff_virtual_sites_trivalent_match_once,
-            "smi": None,
-            "assert_physics": (
-                (as_charge(+0.0000), None, None),
-                (as_charge(+1.0000), None, None),
-                (as_charge(+0.0000), None, None),
-                (as_charge(+0.0000), None, None),
-                (as_charge(-1.0000), as_sigma(0.00), as_epsilon(0.00)),
-            ),
-            "mol": create_ammonia(),
-        }
-    )
+    opts = {
+        "xml": xml_ff_virtual_sites_trivalent_match_once,
+        "smi": None,
+        "assert_physics": (
+            (as_charge(+0.0000), None, None),
+            (as_charge(+1.0000), None, None),
+            (as_charge(+0.0000), None, None),
+            (as_charge(+0.0000), None, None),
+            (as_charge(-1.0000), as_sigma(0.00), as_epsilon(0.00)),
+        ),
+        "mol": create_ammonia(),
+    }
     trivalent_parameters_args.append(opts)
 
     @pytest.mark.parametrize(

--- a/openff/toolkit/tests/test_utils.py
+++ b/openff/toolkit/tests/test_utils.py
@@ -116,8 +116,6 @@ def test_dimensionless_units():
 
 
 def test_sort_smirnoff_dict():
-    from collections import OrderedDict
-
     from openff.toolkit.typing.engines.smirnoff import ForceField
     from openff.toolkit.utils.utils import sort_smirnoff_dict
 
@@ -126,9 +124,7 @@ def test_sort_smirnoff_dict():
 
     # Ensure data is not created or destroyed
     # dict.__eq__ does not check order
-    assert smirnoff_dict == OrderedDict(
-        sort_smirnoff_dict(forcefield._to_smirnoff_data())
-    )
+    assert smirnoff_dict == sort_smirnoff_dict(forcefield._to_smirnoff_data())
 
 
 def test_import_message_exception_raises_warning(caplog):

--- a/openff/toolkit/tests/test_utils_serialization.py
+++ b/openff/toolkit/tests/test_utils_serialization.py
@@ -150,5 +150,5 @@ class TestUtilsSMIRNOFFSerialization(TestUtilsSerialization):
         filename = get_data_file_path("test_forcefields/test_forcefield.offxml")
         with open(filename, "r") as f:
             xml = f.read()
-            dictionary = xmltodict.parse(xml)
+            dictionary = xmltodict.parse(xml, dict_constructor=dict)
             cls.thing = DictionaryContainer(dictionary)

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -32,7 +32,6 @@ Molecular chemical entity representation and routines to interface with cheminfo
 import operator
 import warnings
 from abc import abstractmethod
-from collections import OrderedDict
 from copy import deepcopy
 from typing import Optional, Union
 
@@ -249,7 +248,7 @@ class Atom(Particle):
     def to_dict(self):
         """Return a dict representation of the atom."""
         # TODO
-        atom_dict = OrderedDict()
+        atom_dict = dict()
         atom_dict["atomic_number"] = self._atomic_number
         atom_dict["formal_charge"] = self._formal_charge / unit.elementary_charge
         atom_dict["is_aromatic"] = self._is_aromatic
@@ -874,7 +873,7 @@ class VirtualSite(Particle):
 
         """
         # Each subclass should have its own to_dict
-        vsite_dict = OrderedDict()
+        vsite_dict = dict()
         vsite_dict["name"] = self._name
         vsite_dict["atoms"] = tuple([i.molecule_atom_index for i in self.atoms])
         vsite_dict["charge_increments"] = quantity_to_string(self._charge_increments)
@@ -1993,7 +1992,7 @@ class Bond(Serializable):
         Return a dict representation of the bond.
 
         """
-        bond_dict = OrderedDict()
+        bond_dict = dict()
         bond_dict["atom1"] = self.atom1.molecule_atom_index
         bond_dict["atom2"] = self.atom2.molecule_atom_index
         bond_dict["bond_order"] = self._bond_order
@@ -2278,7 +2277,7 @@ class FrozenMolecule(Serializable):
                 # TODO: This will need to be updated once FrozenMolecules and Molecules are significantly different
                 self._copy_initializer(other)
                 loaded = True
-            if isinstance(other, OrderedDict) and not (loaded):
+            if isinstance(other, dict) and not (loaded):
                 self.__setstate__(other)
                 loaded = True
 
@@ -2411,13 +2410,13 @@ class FrozenMolecule(Serializable):
 
         Returns
         -------
-        molecule_dict : OrderedDict
+        molecule_dict : dict
             A dictionary representation of the molecule.
 
         """
         from openff.toolkit.utils.utils import serialize_numpy
 
-        molecule_dict = OrderedDict()
+        molecule_dict = dict()
         molecule_dict["name"] = self._name
         ## From Jeff: If we go the properties-as-dict route, then _properties should, at
         ## the top level, be a dict. Should we go through recursively and ensure all values are dicts too?
@@ -2478,7 +2477,7 @@ class FrozenMolecule(Serializable):
 
         Parameters
         ----------
-        molecule_dict : OrderedDict
+        molecule_dict : dict
             A dictionary representation of the molecule.
 
         Returns
@@ -2498,7 +2497,7 @@ class FrozenMolecule(Serializable):
 
         Parameters
         ----------
-        molecule_dict : OrderedDict
+        molecule_dict : dict
             A dictionary representation of the molecule.
         """
         # TODO: Provide useful exception messages if there are any failures

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -18,7 +18,6 @@ Class definitions to represent a molecular system and its chemical components
 """
 
 import itertools
-from collections import OrderedDict
 from collections.abc import MutableMapping
 
 import numpy as np
@@ -55,7 +54,7 @@ class _TransformedDict(MutableMapping):
     """
 
     def __init__(self, *args, **kwargs):
-        self.store = OrderedDict()
+        self.store = dict()
         self.update(dict(*args, **kwargs))  # use the free update to set keys
 
     def __getitem__(self, key):
@@ -122,24 +121,18 @@ class ValenceDict(_TransformedDict):
         assert len(key) < 4
         refkey = __class__.key_transform(key)
         if len(key) == 2:
-            permutations = OrderedDict(
-                {(refkey[0], refkey[1]): 0, (refkey[1], refkey[0]): 1}
-            )
+            permutations = dict({(refkey[0], refkey[1]): 0, (refkey[1], refkey[0]): 1})
         elif len(key) == 3:
-            permutations = OrderedDict(
-                {
-                    (refkey[0], refkey[1], refkey[2]): 0,
-                    (refkey[2], refkey[1], refkey[0]): 1,
-                }
-            )
+            permutations = {
+                (refkey[0], refkey[1], refkey[2]): 0,
+                (refkey[2], refkey[1], refkey[0]): 1,
+            }
         else:
             # For a proper, only forward/backward makes sense
-            permutations = OrderedDict(
-                {
-                    (refkey[0], refkey[1], refkey[2], refkey[3]): 0,
-                    (refkey[3], refkey[1], refkey[2], refkey[0]): 1,
-                }
-            )
+            permutations = {
+                (refkey[0], refkey[1], refkey[2], refkey[3]): 0,
+                (refkey[3], refkey[1], refkey[2], refkey[0]): 1,
+            }
         if possible is not None:
             i = 0
             # If the possible permutations were provided, ensure that `possible` is a SUBSET of `permutations`
@@ -316,16 +309,14 @@ class ImproperDict(_TransformedDict):
         """
         assert len(key) == 4
         refkey = __class__.key_transform(key)
-        permutations = OrderedDict(
-            {
-                (refkey[0], refkey[1], refkey[2], refkey[3]): 0,
-                (refkey[0], refkey[1], refkey[3], refkey[2]): 1,
-                (refkey[2], refkey[1], refkey[0], refkey[3]): 2,
-                (refkey[2], refkey[1], refkey[3], refkey[0]): 3,
-                (refkey[3], refkey[1], refkey[0], refkey[2]): 4,
-                (refkey[3], refkey[1], refkey[2], refkey[0]): 5,
-            }
-        )
+        permutations = {
+            (refkey[0], refkey[1], refkey[2], refkey[3]): 0,
+            (refkey[0], refkey[1], refkey[3], refkey[2]): 1,
+            (refkey[2], refkey[1], refkey[0], refkey[3]): 2,
+            (refkey[2], refkey[1], refkey[3], refkey[0]): 3,
+            (refkey[3], refkey[1], refkey[0], refkey[2]): 4,
+            (refkey[3], refkey[1], refkey[2], refkey[0]): 5,
+        }
         if possible is not None:
             assert all(
                 [p in permutations for p in possible]
@@ -1417,7 +1408,7 @@ class Topology(Serializable):
             self.copy_initializer(other)
         elif isinstance(other, FrozenMolecule):
             self.from_molecules([other])
-        elif isinstance(other, OrderedDict):
+        elif isinstance(other, dict):
             self._initialize_from_dict(other)
 
     def _initialize(self):
@@ -1429,7 +1420,7 @@ class Topology(Serializable):
         self._box_vectors = None
         # self._reference_molecule_dicts = set()
         # TODO: Look into weakref and what it does. Having multiple topologies might cause a memory leak.
-        self._reference_molecule_to_topology_molecules = OrderedDict()
+        self._reference_molecule_to_topology_molecules = dict()
         self._topology_molecules = list()
 
     @property

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -33,7 +33,6 @@ import copy
 import logging
 import os
 import pathlib
-from collections import OrderedDict
 
 from simtk import openmm
 
@@ -343,18 +342,14 @@ class ForceField:
             False  # if True, will disable checking compatibility version
         )
         self._aromaticity_model = None
-        self._parameter_handler_classes = (
-            OrderedDict()
-        )  # Parameter handler classes that _can_ be initialized if needed
-        self._parameter_handlers = (
-            OrderedDict()
-        )  # ParameterHandler classes to be instantiated for each parameter type
-        self._parameter_io_handler_classes = (
-            OrderedDict()
-        )  # ParameterIOHandler classes that _can_ be initialiazed if needed
-        self._parameter_io_handlers = (
-            OrderedDict()
-        )  # ParameterIO classes to be used for each file type
+        # Parameter handler classes that _can_ be initialized if needed
+        self._parameter_handler_classes = dict()
+        # ParameterHandler classes to be instantiated for each parameter type
+        self._parameter_handlers = dict()
+        # ParameterIOHandler classes that _can_ be initialiazed if needed
+        self._parameter_io_handler_classes = dict()
+        # ParameterIO classes to be used for each file type
+        self._parameter_io_handlers = dict()
         self._author = None
         self._date = None
 
@@ -882,18 +877,18 @@ class ForceField:
 
     def _to_smirnoff_data(self, discard_cosmetic_attributes=False):
         """
-        Convert this ForceField and all related ParameterHandlers to an OrderedDict representing a SMIRNOFF
+        Convert this ForceField and all related ParameterHandlers to an dict representing a SMIRNOFF
         data object.
 
         Returns
         -------
-        smirnoff_dict : OrderedDict
-            A nested OrderedDict representing this ForceField as a SMIRNOFF data object.
+        smirnoff_dict : dict
+            A nested dict representing this ForceField as a SMIRNOFF data object.
         discard_cosmetic_attributes : bool, optional. Default=False
             Whether to discard any non-spec attributes stored in the ForceField.
 
         """
-        l1_dict = OrderedDict()
+        l1_dict = dict()
 
         # Assume we will write out SMIRNOFF data in compliance with the max supported spec version
         l1_dict["version"] = self._MAX_SUPPORTED_SMIRNOFF_VERSION
@@ -915,7 +910,7 @@ class ForceField:
                 discard_cosmetic_attributes=discard_cosmetic_attributes
             )
 
-        smirnoff_dict = OrderedDict()
+        smirnoff_dict = dict()
         smirnoff_dict["SMIRNOFF"] = l1_dict
         smirnoff_dict = convert_all_quantities_to_string(smirnoff_dict)
         return smirnoff_dict
@@ -927,7 +922,7 @@ class ForceField:
 
         Parameters
         ----------
-        smirnoff_data : OrderedDict
+        smirnoff_data : dict
             A representation of a SMIRNOFF-format data structure. Begins at top-level 'SMIRNOFF' key.
         allow_cosmetic_attributes : bool, optional. Default = False
             Whether to permit non-spec kwargs in smirnoff_data.
@@ -1015,7 +1010,7 @@ class ForceField:
                 parameter_list_tagname = infotype._ELEMENT_NAME
             except AttributeError:
                 # The ParameterHandler doesn't have ParameterTypes (e.g. ToolkitAM1BCCHandler).
-                parameter_list_dict = {}
+                parameter_list_dict = dict()
             else:
                 parameter_list_dict = section_dict.pop(parameter_list_tagname, {})
 
@@ -1054,7 +1049,7 @@ class ForceField:
 
         Returns
         -------
-        smirnoff_data : OrderedDict
+        smirnoff_data : dict
             A representation of a SMIRNOFF-format data structure. Begins at top-level 'SMIRNOFF' key.
 
         """

--- a/openff/toolkit/typing/engines/smirnoff/io.py
+++ b/openff/toolkit/typing/engines/smirnoff/io.py
@@ -209,7 +209,7 @@ class XMLParameterIOHandler(ParameterIOHandler):
 
         # Parse XML file
         try:
-            smirnoff_data = xmltodict.parse(data, attr_prefix="")
+            smirnoff_data = xmltodict.parse(data, attr_prefix="", dict_constructor=dict)
             return smirnoff_data
         except ExpatError as e:
             raise SMIRNOFFParseError(str(e))

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -54,7 +54,7 @@ import functools
 import inspect
 import logging
 import re
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from enum import Enum
 from itertools import combinations
 
@@ -1043,7 +1043,7 @@ class _ParameterAttributeHandler:
         indexed_mapped_attribs = set(
             self._get_indexed_mapped_parameter_attributes().keys()
         )
-        smirnoff_dict = OrderedDict()
+        smirnoff_dict = dict()
 
         # If attribs_to_return is ordered here, that will effectively be an informal output ordering
         for attrib_name in attribs_to_return:
@@ -1345,12 +1345,12 @@ class _ParameterAttributeHandler:
         # sorts the attribute alphabetically by name. Here we want the order
         # to be the same as the declaration order, which is guaranteed by PEP 520,
         # starting from the parent class.
-        parameter_attributes = OrderedDict(
-            (name, descriptor)
+        parameter_attributes = {
+            name: descriptor
             for c in reversed(inspect.getmro(cls))
             for name, descriptor in c.__dict__.items()
             if isinstance(descriptor, ParameterAttribute) and filter(descriptor)
-        )
+        }
         return parameter_attributes
 
     @classmethod
@@ -1395,13 +1395,13 @@ class _ParameterAttributeHandler:
         required = self._get_required_parameter_attributes()
         optional = self._get_optional_parameter_attributes()
         # Filter the optional parameters that are set to their default.
-        optional = OrderedDict(
-            (name, descriptor)
+        optional = {
+            name: descriptor
             for name, descriptor in optional.items()
             if not (
                 descriptor.default is None and getattr(self, name) == descriptor.default
             )
-        )
+        }
         required.update(optional)
         return required
 
@@ -1888,7 +1888,7 @@ class ParameterHandler(_ParameterAttributeHandler):
                     f"0.3 SMIRNOFF spec requires each parameter section to have its own version."
                 )
 
-        # List of ParameterType objects (also behaves like an OrderedDict where keys are SMARTS).
+        # List of ParameterType objects (also behaves like a dict where keys are SMARTS).
         self._parameters = ParameterList()
 
         # Initialize ParameterAttributes and cosmetic attributes.
@@ -2289,7 +2289,7 @@ class ParameterHandler(_ParameterAttributeHandler):
 
     def to_dict(self, discard_cosmetic_attributes=False):
         """
-        Convert this ParameterHandler to an OrderedDict, compliant with the SMIRNOFF data spec.
+        Convert this ParameterHandler to an dict, compliant with the SMIRNOFF data spec.
 
         Parameters
         ----------
@@ -2298,11 +2298,11 @@ class ParameterHandler(_ParameterAttributeHandler):
 
         Returns
         -------
-        smirnoff_data : OrderedDict
+        smirnoff_data : dict
             SMIRNOFF-spec compliant representation of this ParameterHandler and its internal ParameterList.
 
         """
-        smirnoff_data = OrderedDict()
+        smirnoff_data = dict()
 
         # Populate parameter list
         parameter_list = self._parameters.to_list(

--- a/openff/toolkit/utils/serialization.py
+++ b/openff/toolkit/utils/serialization.py
@@ -279,16 +279,8 @@ class Serializable(abc.ABC):
             A YAML serialized representation of the object
 
         """
-        from collections import OrderedDict
-
         import yaml
 
-        yaml.SafeDumper.add_representer(
-            OrderedDict,
-            lambda dumper, value: self._represent_odict(
-                dumper, u"tag:yaml.org,2002:map", value
-            ),
-        )
         d = self.to_dict()
         return yaml.safe_dump(d, width=180)
 
@@ -311,17 +303,16 @@ class Serializable(abc.ABC):
             Instantiated object
 
         """
-        from collections import OrderedDict
-
         import yaml
 
-        yaml.SafeDumper.add_representer(
-            OrderedDict,
-            lambda dumper, value: self._represent_odict(
-                dumper, u"tag:yaml.org,2002:map", value
-            ),
-        )
-        d = yaml.safe_load(serialized)
+        # yaml.SafeDumper.add_representer(
+        #     dict,
+        #     lambda dumper, value: self._represent_odict(
+        #         dumper, u"tag:yaml.org,2002:map", value
+        #     ),
+        # )
+        # d = yaml.safe_load(serialized)
+        d = yaml.load(serialized)
         return cls.from_dict(d)
 
     @requires_package("msgpack")

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -505,9 +505,8 @@ def extract_serialized_units_from_dict(input_dict):
     """
 
     # TODO: Should this scheme also convert "1" to int(1) and "8.0" to float(8.0)?
-    from collections import OrderedDict
 
-    attached_units = OrderedDict()
+    attached_units = dict()
     unitless_dict = input_dict.copy()
     keys_to_delete = []
     for key in input_dict.keys():
@@ -1062,7 +1061,7 @@ def sort_smirnoff_dict(data):
             sorted_dict[key] = sort_smirnoff_dict(val)
         elif isinstance(val, list):
             # Handle case of ParameterLists, which show up in
-            # the smirnoff dicts as lists of OrderedDicts
+            # the smirnoff dicts as lists of dicts
             new_parameter_list = list()
             for param in val:
                 new_parameter_list.append(sort_smirnoff_dict(param))


### PR DESCRIPTION
`collections.OrderedDict` is effectively legacy in Python 3.6+, after which `dict` preserves order based on when keys are added. This PR removes all uses of it as it was seemingly only ever duck-typing the built-in `dict`. The only gotcha I ran into was that `xmltodict.parse` defaulted to returning an ordered dict, which is backwards from what I expected but probably makes sense for historical reasons.

People say `OrderedDict` is slower than the built-in, but some quick benchmarking does not clearly show an impact on file parsing or round-tripping a molecule object. My guess is that the performance differences are less than other, slower operations that typically happen in our workflows.

This changes the return type of `Serializable.to_dict` to actually be a dict; whether or not that's formally an API break I think its impact would be minimal or none.