### PR TITLE
Disable HTML post processing to help RTD builds pass

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,7 +156,7 @@ html_theme_options = {
     # teal, green, light-green, lime, yellow, amber, orange, deep-orange
     "color_accent": "openff-toolkit-blue",
     # Content Minification for deployment, prettification for debugging
-    "html_minify": True,
+    "html_minify": False,
     "html_prettify": False,
     "css_minify": True,
     "master_doc": False,


### PR DESCRIPTION
Latest builds are failing on ReadTheDocs because the HTML post processing step can't find a file. I'll change this upstream so that it succeeds without post-processing missing files in the future (post-processing is just minification or prettification), but for now we'll just disable post-processing.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
