### PR TITLE
Strict chirality option for perceiving residues

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -3767,13 +3767,14 @@ class TestMolecule:
 
         assert isinstance(mol.visualize(backend="openeye"), IPython.core.display.Image)
 
-    def test_perceive_residues_natoms_nterminal_alanine(self):
+    @pytest.mark.parametrize("strict_chirality", (True, False))
+    def test_perceive_residues_natoms_nterminal_alanine(self, strict_chirality):
         """Test number of matches atoms in residue perception with NTerminal form of Alanine."""
         offmol = Molecule.from_file(
             get_data_file_path('proteins/NTerminal_ALA.sdf')
         )
         # Perceive residue substructures
-        offmol.perceive_residues()
+        offmol.perceive_residues(strict_chirality=strict_chirality)
         counter = 0  # matched atom counter
         for atom in offmol.atoms:
             if atom.metadata:
@@ -3781,13 +3782,14 @@ class TestMolecule:
         # Number of atoms in NTerminal cap is 6
         assert counter == offmol.n_atoms - 6
 
-    def test_perceive_residues_natoms_cterminal_alanine(self):
+    @pytest.mark.parametrize("strict_chirality", (True, False))
+    def test_perceive_residues_natoms_cterminal_alanine(self, strict_chirality):
         """Test number of matches atoms in residue perception with CTerminal form of Alanine."""
         offmol = Molecule.from_file(
             get_data_file_path('proteins/CTerminal_ALA.sdf')
         )
         # Perceive residue substructures
-        offmol.perceive_residues()
+        offmol.perceive_residues(strict_chirality=strict_chirality)
         counter = 0  # matched atom counter
         for atom in offmol.atoms:
             if atom.metadata:
@@ -3795,13 +3797,14 @@ class TestMolecule:
         # Number of atoms in CTerminal cap is 6
         assert counter == offmol.n_atoms - 6
 
-    def test_perceive_residues_natoms_mainchain_alanine(self):
+    @pytest.mark.parametrize("strict_chirality", (True, False))
+    def test_perceive_residues_natoms_mainchain_alanine(self, strict_chirality):
         """Test number of matches atoms in residue perception with MainChain form of Alanine."""
         offmol = Molecule.from_file(
             get_data_file_path('proteins/MainChain_ALA.sdf')
         )
         # Perceive residue substructures
-        offmol.perceive_residues()
+        offmol.perceive_residues(strict_chirality=strict_chirality)
         counter = 0  # matched atom counter
         unlabelled_counter = 0  # unmatched atom counter
         for atom in offmol.atoms:
@@ -3813,13 +3816,14 @@ class TestMolecule:
         assert unlabelled_counter == 12
         assert counter == offmol.n_atoms - 12
 
-    def test_perceive_residues_natoms_mainchain_glutamic_acid(self):
+    @pytest.mark.parametrize("strict_chirality", (True, False))
+    def test_perceive_residues_natoms_mainchain_glutamic_acid(self, strict_chirality):
         """Test number of matches atoms in residue perception with MainChain form of Glutamic acid."""
         offmol = Molecule.from_file(
             get_data_file_path('proteins/MainChain_GLU.sdf')
         )
         # Perceive residue substructures
-        offmol.perceive_residues()
+        offmol.perceive_residues(strict_chirality=strict_chirality)
         counter = 0  # matched atom counter
         unlabelled_counter = 0  # unmatched atom counter
         for atom in offmol.atoms:
@@ -3831,14 +3835,15 @@ class TestMolecule:
         assert unlabelled_counter == 12
         assert counter == offmol.n_atoms - 12
 
-    def test_perceive_residues_natoms_mainchain_charged_glutamic_acid(self):
+    @pytest.mark.parametrize("strict_chirality", (True, False))
+    def test_perceive_residues_natoms_mainchain_charged_glutamic_acid(self, strict_chirality):
         """Test number of matches atoms in residue perception with MainChain form of charged
          Glutamic acid."""
         offmol = Molecule.from_file(
             get_data_file_path('proteins/MainChain_GLH.sdf')
         )
         # Perceive residue substructures
-        offmol.perceive_residues()
+        offmol.perceive_residues(strict_chirality=strict_chirality)
         counter = 0  # matched atom counter
         unlabelled_counter = 0  # unmatched atom counter
         for atom in offmol.atoms:
@@ -3850,13 +3855,14 @@ class TestMolecule:
         assert unlabelled_counter == 12
         assert counter == offmol.n_atoms - 12
 
-    def test_perceive_residues_natoms_mainchain_arginine(self):
+    @pytest.mark.parametrize("strict_chirality", (True, False))
+    def test_perceive_residues_natoms_mainchain_arginine(self, strict_chirality):
         """Test number of matches atoms in residue perception with MainChain form of Alanine."""
         offmol = Molecule.from_file(
             get_data_file_path('proteins/MainChain_ARG.sdf')
         )
         # Perceive residue substructures
