### PR TITLE
Speed up rdkit distances

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "maintenance/.*"
+      - "lily/*"
   pull_request:
     branches:
       - "master"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "master"
       - "maintenance/.*"
-      - "lily/*"
   pull_request:
     branches:
       - "master"

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -1111,13 +1111,13 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         ).reshape(-1, 1)
 
         # Build an exclusion list for 1-2 and 1-3 interactions.
-        excluded_pairs = {
+        excluded_x, excluded_y = zip(*{
             *[(bond.atom1_index, bond.atom2_index) for bond in molecule.bonds],
             *[
                 (angle[0].molecule_atom_index, angle[-1].molecule_atom_index)
                 for angle in molecule.angles
             ],
-        }
+        })
 
         # Build the distance matrix between all pairs of atoms.
         coordinates = conformer.value_in_unit(unit.angstrom)
@@ -1140,9 +1140,8 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         # Multiply by the charge products.
         charge_products = partial_charges @ partial_charges.T
 
-        for x, y in excluded_pairs:
-            charge_products[x, y] = 0.0
-            charge_products[y, x] = 0.0
+        charge_products[excluded_x, excluded_y] = 0.0
+        charge_products[excluded_y, excluded_x] = 0.0
 
         interaction_energies = inverse_distances * charge_products
 

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -1111,13 +1111,15 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         ).reshape(-1, 1)
 
         # Build an exclusion list for 1-2 and 1-3 interactions.
-        excluded_x, excluded_y = zip(*{
-            *[(bond.atom1_index, bond.atom2_index) for bond in molecule.bonds],
-            *[
-                (angle[0].molecule_atom_index, angle[-1].molecule_atom_index)
-                for angle in molecule.angles
-            ],
-        })
+        excluded_x, excluded_y = zip(
+            *{
+                *[(bond.atom1_index, bond.atom2_index) for bond in molecule.bonds],
+                *[
+                    (angle[0].molecule_atom_index, angle[-1].molecule_atom_index)
+                    for angle in molecule.angles
+                ],
+            }
+        )
 
         # Build the distance matrix between all pairs of atoms.
         coordinates = conformer.value_in_unit(unit.angstrom)
@@ -1127,10 +1129,10 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         # np.einsum is both faster than np.diag, and not read-only
         diag = np.einsum("ii->i", ab)
         # modifying in-place lets us take advantage of diag
-        ab += (ab - diag - diag[..., np.newaxis])
+        ab += ab - diag - diag[..., np.newaxis]
         # Handle edge cases where the squared distance is slightly negative due to
         # precision issues
-        diag[:] = -0.
+        diag[:] = -0.0
         distances = np.sqrt(-ab)
 
         inverse_distances = np.reciprocal(


### PR DESCRIPTION
Fixes #1069

The first commit is regarding A, B, and C in issue #1069. I get about a 8 us speed-up in general. This corresponds to 50% the time in the test-case in `test_elf_compute_electrostatic_energy`, or 87% in a bigger molecule.

```python
def old_coords(coordinates):
    distances = np.sqrt(
            np.sum(np.square(coordinates)[:, np.newaxis, :], axis=2)
            - 2 * coordinates.dot(coordinates.T)
            + np.sum(np.square(coordinates), axis=1)
        )
    return distances

def new_coords(coordinates):
    ab = coordinates.dot(coordinates.T)
    diag = np.einsum('ii->i', ab) # faster than np.diag
    ab += (ab - diag - diag[..., np.newaxis])
    diag[:] = -0.
    matrix = np.sqrt(-ab)
    return matrix

conformer = np.array(
            [
                [1.0, 0.0, 0.0],
                [0.0, 0.0, 0.0],
                [-1.0, 0.0, 0.0],
                [0.0, 1.0, 0.0],
                [0.0, -1.0, 0.0],
            ]
        )

>>> %timeit old_coords(conformer)
18.6 µs ± 229 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

>>> %timeit new_coords(conformer)
9.7 µs ± 213 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

from openff.toolkit.topology.molecule import Molecule, unit
mol = Molecule.from_smiles("CCCCCCCCCCCCCCCCCCCCCCCCCCCC")
mol.generate_conformers()
conformer = mol.conformers[0].value_in_unit(unit.angstrom)

>>> %timeit old_coords(conformer)
52.8 µs ± 1.38 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

>>> %timeit new_coords(conformer)
45.5 µs ± 439 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

```

The second (non-CI related) commit is related to D), and just takes advantage of numpy's tuple indexing. I didn't time this to see if it's faster.

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
