### PR TITLE
Improve speed of RDKit greedy diverse conformer selection

### DIFF
--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -1250,35 +1250,22 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         rms_matrix = cls._elf_compute_rms_matrix(molecule)
 
         # Apply the greedy selection process.
-        closed_list = np.zeros(limit).astype(int)
-        closed_mask = np.zeros(rms_matrix.shape[0], dtype=bool)
-
-        n_selected = 1
-
-        for i in range(min(molecule.n_conformers, limit - 1)):
-
-            distances = rms_matrix[closed_list[: i + 1], :].sum(axis=0)
-
-            # Exclude already selected conformers or conformers which are too similar
-            # to those already selected.
-            closed_mask[
-                np.any(
-                    rms_matrix[closed_list[: i + 1], :]
-                    < rms_tolerance.value_in_unit(unit.angstrom),
-                    axis=0,
-                )
-            ] = True
-
-            if np.all(closed_mask):
-                # Stop of there are no more distinct conformers to select from.
+        selected_indices = [0]
+        angstrom_tol = rms_tolerance.value_in_unit(unit.angstrom)
+        for i in range(min(limit, molecule.n_conformers) - 1):
+            selected_rms = rms_matrix[selected_indices]
+            any_too_close = np.any(selected_rms < angstrom_tol, axis=0)
+            if np.all(any_too_close):
+                # stop if all conformers remaining are within RMS
+                # threshold of any selected conformer
                 break
 
-            distant_index = np.ma.array(distances, mask=closed_mask).argmax()
-            closed_list[i + 1] = distant_index
+            # add the next conformer with the largest summed RMS distance
+            # to current selected conformers
+            rmsdist = np.where(any_too_close, -np.inf, selected_rms.sum(axis=0))
+            selected_indices.append(rmsdist.argmax())
 
-            n_selected += 1
-
-        return [ranked_conformers[i.item()] for i in closed_list[:n_selected]]
+        return [ranked_conformers[i] for i in selected_indices]
 
     def apply_elf_conformer_selection(
         self,


### PR DESCRIPTION
This does not address any bug per se, but the code is faster and (IMO) much more readable, which makes future maintenance easier. I get a fairly consistent 2x+ speedup from my function, most likely from not working with numpy masked arrays.

**Original function**
```python
def greedy_select(rms_matrix, limit=10, rms_tolerance=0.05):
    # Apply the greedy selection process.
    closed_list = np.zeros(limit).astype(int)
    closed_mask = np.zeros(rms_matrix.shape[0], dtype=bool)

    n_selected = 1

    for i in range(limit - 1):

        distances = rms_matrix[closed_list[: i + 1], :].sum(axis=0)

        # Exclude already selected conformers or conformers which are too similar
        # to those already selected.
        closed_mask[
            np.any(
                rms_matrix[closed_list[: i + 1], :]
                < rms_tolerance,
                axis=0,
            )
        ] = True

        if np.all(closed_mask):
            # Stop of there are no more distinct conformers to select from.
            break

        distant_index = np.ma.array(distances, mask=closed_mask).argmax()
        closed_list[i + 1] = distant_index

        n_selected += 1

    return [i.item() for i in closed_list[:n_selected]]
```

**Newer function**
```python
def greedy_select2(rms_matrix, limit=10, rms_tolerance=0.05):
    selected_indices = [0]
    for i in range(limit - 1):
        selected_rms = rms_matrix[selected_indices]
        any_too_close = np.any(selected_rms < rms_tolerance, axis=0)
        if np.all(any_too_close):
            break
        
        rmsdist = np.where(any_too_close, -np.inf, selected_rms.sum(axis=0))
        selected_indices.append(rmsdist.argmax())
    return selected_indices
```

**Speed comparison**

```python
import timeit

for shape in [3, 10, 100, 1000]:
    arr = np.random.rand(shape, shape)
    arr += arr.T
    
    assert np.allclose(greedy_select(arr), greedy_select2(arr))
    original = timeit.timeit(lambda: greedy_select(arr), number=1000)
    new = timeit.timeit(lambda: greedy_select2(arr), number=1000)
    speedup = original / new
    shape_text = f"Shape ({shape}, {shape})"
    print(f"{shape_text:>20s}: {original:.3f} => {new:.3f} ({speedup:.1f}x speedup)")
```

```
        Shape (3, 3): 0.372 => 0.159 (2.3x speedup)
      Shape (10, 10): 0.370 => 0.158 (2.3x speedup)
    Shape (100, 100): 0.377 => 0.162 (2.3x speedup)
  Shape (1000, 1000): 0.522 => 0.243 (2.1x speedup)

```

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
