### PR TITLE
Use Quantity.value_in_unit() instead of dividing quantities by units

### DIFF
--- a/openff/toolkit/tests/test_energies.py
+++ b/openff/toolkit/tests/test_energies.py
@@ -49,7 +49,7 @@ def test_reference(constrained, mol):
     derived_energy = _get_energy(simulation=simulation, positions=positions)
 
     np.testing.assert_almost_equal(
-        actual=derived_energy / unit.kilojoule_per_mole,
+        actual=derived_energy.value_in_unit(unit.kilojoule_per_mole),
         desired=reference_energy,
         decimal=5,
     )
@@ -77,7 +77,7 @@ def generate_reference():
             if not constrained:
                 name += "un"
             name += "constrained"
-            reference.update({name: energy / unit.kilojoule_per_mole})
+            reference.update({name: energy.value_in_unit(unit.kilojoule_per_mole)})
 
     import openff.toolkit
 

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -3242,7 +3242,10 @@ class TestForceFieldConstraints:
                 molecule.atoms[atom2_idx].element.symbol,
             }
             assert atom_elements == bond_elements
-            assert np.isclose(distance / unit.angstrom, bond_length / unit.angstrom)
+            assert np.isclose(
+                distance.value_in_unit(unit.angstrom),
+                bond_length.value_in_unit(unit.angstrom),
+            )
 
     def test_constraints_hbonds(self):
         """Test that hydrogen bonds constraints are applied correctly to a ethane molecule."""
@@ -3821,12 +3824,13 @@ class TestForceFieldParameterAssignment:
         ref_ene = 0.0011797690240 * unit.kilojoule_per_mole
 
         assert np.allclose(
-            off_crds / unit.angstrom, ref_crds_with_vsite / unit.angstrom
+            off_crds.value_in_unit(unit.angstrom),
+            ref_crds_with_vsite.value_in_unit(unit.angstrom),
         )
         # allow 1% error in energy difference (default is .001%)
         assert np.allclose(
-            off_ene / unit.kilocalorie_per_mole,
-            ref_ene / unit.kilocalorie_per_mole,
+            off_ene.value_in_unit(unit.kilocalorie_per_mole),
+            ref_ene.value_in_unit(unit.kilocalorie_per_mole),
             rtol=0.05,
         )
 

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -3476,10 +3476,14 @@ class TestMolecule:
         initial_charges = molecule._partial_charges
 
         # Make sure everything isn't 0s
-        assert (abs(initial_charges / unit.elementary_charge) > 0.01).any()
+        assert (abs(initial_charges.value_in_unit(unit.elementary_charge)) > 0.01).any()
         # Check total charge
-        charges_sum_unitless = initial_charges.sum() / unit.elementary_charge
-        total_charge_unitless = molecule.total_charge / unit.elementary_charge
+        charges_sum_unitless = initial_charges.sum().value_in_unit(
+            unit.elementary_charge
+        )
+        total_charge_unitless = molecule.total_charge.value_in_unit(
+            unit.elementary_charge
+        )
         # if abs(charges_sum_unitless - total_charge_unitless) > 0.0001:
         # print(
         #     "molecule {}    charge_sum {}     molecule.total_charge {}".format(

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -476,8 +476,8 @@ class TestOpenEyeToolkitWrapper:
             assert bond1.to_dict() == bond2.to_dict()
         assert (molecule.conformers[0] == molecule2.conformers[0]).all()
         for pc1, pc2 in zip(molecule._partial_charges, molecule2._partial_charges):
