### PR TITLE
Raise exception when dealing with radicals

### DIFF
--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -46,6 +46,7 @@ from openff.toolkit.utils.exceptions import (
     IncorrectNumConformersWarning,
     InvalidIUPACNameError,
     InvalidToolkitError,
+    RadicalsNotSupportedError,
     ToolkitUnavailableException,
     UndefinedStereochemistryError,
 )
@@ -1842,6 +1843,11 @@ class TestRDKitToolkitWrapper:
         smiles2 = molecule.to_smiles(toolkit_registry=toolkit_wrapper)
         assert smiles2 == expected_output_smiles
 
+    def test_rdkit_from_smiles_radical(self):
+        """Test that parsing an SMILES with a radical raises RadicalsNotSupportedError."""
+        with pytest.raises(RadicalsNotSupportedError):
+            RDKitToolkitWrapper().from_smiles("[CH3]")
+
     def test_rdkit_from_smiles_hydrogens_are_explicit(self):
         """
         Test to ensure that RDKitToolkitWrapper.from_smiles has the proper behavior with
@@ -2173,6 +2179,15 @@ class TestRDKitToolkitWrapper:
 
         offmol_no_h = Molecule.from_rdkit(rdmol, hydrogens_are_explicit=True)
         assert not any([a.atomic_number == 1 for a in offmol_no_h.atoms])
+
+    def test_from_rdkit_radical(self):
+        """Test that parsing an rdmol with a radical raises RadicalsNotSupportedError."""
+        from rdkit import Chem
+
+        rdmol = Chem.MolFromSmiles("[CH3]")
+
+        with pytest.raises(RadicalsNotSupportedError):
+            RDKitToolkitWrapper().from_rdkit(rdmol)
 
     @pytest.mark.parametrize(
         "smiles, expected_map", [("[Cl:1][Cl]", {0: 1}), ("[Cl:1][Cl:2]", {0: 1, 1: 2})]

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -128,6 +128,10 @@ class SMILESParseError(OpenFFToolkitException, ValueError):
     """The record could not be parsed into the given format"""
 
 
+class RadicalsNotSupportedError(OpenFFToolkitException):
+    """The OpenFF Toolkit does not currently support parsing molecules with radicals."""
+
+
 class InvalidConformerError(OpenFFToolkitException):
     """
     This error is raised when the conformer added to the molecule

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -26,6 +26,7 @@ from openff.toolkit.utils.constants import DEFAULT_AROMATICITY_MODEL
 from openff.toolkit.utils.exceptions import (
     ChargeMethodUnavailableError,
     ConformerGenerationError,
+    RadicalsNotSupportedError,
     SMILESParseError,
     ToolkitUnavailableException,
     UndefinedStereochemistryError,
@@ -1482,6 +1483,13 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         # if we are loading from a mapped smiles extract the mapping
         atom_mapping = {}
         for rda in rdmol.GetAtoms():
+
+            # See issues #1075 for some discussion on radicals
+            if rda.GetNumRadicalElectrons() != 0:
+                raise RadicalsNotSupportedError(
+                    "The OpenFF Toolkit does not currently support parsing molecules with radicals."
+                )
+
             rd_idx = rda.GetIdx()
             # if the molecule was made from a mapped smiles this has been hidden
             # so that it does not affect the sterochemistry tags


### PR DESCRIPTION
Resolves #1075

I could not figure out how to detect radicals with `oechem`. Maybe I'm too novice, but [searching the docs](https://docs.eyesopen.com/toolkits/python/search.html?q=radical&check_keywords=yes&area=default) or skimming through the [API docs](https://docs.eyesopen.com/toolkits/python/oechemtk/OEChemClasses/OEAtomBase.html) did not get me anywhere, nor did inspecting an atom object in memory. I would have expected either to lead me somewhere, so either it's not offered or I'm missing something under my nose.

I have not thought about this affects parsing other files, but my guess is that enough paths run through `from_rdkit`/`from_openeye` that those serve as chokepoints for catching this.
 
This implementation does add a method call for each atom in `from_rdkit`; it's quick (< 1 us / atom) enough that I don't know if there'd be a better API point to use.

```
In [1]: from rdkit import Chem

In [2]: rdmol = Chem.MolFromSmiles(100 * 'CC')

In [3]: %timeit [atom for atom in rdmol.GetAtoms()]
141 µs ± 2.28 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [4]: %timeit [atom.GetNumRadicalElectrons() for atom in rdmol.GetAtoms()]
183 µs ± 2.11 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

- [ ] Implement for `OpenEyeToolkitWrapper`
- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
