### PR TITLE
Fix renaming of map_atoms variable

### DIFF
--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1275,7 +1275,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             for conf in molecule._conformers:
                 # OE needs a 1 x (3*n_Atoms) double array as input
                 flat_coords = np.zeros(shape=oemol.NumAtoms() * 3, dtype=np.float64)
-                for index, oe_idx in map_atoms.items():
+                for index, oe_idx in off_to_oe_idx.items():
                     (x, y, z) = conf[index, :].value_in_unit(unit.angstrom)
                     flat_coords[(3 * oe_idx)] = x
                     flat_coords[(3 * oe_idx) + 1] = y
@@ -1288,7 +1288,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         if molecule._partial_charges is not None:
             oe_indexed_charges = np.zeros(shape=molecule.n_atoms, dtype=np.float64)
             for off_idx, charge in enumerate(molecule._partial_charges):
-                oe_idx = map_atoms[off_idx]
+                oe_idx = off_to_oe_idx[off_idx]
                 charge_unitless = charge.value_in_unit(unit.elementary_charge)
                 oe_indexed_charges[oe_idx] = charge_unitless
             # TODO: This loop below fails if we try to use an "enumerate"-style loop.


### PR DESCRIPTION
A variable was renamed in some code I don't completely understand; this fixes it for a minimally breaking case I ran into today. AFAIK `map_atoms` previously mapped atom indices between an OpenEye and OpenFF molecules; this is now `off_to_oe_idx` with some code moved around to different functions.

CI isn't super useful so I won't check it, but a minimal repro:

```shell
(interchange-topology) [openforcefield] git checkout upstream/topology-biopolymer-refactor                                                                               f5773701  ✱
HEAD is now at f5773701 Merge branch 'master' into topology-biopolymer-refactor
(interchange-topology) [openforcefield] python                                                                                                                           f5773701  ✱
Python 3.9.7 | packaged by conda-forge | (default, Sep 29 2021, 20:33:18)
[Clang 11.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from openff.toolkit.topology import Molecule
>>> mol = Molecule.from_smiles("CCO")
>>> mol.generate_conformers(n_conformers=1)
>>> mol.to_openeye()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mwt/software/openforcefield/openff/toolkit/topology/molecule.py", line 6228, in to_openeye
    return toolkit_registry.call(
  File "/Users/mwt/software/openforcefield/openff/toolkit/utils/toolkit_registry.py", line 366, in call
    raise e
  File "/Users/mwt/software/openforcefield/openff/toolkit/utils/toolkit_registry.py", line 362, in call
    return method(*args, **kwargs)
  File "/Users/mwt/software/openforcefield/openff/toolkit/utils/openeye_wrapper.py", line 1278, in to_openeye
    for index, oe_idx in map_atoms.items():
NameError: name 'map_atoms' is not defined
>>>
(interchange-topology) [openforcefield] git checkout map-atoms-bug                                                                                                       f5773701  ✱
Previous HEAD position was f5773701 Merge branch 'master' into topology-biopolymer-refactor
Switched to branch 'map-atoms-bug'
(interchange-topology) [openforcefield] python                                                                                                                      map-atoms-bug  ✱
Python 3.9.7 | packaged by conda-forge | (default, Sep 29 2021, 20:33:18)
[Clang 11.1.0 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from openff.toolkit.topology import Molecule
>>> mol = Molecule.from_smiles("CCO")
>>> mol.generate_conformers(n_conformers=1)
>>> mol.to_openeye()
<openeye.oechem.OEMol; proxy of <Swig Object of type 'OEMolWrapper *' at 0x107a72090> >
>>>
```

Here's two tabs I had open: the [`master`](https://github.com/openforcefield/openff-toolkit/blob/36e4e30ea7d2ac10a96c624c90c2dae4b63f4582/openff/toolkit/utils/openeye_wrapper.py#L966) branch and [feature branch](https://github.com/openforcefield/openff-toolkit/blob/f5773701de469aecd2c330af03a1a51b648bbf9e/openff/toolkit/utils/openeye_wrapper.py#L1278)


- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
