### PR TITLE
Replace nbqa-black with black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,8 @@ repos:
   - id: black
     files: ^openff
     args: [--check]
+  - id: black-jupyter
+    files: ^examples/((?!deprecated).)*$
 - repo: https://github.com/PyCQA/isort
   rev: 5.9.3
   hooks:
@@ -19,6 +21,4 @@ repos:
       args:
         - --py37-plus
     - id: nbqa-isort
-      files: ^examples/((?!deprecated).)*$
-    - id: nbqa-black
       files: ^examples/((?!deprecated).)*$

--- a/examples/conformer_energies/conformer_energies.py
+++ b/examples/conformer_energies/conformer_energies.py
@@ -5,10 +5,11 @@ from rdkit.Chem import rdMolAlign
 import numpy as np
 from simtk import openmm, unit
 
+
 def compute_conformer_energies_from_file(filename):
     # Load in the molecule and its conformers.
     # Note that all conformers of the same molecule are loaded as separate Molecule objects
-    # If using a OFF Toolkit version before 0.7.0, loading SDFs through RDKit and OpenEye may provide 
+    # If using a OFF Toolkit version before 0.7.0, loading SDFs through RDKit and OpenEye may provide
     # different behavior in some cases. So, here we force loading through RDKit to ensure the correct behavior
     rdktkw = RDKitToolkitWrapper()
     loaded_molecules = Molecule.from_file(filename, toolkit_registry=rdktkw)
@@ -29,17 +30,20 @@ def compute_conformer_energies_from_file(filename):
 
     n_molecules = len(molecules)
     n_conformers = sum([mol.n_conformers for mol in molecules])
-    print(f'{n_molecules} unique molecule(s) loaded, with {n_conformers} total conformers')
+    print(
+        f"{n_molecules} unique molecule(s) loaded, with {n_conformers} total conformers"
+    )
 
     # Load the openff-1.1.0 force field appropriate for vacuum calculations (without constraints)
     from openff.toolkit.typing.engines.smirnoff import ForceField
-    forcefield = ForceField('openff_unconstrained-1.1.0.offxml')
+
+    forcefield = ForceField("openff_unconstrained-1.1.0.offxml")
     # Loop over molecules and minimize each conformer
     for molecule in molecules:
         # If the molecule doesn't have a name, set mol.name to be the hill formula
-        if molecule.name == '':
+        if molecule.name == "":
             molecule.name = Topology._networkx_to_hill_formula(molecule.to_networkx())
-            print('%s : %d conformers' % (molecule.name, molecule.n_conformers))
+            print("%s : %d conformers" % (molecule.name, molecule.n_conformers))
             # Make a temporary copy of the molecule that we can update for each minimization
         mol_copy = Molecule(molecule)
         # Make an OpenFF Topology so we can parameterize the system
@@ -47,24 +51,38 @@ def compute_conformer_energies_from_file(filename):
         print(f"Parametrizing {molecule.name} (may take a moment to calculate charges)")
         system = forcefield.create_openmm_system(off_top)
         # Use OpenMM to compute initial and minimized energy for all conformers
-        integrator = openmm.VerletIntegrator(1*unit.femtoseconds)
-        platform = openmm.Platform.getPlatformByName('Reference')
+        integrator = openmm.VerletIntegrator(1 * unit.femtoseconds)
+        platform = openmm.Platform.getPlatformByName("Reference")
         omm_top = off_top.to_openmm()
         simulation = openmm.app.Simulation(omm_top, system, integrator, platform)
 
         # Print text header
-        print('Conformer         Initial PE         Minimized PE       RMS between initial and minimized conformer')
-        output = [['Conformer','Initial PE (kcal/mol)','Minimized PE (kcal/mol)','RMS between initial and minimized conformer (Angstrom)']]
+        print(
+            "Conformer         Initial PE         Minimized PE       RMS between initial and minimized conformer"
+        )
+        output = [
+            [
+                "Conformer",
+                "Initial PE (kcal/mol)",
+                "Minimized PE (kcal/mol)",
+                "RMS between initial and minimized conformer (Angstrom)",
+            ]
+        ]
         for conformer_index, conformer in enumerate(molecule.conformers):
             simulation.context.setPositions(conformer)
