### PR TITLE
Fix GLOBAL_TOOLKIT_REGISTRY etc being expanded in sigs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ autodoc_default_options = {
     "inherited-members": True,
     "member-order": "bysource",
 }
+autodoc_preserve_defaults = True
 
 # Disable NumPy style attributes/methods expecting every method to have its own docs page
 numpydoc_class_members_toctree = False


### PR DESCRIPTION
In the API reference, `GLOBAL_TOOLKIT_REGISTRY` is currently expanded into it's `__repr__()` implementation, "ToolkitRegistry containing The RDKit, AmberTools, Built-in Toolkit". This breaks Sphinx's argument parsing code, is confusing, and looks ugly. For an example, see `Molecule.strip_atom_stereochemistry()` ([`master`](https://open-forcefield-toolkit.readthedocs.io/en/latest/api/generated/openff.toolkit.topology.Molecule.html#openff.toolkit.topology.Molecule.strip_atom_stereochemistry), [PR](https://open-forcefield-toolkit--1135.org.readthedocs.build/en/1135/api/generated/openff.toolkit.topology.Molecule.html#openff.toolkit.topology.Molecule.strip_atom_stereochemistry)). This PR uses a Sphinx option I just discovered to avoid expanding default argument values, and instead present the default as `GLOBAL_TOOLKIT_REGISTRY`

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