-            pc1_ul = pc1 / unit.elementary_charge
-            pc2_ul = pc2 / unit.elementary_charge
+            pc1_ul = pc1.value_in_unit(unit.elementary_charge)
+            pc2_ul = pc2.value_in_unit(unit.elementary_charge)
             assert_almost_equal(pc1_ul, pc2_ul, decimal=6)
         assert (
             molecule2.to_smiles(toolkit_registry=toolkit_wrapper)
@@ -554,9 +554,11 @@ class TestOpenEyeToolkitWrapper:
             oeatom.SetPartialCharge(float("nan"))
             break
         eth_from_oe = Molecule.from_openeye(oemol)
-        assert math.isnan(eth_from_oe.partial_charges[0] / unit.elementary_charge)
+        assert math.isnan(
+            eth_from_oe.partial_charges[0].value_in_unit(unit.elementary_charge)
+        )
         for pc in eth_from_oe.partial_charges[1:]:
-            assert not math.isnan(pc / unit.elementary_charge)
+            assert not math.isnan(pc.value_in_unit(unit.elementary_charge))
         # Then, set all the OEMol's partial charges to nan, and ensure that
         # from_openeye produces an OFFMol with partial_charges = None
         for oeatom in oemol.GetAtoms():
@@ -865,7 +867,7 @@ class TestOpenEyeToolkitWrapper:
         # The first molecule in the SDF has the following properties and charges:
         assert molecules[0].properties["test_property_key"] == "test_property_value"
         np.testing.assert_allclose(
-            molecules[0].partial_charges / unit.elementary_charge,
+            molecules[0].partial_charges.value_in_unit(unit.elementary_charge),
             [-0.108680, 0.027170, 0.027170, 0.027170, 0.027170],
         )
         # The second molecule in the SDF has the following properties and charges:
@@ -875,7 +877,7 @@ class TestOpenEyeToolkitWrapper:
             == "another_test_property_value"
         )
         np.testing.assert_allclose(
-            molecules[1].partial_charges / unit.elementary_charge,
+            molecules[1].partial_charges.value_in_unit(unit.elementary_charge),
             [0.027170, 0.027170, 0.027170, 0.027170, -0.108680],
         )
 
@@ -957,8 +959,8 @@ class TestOpenEyeToolkitWrapper:
                 iofile.name, file_format="SDF", toolkit_registry=toolkit_wrapper
             )
         np.testing.assert_allclose(
-            ethanol.partial_charges / unit.elementary_charge,
-            ethanol2.partial_charges / unit.elementary_charge,
+            ethanol.partial_charges.value_in_unit(unit.elementary_charge),
+            ethanol2.partial_charges.value_in_unit(unit.elementary_charge),
         )
         assert ethanol2.properties["test_property"] == "test_value"
 
@@ -1019,7 +1021,7 @@ class TestOpenEyeToolkitWrapper:
         assert len(molecule1.conformers) == 1
         assert molecule1.conformers[0].shape == (15, 3)
         assert_almost_equal(
-            molecule1.conformers[0][5][1] / unit.angstrom, 22.98, decimal=2
+            molecule1.conformers[0][5][1].value_in_unit(unit.angstrom), 22.98, decimal=2
         )
 
         # Test loading from file-like object
@@ -1031,7 +1033,7 @@ class TestOpenEyeToolkitWrapper:
         assert len(molecule2.conformers) == 1
         assert molecule2.conformers[0].shape == (15, 3)
         assert_almost_equal(
-            molecule2.conformers[0][5][1] / unit.angstrom, 22.98, decimal=2
+            molecule2.conformers[0][5][1].value_in_unit(unit.angstrom), 22.98, decimal=2
         )
 
         # Test loading from gzipped mol2
@@ -1045,7 +1047,7 @@ class TestOpenEyeToolkitWrapper:
         assert len(molecule3.conformers) == 1
         assert molecule3.conformers[0].shape == (15, 3)
         assert_almost_equal(
-            molecule3.conformers[0][5][1] / unit.angstrom, 22.98, decimal=2
+            molecule3.conformers[0][5][1].value_in_unit(unit.angstrom), 22.98, decimal=2
         )
 
     def test_get_mol2_charges(self):
@@ -1078,8 +1080,8 @@ class TestOpenEyeToolkitWrapper:
             unit.elementary_charge,
         )
         for pc1, pc2 in zip(molecule._partial_charges, target_charges):
-            pc1_ul = pc1 / unit.elementary_charge
-            pc2_ul = pc2 / unit.elementary_charge
+            pc1_ul = pc1.value_in_unit(unit.elementary_charge)
+            pc2_ul = pc2.value_in_unit(unit.elementary_charge)
             assert_almost_equal(pc1_ul, pc2_ul, decimal=4)
 
     def test_mol2_charges_roundtrip(self):
@@ -1099,8 +1101,8 @@ class TestOpenEyeToolkitWrapper:
                 iofile.name, file_format="mol2", toolkit_registry=toolkit_wrapper
             )
         np.testing.assert_allclose(
-            ethanol.partial_charges / unit.elementary_charge,
-            ethanol2.partial_charges / unit.elementary_charge,
+            ethanol.partial_charges.value_in_unit(unit.elementary_charge),
+            ethanol2.partial_charges.value_in_unit(unit.elementary_charge),
         )
 
         # Now test with no properties or charges
