### PR TITLE
Avoid ParseError deprecation warning when not imported

### DIFF
--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -23,7 +23,6 @@ __all__ = [
     "SMIRNOFFVersionError",
     "SMIRNOFFAromaticityError",
     "SMIRNOFFParseError",
-    "ParseError",
     "PartialChargeVirtualSitesError",
     "ForceField",
 ]
@@ -32,6 +31,7 @@ import copy
 import logging
 import os
 import pathlib
+import warnings
 from collections import OrderedDict
 from typing import List
 
@@ -49,7 +49,6 @@ from openff.toolkit.typing.engines.smirnoff.parameters import (
 from openff.toolkit.typing.engines.smirnoff.plugins import load_handler_plugins
 from openff.toolkit.utils.exceptions import (
     ParameterHandlerRegistrationError,
-    ParseError,
     PartialChargeVirtualSitesError,
     SMIRNOFFAromaticityError,
     SMIRNOFFParseError,
@@ -63,6 +62,23 @@ from openff.toolkit.utils.utils import (
     convert_all_strings_to_quantity,
     requires_package,
 )
+
+deprecated_names = ["ParseError"]
+
+
+def __getattr__(name):
+    if name in deprecated_names:
+        warnings.filterwarnings("default", category=DeprecationWarning)
+        warning_msg = f"{name} is DEPRECATED and will be removed in a future release of the OpenFF Toolkit."
+        warnings.warn(warning_msg, DeprecationWarning)
+
+        if name == "ParseError":
+            from openff.toolkit.utils.exceptions import _DeprecatedParseError
+
+            return _DeprecatedParseError
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
 
 # =============================================================================================
 # CONFIGURE LOGGER


### PR DESCRIPTION
Fixes #1093, at least locally.

```python3
>>> from openff.toolkit.typing.engines.smirnoff import ForceField
>>> from openff.toolkit.typing.engines.smirnoff.forcefield import ForceField
>>> from openff.toolkit.typing.engines.smirnoff import *
>>> from openff.toolkit.typing.engines.smirnoff.forcefield import ParseError
/Users/mwt/software/openforcefield/openff/toolkit/typing/engines/smirnoff/forcefield.py:73: DeprecationWarning: ParseError is DEPRECATED and will be removed in a future release of the OpenFF Toolkit.
  warnings.warn(warning_msg, DeprecationWarning)
```

This should prevent the confusing deprecation warning from being emitted in common import paths but still expose `ParseError` if somebody is using it (I hope nobody is).

The only thing not totally fixed by that patch is if a user does a start import for an obscure deprecated exception and expect it to be there:

```
>>> from openff.toolkit.typing.engines.smirnoff import *
>>> ParseError
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'ParseError' is not defined
>>> from openff.toolkit.typing.engines.smirnoff.forcefield import ParseError
/Users/mwt/software/openforcefield/openff/toolkit/typing/engines/smirnoff/forcefield.py:73: DeprecationWarning: ParseError is DEPRECATED and will be removed in a future release of the OpenFF Toolkit.
  warnings.warn(warning_msg, DeprecationWarning)
>>> ParseError
<class 'openff.toolkit.utils.exceptions._DeprecatedParseError'>
```

I think there's a way to get that to work, but I'd like to avoid that, since star imports are a bad pattern, it's a peculiar exception for users to catch, and it is a name clash with another one (https://github.com/openforcefield/openff-toolkit/pull/1006).

- [ ] Check logs to see if error is still reported
- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