-            orig_potential = simulation.context.getState(getEnergy=True).getPotentialEnergy()
+            orig_potential = simulation.context.getState(
+                getEnergy=True
+            ).getPotentialEnergy()
             simulation.minimizeEnergy()
             min_state = simulation.context.getState(getEnergy=True, getPositions=True)
             min_potential = min_state.getPotentialEnergy()
 
             # Calculate the RMSD between the initial and minimized conformer
             min_coords = min_state.getPositions()
-            min_coords = np.array([ [atom.x, atom.y, atom.z] for atom in min_coords]) * unit.nanometer
+            min_coords = (
+                np.array([[atom.x, atom.y, atom.z] for atom in min_coords])
+                * unit.nanometer
+            )
             mol_copy._conformers = None
             mol_copy.add_conformer(conformer)
             mol_copy.add_conformer(min_coords)
@@ -76,22 +94,43 @@ def compute_conformer_energies_from_file(filename):
             # Save the minimized conformer to file
             mol_copy._conformers = None
             mol_copy.add_conformer(min_coords)
-            mol_copy.to_file(f'{molecule.name}_conf{conformer_index+1}_minimized.sdf', file_format='sdf')
-            print('%5d / %5d : %8.3f kcal/mol %8.3f kcal/mol  %8.3f Angstroms' % (conformer_index+1, molecule.n_conformers, orig_potential/unit.kilocalories_per_mole, min_potential/unit.kilocalories_per_mole, minimization_rms))
-            output.append([str(conformer_index+1), 
-                           f'{orig_potential/unit.kilocalories_per_mole:.3f}', 
-                           f'{min_potential/unit.kilocalories_per_mole:.3f}', 
-                           f'{minimization_rms:.3f}'])
+            mol_copy.to_file(
+                f"{molecule.name}_conf{conformer_index+1}_minimized.sdf",
+                file_format="sdf",
+            )
+            print(
+                "%5d / %5d : %8.3f kcal/mol %8.3f kcal/mol  %8.3f Angstroms"
+                % (
+                    conformer_index + 1,
+                    molecule.n_conformers,
+                    orig_potential / unit.kilocalories_per_mole,
+                    min_potential / unit.kilocalories_per_mole,
+                    minimization_rms,
+                )
+            )
+            output.append(
+                [
+                    str(conformer_index + 1),
+                    f"{orig_potential/unit.kilocalories_per_mole:.3f}",
+                    f"{min_potential/unit.kilocalories_per_mole:.3f}",
+                    f"{minimization_rms:.3f}",
+                ]
+            )
             # Write the results out to CSV
-        with open(f'{molecule.name}.csv', 'w') as of:
+        with open(f"{molecule.name}.csv", "w") as of:
             for line in output:
-                of.write(','.join(line)+'\n')
+                of.write(",".join(line) + "\n")
                 # Clean up OpenMM Simulation
         del simulation, integrator
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description="Perform energy minimization on a molecule, potentially with many conformers. For each conformer, this script will provide the initial energy, minimized energy, and RMSD between the initial and minimized structure (both as STDOUT and a csv file). The minimized conformers will be written out to SDF.")
-    parser.add_argument('-f', '--filename', help='Name of an input file containing conformers')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Perform energy minimization on a molecule, potentially with many conformers. For each conformer, this script will provide the initial energy, minimized energy, and RMSD between the initial and minimized structure (both as STDOUT and a csv file). The minimized conformers will be written out to SDF."
+    )
+    parser.add_argument(
+        "-f", "--filename", help="Name of an input file containing conformers"
+    )
     args = parser.parse_args()
 
     compute_conformer_energies_from_file(args.filename)


### PR DESCRIPTION
The creator/maintainer of nbQA dropped by to say he'll soon deprecate the `nbqa-black` hook now that it is natively supported in `black`. https://github.com/openforcefield/openff-toolkit/pull/1060#issuecomment-912955601

The process was:
1. Edit `.pre-commit-config.yaml`
2. Run `pre-commit run --all-files` - this is how there is a diff in `examples/conformer_energies/conformer_energies.py`, which was previously missed because the tool only looked for notebooks in that path
3. `pre-commit autoupdate` - no changes

I one-off tested this and found that it would catch formatting errors in notebook files as one would expect.  The only "gotcha" is that I needed to do `pip install black[jupyter]`, which was clearly indicated in the error message if it isn't installed. Something was funky with the executable not being found from the `conda-forge` build, but I doubt that's a problem outside of my machine and not a huge issue given it's not typically necessary for developers to run it manually.


- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