-        offmol.perceive_residues()
+        offmol.perceive_residues(strict_chirality=strict_chirality)
         counter = 0  # matched atom counter
         unlabelled_counter = 0  # unmatched atom counter
         for atom in offmol.atoms:
@@ -3868,14 +3874,15 @@ class TestMolecule:
         assert unlabelled_counter == 12
         assert counter == offmol.n_atoms - 12
 
-    def test_perceive_residues_natoms_mainchain_histidine(self):
+    @pytest.mark.parametrize("strict_chirality", (True, False))
+    def test_perceive_residues_natoms_mainchain_histidine(self, strict_chirality):
         """Test number of matches atoms in residue perception with MainChain form of protonated
         state of Histidine."""
         offmol = Molecule.from_file(
             get_data_file_path('proteins/MainChain_HIP.sdf')
         )
         # Perceive residue substructures
-        offmol.perceive_residues()
+        offmol.perceive_residues(strict_chirality=strict_chirality)
         counter = 0  # matched atom counter
         unlabelled_counter = 0  # unmatched atom counter
         for atom in offmol.atoms:
@@ -3887,14 +3894,15 @@ class TestMolecule:
         assert unlabelled_counter == 12
         assert counter == offmol.n_atoms - 12
 
-    def test_perceive_residues_natoms_cyxteine(self):
+    @pytest.mark.parametrize("strict_chirality", (True, False))
+    def test_perceive_residues_natoms_cyxteine(self, strict_chirality):
         """Test number of atoms matched for residue perception of disulfide bond form
         of cysteine."""
         offmol = Molecule.from_file(
             get_data_file_path('proteins/MainChain_CYX.sdf')
         )
         # Perceive residue substructures
-        offmol.perceive_residues()
+        offmol.perceive_residues(strict_chirality=strict_chirality)
         counter = 0  # matched atom counter
         unlabelled_counter = 0  # unmatched atom counter
         for atom in offmol.atoms:
@@ -3907,14 +3915,15 @@ class TestMolecule:
         assert counter == offmol.n_atoms - 24
 
     @pytest.mark.slow
-    def test_perceive_residues_natoms_t4(self):
+    @pytest.mark.parametrize("strict_chirality", (True, False))
+    def test_perceive_residues_natoms_t4(self, strict_chirality):
         """Test number of atoms matched for residue perception of free from of
         T4 lysozyme."""
         offmol = Molecule.from_file(
             get_data_file_path('proteins/T4-protein.sdf')
         )
         # Perceive residue substructures
-        offmol.perceive_residues()
+        offmol.perceive_residues(strict_chirality=strict_chirality)
         counter = 0  # matched atom counter
         unlabelled_counter = 0  # unmatched atom counter
         for atom in offmol.atoms:

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -6468,14 +6468,40 @@ class Molecule(FrozenMolecule):
 
         raise ValueError("Could not find an appropriate backend")
 
-    def perceive_residues(self):
+    def perceive_residues(self, substructure_file_path=None, strict_chirality=True):
         """
         Perceive residue substructure and fill atoms metadata accordingly.
+
+        Perceives residues by matching substructures in the current molecule with a substructure dictionary file,
+        using SMARTS.
+
+        Parameters
+        ----------
+        substructure_file_path : str, optional, default=None
+            Path to substructure library file in JSON format. Defaults to using built-in substructure file.
+        strict_chirality: bool, optional, default=True
+            Whether to use strict chirality symbols (stereomarks) for substructure matchings with SMARTS.
         """
         # Read substructure dictionary file
-        substructure_file_path = get_data_file_path('proteins/aa_residues_substructures.json')
+        if not substructure_file_path:
+            substructure_file_path = get_data_file_path('proteins/aa_residues_substructures.json')
         with open(substructure_file_path, 'r') as subfile:
             substructure_dictionary = json.load(subfile)
+
+        # TODO: Think of a better way to deal with no strict chirality case
+        # if ignoring strict chirality, remove/update keys in inner dictionary
+        if not strict_chirality:
+            # make a copy of substructure dict
+            substructure_dictionary_no_chirality = deepcopy(substructure_dictionary)
+            # Update inner key (SMARTS) maintaining its value
+            for res_name, inner_dict in substructure_dictionary.items():
+                for smarts, atom_types in inner_dict.items():
+                    smarts_no_chirality = smarts.replace('@', '')  # remove @ in smarts
+                    substructure_dictionary_no_chirality[res_name][smarts_no_chirality] = \
+                        substructure_dictionary_no_chirality[res_name].pop(smarts)  # update key
+            # replace with the new substructure dictionary
+            substructure_dictionary = substructure_dictionary_no_chirality
+
         all_matches = list()
         for residue_name, smarts_dict in substructure_dictionary.items():
             matches = dict()


### PR DESCRIPTION
Perceiving residues for molecule now has the option to specify if it uses strict chirality or not, by ignoring the stereomarks (`@`) in the SMARTS substructures matching. This is useful for cyclic peptides which commonly have different chiralities.

- [ ] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
