### PR TITLE
Add @requires_pkg on Interchange tests

### DIFF
--- a/openff/toolkit/tests/test_interchange.py
+++ b/openff/toolkit/tests/test_interchange.py
@@ -1,7 +1,9 @@
+from openff.toolkit.tests.utils import requires_pkg
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff.forcefield import ForceField
 
 
+@requires_pkg("openff.interchange")
 def test_basic_construction():
     top = Molecule.from_smiles("C").to_topology()
     parsley = ForceField("openff-1.0.0.offxml")


### PR DESCRIPTION
In #991 I neglected to skip the tests when Interchange was not installed. This fixes that.

In general I  think it would be useful to have two sets of tests, one with everything or close to everything installed, and the other with all optional dependencies not installed. I do this [else](https://github.com/openforcefield/openff-interchange/blob/783f9034ee53d8fce7ce4e4ad0cac5e92fa40751/.github/workflows/ci.yaml)-[where](https://github.com/openforcefield/openff-interchange/blob/783f9034ee53d8fce7ce4e4ad0cac5e92fa40751/.github/workflows/ci_minimal.yaml) because I'm impatient with slow CI.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
