### PR TITLE
Add 404 page to docs

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,9 +1,0 @@
----
-orphan: True
----
-
-# 404: File not found
-
-This file does not exist. Sorry about that!
-
-[Return to index](openff-toolkit-index)

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,9 @@
+---
+orphan: True
+---
+
+# 404: File not found
+
+This file does not exist. Sorry about that!
+
+[Return to index](openff-toolkit-index)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,24 @@ jupyter_execute_notebooks = "force"
 # List of notebooks NOT to execute (use output stored in notebook instead)
 execution_excludepatterns = []
 
+
+# sphinx-notfound-page
+# https://github.com/readthedocs/sphinx-notfound-page
+# Renders a 404 page with absolute links
+import importlib
+
+if importlib.util.find_spec("notfound"):
+    extensions.append("notfound.extension")
+
+    notfound_context = {
+        "title": "404: File Not Found",
+        "body": """
+    <h1>File Not Found</h1>
+    <p>Sorry, we couldn't find that page.</p>
+    <p>Try using the search box or go to the homepage.</p>
+    """,
+    }
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 source_suffix = [".rst", ".md", ".ipynb"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,9 +105,9 @@ if importlib.util.find_spec("notfound"):
     notfound_context = {
         "title": "404: File Not Found",
         "body": """
-    <h1>File Not Found</h1>
+    <h1>404: File Not Found</h1>
     <p>Sorry, we couldn't find that page.</p>
-    <p>Try using the search box or go to the homepage.</p>
+    <p>Try using the search box or use the navigation menu on the left.</p>
     """,
     }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,8 +106,15 @@ if importlib.util.find_spec("notfound"):
         "title": "404: File Not Found",
         "body": """
     <h1>404: File Not Found</h1>
-    <p>Sorry, we couldn't find that page.</p>
-    <p>Try using the search box or use the navigation menu on the left.</p>
+    <p>
+        Sorry, we couldn't find that page. This often happens as a result of
+        following an outdated link. Please check the
+        <a href="https://open-forcefield-toolkit.readthedocs.io/en/stable/">latest stable version</a>
+        of the docs, unless you're sure you want an earlier version, and
+        try using the search box or the navigation menu on the left.
+    </p>
+    <p>
+    </p>
     """,
     }
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,6 +12,7 @@ dependencies:
     - myst-parser>=0.13.6
     - testpath==0.3.1
     - docutils
+    - sphinx-notfound-page
     # conda build dependencies
     - python
     - setuptools

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. _openff-toolkit-index:
 Open Force Field Toolkit
 ========================
 


### PR DESCRIPTION
While sorting out some housekeeping issues, I realised it might be possible to provide our own 404 page, which would be much better than using the RTD 404 page that doesn't even link to our docs. This PR is testing that.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