@@ -1262,7 +1264,7 @@ class TestOpenEyeToolkitWrapper:
             abs(molecule.partial_charges), 0.0 * unit.elementary_charge
         )
         # Rounding error should be on the order of 1e-3
-        assert 1e-7 > abs(charge_sum / unit.elementary_charge) > 1e-8
+        assert 1e-7 > abs(charge_sum.value_in_unit(unit.elementary_charge)) > 1e-8
         assert abs_charge_sum > 0.25 * unit.elementary_charge
 
     def test_assign_partial_charges_am1bcc_net_charge(self):
@@ -1274,7 +1276,7 @@ class TestOpenEyeToolkitWrapper:
         )
         charge_sum = sum(molecule.partial_charges, 0.0 * unit.elementary_charge)
         assert 1e-10 > abs(
-            (charge_sum - molecule.total_charge) / unit.elementary_charge
+            (charge_sum - molecule.total_charge).value_in_unit(unit.elementary_charge)
         )
 
     def test_assign_partial_charges_am1bcc_wrong_n_confs(self):
@@ -2101,8 +2103,8 @@ class TestRDKitToolkitWrapper:
             assert bond1.to_dict() == bond2.to_dict()
         assert (molecule.conformers[0] == molecule2.conformers[0]).all()
         for pc1, pc2 in zip(molecule._partial_charges, molecule2._partial_charges):
-            pc1_ul = pc1 / unit.elementary_charge
-            pc2_ul = pc2 / unit.elementary_charge
+            pc1_ul = pc1.value_in_unit(unit.elementary_charge)
+            pc2_ul = pc2.value_in_unit(unit.elementary_charge)
             assert_almost_equal(pc1_ul, pc2_ul, decimal=6)
         assert (
             molecule2.to_smiles(toolkit_registry=toolkit_wrapper)
@@ -2213,7 +2215,7 @@ class TestRDKitToolkitWrapper:
         assert len(molecule.conformers) == 1
         assert molecule.conformers[0].shape == (15, 3)
         assert_almost_equal(
-            molecule.conformers[0][5][1] / unit.angstrom, 2.0104, decimal=4
+            molecule.conformers[0][5][1].value_in_unit(unit.angstrom), 2.0104, decimal=4
         )
 
     def test_read_sdf_charges(self):
@@ -2337,7 +2339,7 @@ class TestRDKitToolkitWrapper:
         # The first molecule in the SDF has the following properties and charges:
         assert molecules[0].properties["test_property_key"] == "test_property_value"
         np.testing.assert_allclose(
-            molecules[0].partial_charges / unit.elementary_charge,
+            molecules[0].partial_charges.value_in_unit(unit.elementary_charge),
             [-0.108680, 0.027170, 0.027170, 0.027170, 0.027170],
         )
         # The second molecule in the SDF has the following properties and charges:
@@ -2347,7 +2349,7 @@ class TestRDKitToolkitWrapper:
             == "another_test_property_value"
         )
         np.testing.assert_allclose(
-            molecules[1].partial_charges / unit.elementary_charge,
+            molecules[1].partial_charges.value_in_unit(unit.elementary_charge),
             [0.027170, 0.027170, 0.027170, 0.027170, -0.108680],
         )
 
@@ -2490,7 +2492,7 @@ class TestRDKitToolkitWrapper:
             normalize_partial_charges=False,
         )
         charge_sum = sum(molecule.partial_charges, 0.0 * unit.elementary_charge)
-        assert 1.0e-10 > abs(charge_sum / unit.elementary_charge)
+        assert 1.0e-10 > abs(charge_sum.value_in_unit(unit.elementary_charge))
 
     @pytest.mark.parametrize("partial_charge_method", ["mmff94"])
     def test_assign_partial_charges_net_charge(self, partial_charge_method):
@@ -2506,7 +2508,7 @@ class TestRDKitToolkitWrapper:
             partial_charge_method=partial_charge_method,
         )
         charge_sum = sum(molecule.partial_charges, 0.0 * unit.elementary_charge)
-        assert 1.0e-10 > abs((charge_sum / unit.elementary_charge) + 1.0)
+        assert 1.0e-10 > abs((charge_sum.value_in_unit(unit.elementary_charge)) + 1.0)
 
     def test_assign_partial_charges_bad_charge_method(self):
         """Test RDKitToolkitWrapper assign_partial_charges() for a nonexistent charge method"""
@@ -2928,7 +2930,7 @@ class TestAmberToolsToolkitWrapper:
             abs(molecule.partial_charges), 0.0 * unit.elementary_charge
         )
         # Rounding error should be on the order of 1e-3
