### PR TITLE
Fall back to hill formula in Molecule.__repr__ if to_smiles() fails

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -484,6 +484,29 @@ class TestMolecule:
         molecule_copy.properties["aaa"] = "bbb"
         assert "aaa" not in molecule.properties
 
+    @pytest.mark.skipif(
+        has_pkg("openeye"),
+        reason="Test requires that OpenEye is not installed",
+    )
+    def test_repr_bad_smiles(self):
+        """Test that the repr falls back to Hill formula if to_smiles fails."""
+
+        assert "bad" not in Molecule.from_smiles("CC").__repr__()
+
+        # OpenEye will report a smiles of ClCl(Cl)C without error, so only test with RDKit unless we
+        # can come up with a molecule that OpenEyeToolkitWrapper.to_smiles() will reliably fail on
+
+        molecule = Molecule()
+        molecule.add_atom(17, 0, False)
+        molecule.add_atom(17, 0, False)
+        molecule.add_atom(17, 0, False)
+
+        molecule.add_bond(0, 1, 1, False)
+        molecule.add_bond(0, 2, 1, False)
+
+        expected_repr = "Molecule with name '' with bad SMILES and Hill formula 'Cl3'"
+        assert molecule.__repr__() == expected_repr
+
     @pytest.mark.parametrize("toolkit", [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_smiles(self, molecule, toolkit):

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -2601,10 +2601,14 @@ class FrozenMolecule(Serializable):
         self._properties = molecule_dict["properties"]
 
     def __repr__(self):
-        """Return the SMILES of this molecule"""
-        return "Molecule with name '{}' and SMILES '{}'".format(
-            self.name, self.to_smiles()
-        )
+        """Return a summary of this molecule; SMILES if valid, Hill formula if not."""
+        description = f"Molecule with name '{self.name}'"
+        try:
+            smiles = self.to_smiles()
+        except:
+            hill = Molecule.to_hill_formula(self)
+            return description + f" with bad SMILES and Hill formula '{hill}'"
+        return description + f" and SMILES '{smiles}'"
 
     def __getstate__(self):
         return self.to_dict()


### PR DESCRIPTION
Fixes #1073 

- [ ] I'm confused as to why `Molecule.to_hill_formula` a static method?
- [ ] The tests would be cleaner if there was as "molecule" that could be constructed with the  API that OpenEye would not create a smiles for. My imagination is limited. I was surprised by this behavior:
```
>>> molecule.add_atom(17, 0, False)
0
>>> molecule.add_atom(17, 0, False)
1
>>> molecule.add_atom(17, 0, False)
2
>>> molecule.add_atom(17, 0, False)
3
>>> molecule.add_bond(0, 1, 1, False)
0
>>> molecule.add_bond(0, 2, 1, False)
1
>>> molecule.add_bond(0, 3, 1, False)
2
>>> molecule.to_smiles(toolkit_registry=OpenEyeToolkitWrapper())
'ClCl(Cl)Cl'
>>> molecule.to_smiles(toolkit_registry=RDKitToolkitWrapper())
[10:18:04] Explicit valence for atom # 0 Cl, 3, is greater than permitted
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mwt/software/openforcefield/openff/toolkit/topology/molecule.py", line 2737, in to_smiles
    smiles = to_smiles_method(self, isomeric, explicit_hydrogens, mapped)
  File "/Users/mwt/software/openforcefield/openff/toolkit/utils/rdkit_wrapper.py", line 672, in to_smiles
    rdmol = self.to_rdkit(molecule)
  File "/Users/mwt/software/openforcefield/openff/toolkit/utils/rdkit_wrapper.py", line 1724, in to_rdkit
    Chem.SanitizeMol(
rdkit.Chem.rdchem.AtomValenceException: Explicit valence for atom # 0 Cl, 3, is greater than permitted
```
- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