-        assert 1e-2 > abs(charge_sum / unit.elementary_charge) > 1e-4
+        assert 1e-2 > abs(charge_sum.value_in_unit(unit.elementary_charge)) > 1e-4
         assert abs_charge_sum > 0.25 * unit.elementary_charge
 
     def test_assign_partial_charges_am1bcc_net_charge(self):
@@ -2941,7 +2943,7 @@ class TestAmberToolsToolkitWrapper:
             partial_charge_method="am1bcc", toolkit_registry=toolkit_registry
         )
         charge_sum = sum(molecule.partial_charges, 0.0 * unit.elementary_charge)
-        assert 1e-10 > abs((charge_sum / unit.elementary_charge) + 1)
+        assert 1e-10 > abs((charge_sum.value_in_unit(unit.elementary_charge)) + 1)
 
     def test_assign_partial_charges_am1bcc_wrong_n_confs(self):
         """
@@ -3088,7 +3090,7 @@ class TestAmberToolsToolkitWrapper:
             partial_charge_method=partial_charge_method,
         )
         charge_sum = sum(molecule.partial_charges, 0.0 * unit.elementary_charge)
-        assert 1e-10 > abs((charge_sum / unit.elementary_charge) + 1)
+        assert 1e-10 > abs((charge_sum.value_in_unit(unit.elementary_charge)) + 1)
 
     def test_assign_partial_charges_bad_charge_method(self):
         """Test AmberToolsToolkitWrapper assign_partial_charges() for a nonexistent charge method"""
@@ -3388,7 +3390,7 @@ class TestBuiltInToolkitWrapper:
             normalize_partial_charges=False,
         )
         charge_sum = sum(molecule.partial_charges, 0.0 * unit.elementary_charge)
-        assert 1.0e-10 > abs(charge_sum / unit.elementary_charge)
+        assert 1.0e-10 > abs(charge_sum.value_in_unit(unit.elementary_charge))
 
     @pytest.mark.parametrize("partial_charge_method", ["formal_charge"])
     def test_assign_partial_charges_net_charge(self, partial_charge_method):

--- a/openff/toolkit/tests/utils.py
+++ b/openff/toolkit/tests/utils.py
@@ -1808,12 +1808,12 @@ def get_14_scaling_factors(omm_sys: openmm.System) -> Tuple[List, List]:
         i, j, q, sig, eps = nonbond_force.getExceptionParameters(exception_idx)
 
         # Trust that q == 0 covers the cases of 1-2, 1-3, and truly being 0
-        if q / unit.elementary_charge ** 2 != 0:
+        if q.value_in_unit(unit.elementary_charge ** 2) != 0:
             q_i = nonbond_force.getParticleParameters(i)[0]
             q_j = nonbond_force.getParticleParameters(j)[0]
             coul_14.append(q / (q_i * q_j))
 
-        if eps / unit.kilojoule_per_mole != 0:
+        if eps.value_in_unit(unit.kilojoule_per_mole) != 0:
             eps_i = nonbond_force.getParticleParameters(i)[2]
             eps_j = nonbond_force.getParticleParameters(j)[2]
             vdw_14.append(eps / (eps_i * eps_j) ** 0.5)

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -257,7 +257,9 @@ class Atom(Particle):
         # TODO
         atom_dict = OrderedDict()
         atom_dict["atomic_number"] = self._atomic_number
-        atom_dict["formal_charge"] = self._formal_charge / unit.elementary_charge
+        atom_dict["formal_charge"] = self._formal_charge.value_in_unit(
+            unit.elementary_charge
+        )
         atom_dict["is_aromatic"] = self._is_aromatic
         atom_dict["stereochemistry"] = self._stereochemistry
         # TODO: Should we let atoms have names?
@@ -2449,7 +2451,7 @@ class FrozenMolecule(Serializable):
                 "conformers_unit"
             ] = "angstrom"  # Have this defined as a class variable?
             for conf in self._conformers:
-                conf_unitless = conf / unit.angstrom
+                conf_unitless = conf.value_in_unit(unit.angstrom)
                 conf_serialized, conf_shape = serialize_numpy((conf_unitless))
                 molecule_dict["conformers"].append(conf_serialized)
         if self._partial_charges is None:
@@ -2457,7 +2459,9 @@ class FrozenMolecule(Serializable):
             molecule_dict["partial_charges_unit"] = None
 
         else:
-            charges_unitless = self._partial_charges / unit.elementary_charge
+            charges_unitless = self._partial_charges.value_in_unit(
+                unit.elementary_charge
+            )
             charges_serialized, charges_shape = serialize_numpy(charges_unitless)
             molecule_dict["partial_charges"] = charges_serialized
             molecule_dict["partial_charges_unit"] = "elementary_charge"
@@ -5239,7 +5243,7 @@ class FrozenMolecule(Serializable):
             )
 
         # Gather the required qcschema data
-        charge = self.total_charge / unit.elementary_charge
+        charge = self.total_charge.value_in_unit(unit.elementary_charge)
         connectivity = [
             (bond.atom1_index, bond.atom2_index, bond.bond_order) for bond in self.bonds
         ]

--- a/openff/toolkit/utils/ambertools_wrapper.py
+++ b/openff/toolkit/utils/ambertools_wrapper.py
@@ -216,7 +216,7 @@ class AmberToolsToolkitWrapper(base_wrapper.ToolkitWrapper):
         # Compute charges
         with tempfile.TemporaryDirectory() as tmpdir:
             with temporary_cd(tmpdir):
-                net_charge = mol_copy.total_charge / unit.elementary_charge
+                net_charge = mol_copy.total_charge.value_in_unit(unit.elementary_charge)
                 # Write out molecule in SDF format
                 # TODO: How should we handle multiple conformers?
                 self._rdkit_toolkit_wrapper.to_file(

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1231,7 +1231,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
                 # OE needs a 1 x (3*n_Atoms) double array as input
                 flat_coords = np.zeros(shape=oemol.NumAtoms() * 3, dtype=np.float64)
                 for index, oe_idx in map_atoms.items():
-                    (x, y, z) = conf[index, :] / unit.angstrom
+                    (x, y, z) = conf[index, :].value_in_unit(unit.angstrom)
                     flat_coords[(3 * oe_idx)] = x
                     flat_coords[(3 * oe_idx) + 1] = y
                     flat_coords[(3 * oe_idx) + 2] = z
@@ -1244,7 +1244,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             oe_indexed_charges = np.zeros(shape=molecule.n_atoms, dtype=np.float64)
             for off_idx, charge in enumerate(molecule._partial_charges):
                 oe_idx = map_atoms[off_idx]
-                charge_unitless = charge / unit.elementary_charge
+                charge_unitless = charge.value_in_unit(unit.elementary_charge)
                 oe_indexed_charges[oe_idx] = charge_unitless
             # TODO: This loop below fails if we try to use an "enumerate"-style loop.
             #  It's worth investigating whether we make this assumption elsewhere in the codebase, since

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -889,7 +889,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         conformer_generation_status = AllChem.EmbedMultipleConfs(
             rdmol,
             numConfs=n_conformers,
-            pruneRmsThresh=rms_cutoff / unit.angstrom,
+            pruneRmsThresh=rms_cutoff.value_in_unit(unit.angstrom),
             randomSeed=1,
             # params=AllChem.ETKDG()
         )

--- a/openff/toolkit/utils/viz.py
+++ b/openff/toolkit/utils/viz.py
@@ -30,7 +30,7 @@ class _OFFTrajectoryNGLView(_NGLViewTrajectory):
         self.id = str(uuid.uuid4())
 
     def get_coordinates(self, index):
-        return self.molecule.conformers[index] / unit.angstrom
+        return self.molecule.conformers[index].value_in_unit(unit.angstrom)
 
     @property
     def n_frames(self):


### PR DESCRIPTION
This is a subset of #1079 that should be a pure upgrade with no API breaks, changed dependencies, etc.

OpenMM quantities can have their units stripped (and appropriate conversions applies) to float/array/etc. representations by dividing by a `Unit` object. This works fine, but  argue it's a little unsafe given that the same thing is accessible from the API.


```
>>> from openmm import unit
>>> x = 1.0 * unit.nanometer
>>> x
Quantity(value=1.0, unit=nanometer)
>>> x.value_in_unit(unit.nanometer)
1.0
>>> x.value_in_unit(unit.meter)
1e-09
>>> x / unit.nanometer
1.0
>>> x / unit.meter
1e-09
>>> x.value_in_unit(unit.nanometer) == x / x.unit
True
```

I scanned through the source code using regex patterns like `\/ unit\/`, `unitless = `, and probably missed a few cases. A tool to automate this would find a way to detect any time a `unit.Quantity` object is divided by a `unit.Unit` object, but I'm not quite sure how to build that.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
