### PR TITLE
Improve topology refactor performance, offer API point to group molecules

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -1369,7 +1369,7 @@ class TestMolecule:
 
         topology = Topology.from_molecules(molecule_smiles)
         assert molecule_smiles.hill_formula == Molecule.to_hill_formula(
-            topology.molecules[0]
+            [*topology.molecules][0]
         )
         # make sure the networkx matches
         assert molecule_smiles.hill_formula == Molecule.to_hill_formula(
@@ -1414,7 +1414,7 @@ class TestMolecule:
         assert (
             Molecule.are_isomorphic(
                 ethanol,
-                topology.molecules[0],
+                [*topology.molecules][0],
                 aromatic_matching=False,
                 formal_charge_matching=False,
                 bond_order_matching=False,

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -1526,6 +1526,18 @@ class TestMolecule:
             is inputs["result"]
         )
 
+        assert (
+            benzene.is_isomorphic_with(
+                benzene_no_aromatic,
+                aromatic_matching=inputs["aromatic_matching"],
+                formal_charge_matching=inputs["formal_charge_matching"],
+                bond_order_matching=inputs["bond_order_matching"],
+                atom_stereochemistry_matching=inputs["atom_stereochemistry_matching"],
+                bond_stereochemistry_matching=inputs["bond_stereochemistry_matching"],
+            )
+            is inputs["result"]
+        )
+
     @requires_openeye
     def test_strip_atom_stereochemistry(self):
         """Test the basic behavior of strip_atom_stereochemistry"""

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -1015,6 +1015,21 @@ class TestTopology:
         # and 12 atoms named "", for a total of 3 unique atom names
         assert len(atom_names) == 3
 
+    def test_group_chemically_identical_molecules(self):
+        from pprint import pprint
+        top = Topology()
+        pprint(top.group_chemically_identical_molecules())
+        top.add_molecule(create_ethanol())
+        pprint(top.group_chemically_identical_molecules())
+        top.add_molecule(create_reversed_ethanol())
+        pprint(top.group_chemically_identical_molecules())
+        top.add_molecule(create_cyclohexane())
+        pprint(top.group_chemically_identical_molecules())
+        top.add_molecule(create_ethanol())
+        pprint(top.group_chemically_identical_molecules())
+        1/0
+
+
     @requires_openeye
     def test_chemical_environments_matches_OE(self):
         """Test Topology.chemical_environment_matches"""

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -1022,56 +1022,57 @@ class TestTopology:
         top = Topology()
 
         # Test for correct behavior with empty topology
-        assert top.identify_chemically_identical_molecules() == {}
+        assert top._identify_chemically_identical_molecules() == {}
 
         # Test for correct behavior with topology of one ethanol
         top.add_molecule(create_ethanol())
-        grouping = top.identify_chemically_identical_molecules()
-        def assert_first_ethanol_is_grouped_correctly(grouping):
-            assert grouping[0] == (0, {i: i for i in range(9)})
-        assert_first_ethanol_is_grouped_correctly(grouping)
+        groupings = top.identical_molecule_groups
+        def assert_first_ethanol_is_grouped_correctly(groupings):
+            assert groupings[0][0] == [0, {i: i for i in range(9)}]
+        assert_first_ethanol_is_grouped_correctly(groupings)
 
         # Add an ethanol in reversed order
         top.add_molecule(create_reversed_ethanol())
-        grouping = top.identify_chemically_identical_molecules()
-        def assert_reversed_ethanol_is_grouped_correctly(grouping):
+        groupings = top.identical_molecule_groups
+        def assert_reversed_ethanol_is_grouped_correctly(groupings):
             # Ensure that the second ethanol knows it's the same chemical species as the first ethanol
-            assert grouping[1][0] == 0
+            assert groupings[0][1][0] == 1
             # Ensure that the second ethanol has the heavy atoms reversed
-            assert grouping[1][1][0] == 8 # C
-            assert grouping[1][1][1] == 7 # C
-            assert grouping[1][1][2] == 6 # O
+            assert groupings[0][1][1][0] == 8 # C
+            assert groupings[0][1][1][1] == 7 # C
+            assert groupings[0][1][1][2] == 6 # O
             # (we only check the hydroxyl H, since the other Hs have multiple valid matches)
-            assert grouping[1][1][8] == 0 # HO
+            assert groupings[0][1][1][8] == 0 # HO
 
-        assert_first_ethanol_is_grouped_correctly(grouping)
-        assert_reversed_ethanol_is_grouped_correctly(grouping)
+        assert_first_ethanol_is_grouped_correctly(groupings)
+        assert_reversed_ethanol_is_grouped_correctly(groupings)
 
         # Add a cyclohexane, which should be unique from all the other molecules
         top.add_molecule(create_cyclohexane())
-        def assert_cyclohexane_is_grouped_correctly(grouping):
-            assert grouping[2] == (2, {i: i for i in range(18)})
-        grouping = top.identify_chemically_identical_molecules()
-        assert_first_ethanol_is_grouped_correctly(grouping)
-        assert_reversed_ethanol_is_grouped_correctly(grouping)
-        assert_cyclohexane_is_grouped_correctly(grouping)
+        def assert_cyclohexane_is_grouped_correctly(groupings):
+            assert len(groupings[2]) == 1
+            assert groupings[2][0] == [2, {i: i for i in range(18)}]
+        groupings = top.identical_molecule_groups
+        assert_first_ethanol_is_grouped_correctly(groupings)
+        assert_reversed_ethanol_is_grouped_correctly(groupings)
+        assert_cyclohexane_is_grouped_correctly(groupings)
 
         # Add a third ethanol, in the same order as the first
         top.add_molecule(create_ethanol())
-        def assert_last_ethanol_is_grouped_correctly(grouping):
+        def assert_last_ethanol_is_grouped_correctly(groupings):
             # Ensure that the last ethanol knows it's the same chemical species as the first ethanol
-            assert grouping[3][0] == 0
+            assert groupings[0][2][0] == 3
             # Ensure that the second ethanol has the heavy atoms matched correctly
-            assert grouping[3][1][0] == 0
-            assert grouping[3][1][1] == 1
-            assert grouping[3][1][2] == 2
+            assert groupings[0][2][1][0] == 0
+            assert groupings[0][2][1][1] == 1
+            assert groupings[0][2][1][2] == 2
             # Ensure that the second ethanol has the hydroxyl hydrogen matched correctly
-            assert grouping[3][1][8] == 8
-        grouping = top.identify_chemically_identical_molecules()
-        assert_first_ethanol_is_grouped_correctly(grouping)
-        assert_reversed_ethanol_is_grouped_correctly(grouping)
-        assert_cyclohexane_is_grouped_correctly(grouping)
-        assert_last_ethanol_is_grouped_correctly(grouping)
+            assert groupings[0][2][1][8] == 8
+        groupings = top.identical_molecule_groups
+        assert_first_ethanol_is_grouped_correctly(groupings)
+        assert_reversed_ethanol_is_grouped_correctly(groupings)
+        assert_cyclohexane_is_grouped_correctly(groupings)
+        assert_last_ethanol_is_grouped_correctly(groupings)
 
     @requires_openeye
     def test_chemical_environments_matches_OE(self):

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -3142,6 +3142,21 @@ class FrozenMolecule(Serializable):
 
         return molecule
 
+    def _is_exactly_the_same(self, other):
+
+        for atom1, atom2 in zip(self.atoms, other.atoms):
+            if ((atom1.atomic_number != atom2.atomic_number) or
+                (atom1.formal_charge != atom2.formal_charge) or
+                (atom1.stereochemistry != atom2.stereochemistry)):
+                return False
+        for bond1, bond2 in zip(self.bonds, other.bonds):
+            if ((bond1.atom1_index != bond2.atom1_index) or
+                (bond1.atom2_index != bond2.atom2_index) or
+                (bond1.stereochemistry != bond2.stereochemistry)):
+                return False
+        return True
+
+
     @staticmethod
     def are_isomorphic(
         mol1,

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -4357,6 +4357,25 @@ class FrozenMolecule(Serializable):
             ptl for vsite in self._virtual_sites for ptl in vsite.particles
         ]
 
+
+    def particle(self, index: int):
+        """
+        Get particle with a specified index.
+
+        Parameters
+        ----------
+        index : int
+
+        Returns
+        -------
+        atom or virtualparticle : openff.toolkit.topology.Atom or VirtualParticle
+        """
+        if index <= self.n_atoms:
+            return self.atom(index)
+        else:
+            index -= self.n_atoms
+            return self.virtual_particle(index)
+
     def particle_index(self, particle):
         """
         Returns the index of a given particle in this molecule
@@ -4373,6 +4392,50 @@ class FrozenMolecule(Serializable):
         for index, mol_particle in enumerate(self.particles):
             if particle is mol_particle:
                 return index
+
+    @property
+    def virtual_particles(self):
+        """
+        Iterate over all virtual particle objects.
+        """
+
+        return [
+            ptl for vsite in self._virtual_sites for ptl in vsite.particles
+        ]
+
+
+    def virtual_particle(self, index: int):
+        """
+        Get virtual particle with a specified index.
+
+        Parameters
+        ----------
+        index : int
+
+        Returns
+        -------
+        virtualparticle : openff.toolkit.topology.VirtualParticle
+        """
+        for ptl_idx, ptl in enumerate(self.virtual_particles):
+            if index == ptl_idx:
+                return ptl
+
+    def virtual_particle_index(self, particle):
+        """
+        Returns the index of a given virtual particle in this molecule
+
+        Parameters
+        ----------
+        virtual_particle : openff.toolkit.topology.VirtualParticle
+
+        Returns
+        -------
+        index : int
+            The index of the given virtual particle in this molecule
+        """
+        for ptl_idx, ptl in enumerate(self.virtual_particles):
+            if ptl is particle:
+                return ptl_idx
 
     @property
     def atoms(self):

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -3142,17 +3142,18 @@ class FrozenMolecule(Serializable):
 
         return molecule
 
-    def _is_exactly_the_same(self, other):
-
+    def _is_exactly_the_same_as(self, other):
         for atom1, atom2 in zip(self.atoms, other.atoms):
             if ((atom1.atomic_number != atom2.atomic_number) or
-                (atom1.formal_charge != atom2.formal_charge) or
-                (atom1.stereochemistry != atom2.stereochemistry)):
+                    (atom1.formal_charge != atom2.formal_charge) or
+                    (atom1.is_aromatic != atom2.is_aromatic) or
+               (atom1.stereochemistry != atom2.stereochemistry)):
                 return False
         for bond1, bond2 in zip(self.bonds, other.bonds):
             if ((bond1.atom1_index != bond2.atom1_index) or
-                (bond1.atom2_index != bond2.atom2_index) or
-                (bond1.stereochemistry != bond2.stereochemistry)):
+               (bond1.atom2_index != bond2.atom2_index) or
+               (bond1.is_aromatic != bond2.is_aromatic) or
+               (bond1.stereochemistry != bond2.stereochemistry)):
                 return False
         return True
 
@@ -3225,8 +3226,13 @@ class FrozenMolecule(Serializable):
         """
 
         # Do a quick hill formula check first
-        if Molecule.to_hill_formula(mol1) != Molecule.to_hill_formula(mol2):
+        if FrozenMolecule.to_hill_formula(mol1) != FrozenMolecule.to_hill_formula(mol2):
             return False, None
+
+        # Do a quick check to see whether the inputs are totally identical (including being in the same atom order)
+        if isinstance(mol1, FrozenMolecule) and isinstance(mol2, FrozenMolecule):
+            if mol1._is_exactly_the_same_as(mol2):
+                return True, {i:i for i in range(mol1.n_atoms)}
 
         # Build the user defined matching functions
         def node_match_func(x, y):

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -689,41 +689,16 @@ class Topology(Serializable):
             )
         self._fractional_bond_order_model = fractional_bond_order_model
 
+
     @property
-    def n_reference_molecules(self):
-        """
-        Returns the number of reference (unique) molecules in in this Topology.
+    def n_molecules(self):
+        """Returns the number of molecules in this Topology
 
         Returns
         -------
-        n_reference_molecules : int
-        """
-        count = 0
-        for i in self.reference_molecules:
-            count += 1
-        return count
-
-    @property
-    def n_topology_molecules(self):
-        """
-        Returns the number of topology molecules in in this Topology.
-
-        Returns
-        -------
-        n_topology_molecules : int
+        n_molecules : Iterable of Molecule
         """
         return len(self._molecules)
-
-    @property
-    def topology_molecules(self):
-        """Returns an iterator over all the TopologyMolecules in this Topology
-
-        Returns
-        -------
-        topology_molecules : Iterable of TopologyMolecule
-        """
-        # TODO: Put deprecation warning here
-        return self.molecules
 
     @property
     def molecules(self):
@@ -2275,3 +2250,39 @@ class Topology(Serializable):
         """
         _TOPOLOGY_DEPRECATION_WARNING("topology_virtual_sites", "virtual_sites")
         return self.virtual_sites
+
+
+    @property
+    def n_reference_molecules(self):
+        """
+        Returns the number of reference (unique) molecules in in this Topology.
+
+        Returns
+        -------
+        n_reference_molecules : int
+        """
+        _TOPOLOGY_DEPRECATION_WARNING("n_reference_molecules", "n_molecules")
+        return self.n_molecules
+
+    @property
+    def n_topology_molecules(self):
+        """
+        Returns the number of topology molecules in in this Topology.
+
+        Returns
+        -------
+        n_topology_molecules : int
+        """
+        _TOPOLOGY_DEPRECATION_WARNING("n_topology_molecules", "n_molecules")
+        return self.n_molecules
+
+    @property
+    def topology_molecules(self):
+        """Returns an iterator over all the TopologyMolecules in this Topology
+
+        Returns
+        -------
+        topology_molecules : Iterable of TopologyMolecule
+        """
+        _TOPOLOGY_DEPRECATION_WARNING("topology_molecules", "molecules")
+        return self.molecules

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1197,6 +1197,11 @@ class Topology(Serializable):
                 matches.append(environment_match)
         return matches
 
+    def find_identical_molecules_heuristic(self):
+        for mol1_idx, mol1 in enumerate(self.molecules):
+            for mol2_idx, mol2 in enumerate(self.molecules[mol1_idx+1:]):
+                pass
+
     def copy_initializer(self, other):
         other_dict = copy.deepcopy(other.to_dict())
         self._initialize_from_dict(other_dict)

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1155,12 +1155,7 @@ class Topology(Serializable):
         # of that molecule in the Topology object.
         matches = list()
 
-        identity_maps = self.identify_chemically_identical_molecules()
-        # Convert molecule identity maps into groups of identical molecules
-        groupings = {}
-        for molecule_idx in identity_maps.keys():
-            unique_mol, atom_map = identity_maps[molecule_idx]
-            groupings[unique_mol] = groupings.get(unique_mol, list()) + [[molecule_idx, atom_map]]
+        groupings = self.identical_molecule_groups
 
         for unique_mol_idx, group in groupings.items():
             unique_mol = self.molecule(unique_mol_idx)
@@ -1193,6 +1188,28 @@ class Topology(Serializable):
 
                     matches.append(environment_match)
         return matches
+
+    @property
+    def identical_molecule_groups(self):
+        """
+        Returns groups of chemically identical molecules, identified by index and atom map.
+
+        Returns
+        -------
+        identical_molecule_groups : {int:[[int: {int: int}]]}
+            A dict of the form {unique_mol_idx : [[topology_mol_idx, atom_map],...].
+            A dict where each key is the topology molecule index of a unique chemical species, and each value is a list
+            describing all of the instances of that chemical species in the topology. Each instance is a
+            two-membered list where the first element is the topology molecule index, and the second element
+            is a dict describing the atom map from the unique molecule to the instance of it in the topology.
+        """
+        identity_maps = self.identify_chemically_identical_molecules()
+        # Convert molecule identity maps into groups of identical molecules
+        groupings = {}
+        for molecule_idx in identity_maps.keys():
+            unique_mol, atom_map = identity_maps[molecule_idx]
+            groupings[unique_mol] = groupings.get(unique_mol, list()) + [[molecule_idx, atom_map]]
+        return groupings
 
     def identify_chemically_identical_molecules(self):
         """

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -3789,17 +3789,20 @@ class ElectrostaticsHandler(_NonbondedHandler):
         force = super().create_force(system, topology, **kwargs)
 
         # See if each molecule should have charges assigned by the charge_from_molecules kwarg
-        for molecule in topology.molecules:
+        groupings = topology.identical_molecule_groups
+
+        for unique_mol_idx, group in groupings.items():
+            unique_mol = topology.molecule(unique_mol_idx)
 
             # If charges were already assigned, skip this molecule
-            if self.check_charges_assigned(molecule, topology):
+            if self.check_charges_assigned(unique_mol, topology):
                 continue
 
             # First, check whether any of the reference molecules in the topology are in the charge_from_mol list
             charges_from_charge_mol = False
             if "charge_from_molecules" in kwargs:
                 charges_from_charge_mol = self.assign_charge_from_molecules(
-                    molecule, kwargs["charge_from_molecules"]
+                    unique_mol, kwargs["charge_from_molecules"]
                 )
 
             # If this reference molecule wasn't in the charge_from_molecules list, end this iteration
@@ -3807,21 +3810,25 @@ class ElectrostaticsHandler(_NonbondedHandler):
                 continue
 
             # Otherwise, the molecule is in the charge_from_molecules list, and we should assign charges to it
-            for particle in molecule.particles:
-                topology_particle_index = topology.particle_index(particle)
-                molecule_particle_index = molecule.particle_index(particle)
+            for unique_mol_particle in unique_mol.particles:
+                unique_mol_particle_index = unique_mol.particle_index(unique_mol_particle)
+                particle_charge = unique_mol.partial_charges[unique_mol_particle_index]
+                for mol_instance_idx, atom_map in group:
+                    mol_instance = topology.molecule(mol_instance_idx)
+                    mol_instance_particle_index = atom_map[unique_mol_particle_index]
+                    mol_instance_particle = mol_instance.particle(mol_instance_particle_index)
+                    mol_instance_particle_top_idx =  topology.particle_index(mol_instance_particle)
 
-                particle_charge = molecule.partial_charges[molecule_particle_index]
 
-                # Retrieve nonbonded parameters for reference atom (charge not set yet)
-                _, sigma, epsilon = force.getParticleParameters(topology_particle_index)
-                # Set the nonbonded force with the partial charge
-                force.setParticleParameters(
-                    topology_particle_index, particle_charge, sigma, epsilon
-                )
+                    # Retrieve nonbonded parameters for reference atom (charge not set yet)
+                    _, sigma, epsilon = force.getParticleParameters(mol_instance_particle_top_idx)
+                    # Set the nonbonded force with the partial charge
+                    force.setParticleParameters(
+                        mol_instance_particle_top_idx, particle_charge, sigma, epsilon
+                    )
 
-            # Finally, mark that charges were assigned for this reference molecule
-            self.mark_charges_assigned(molecule, topology)
+                    # Finally, mark that charges were assigned for this reference molecule
+                    self.mark_charges_assigned(mol_instance, topology)
 
         # Set the nonbonded method
         current_nb_method = force.getNonbondedMethod()
@@ -3886,9 +3893,9 @@ class ElectrostaticsHandler(_NonbondedHandler):
         force = super().create_force(system, topology, **kwargs)
         # Check to ensure all molecules have had charges assigned
         uncharged_mols = []
-        for ref_mol in topology.reference_molecules:
-            if not self.check_charges_assigned(ref_mol, topology):
-                uncharged_mols.append(ref_mol)
+        for molecule in topology.molecules:
+            if not self.check_charges_assigned(molecule, topology):
+                uncharged_mols.append(molecule)
 
         if len(uncharged_mols) != 0:
             msg = "The following molecules did not have charges assigned by any ParameterHandler in the ForceField:\n"
@@ -4022,8 +4029,6 @@ class LibraryChargeHandler(_NonbondedHandler):
         # Check to see whether the set contains any complete molecules, and remove the matches if not.
         for molecule in topology.molecules:
 
-            # Make a temporary copy of ref_mol to assign charges from charge_mol
-
             # If charges were already assigned, skip this molecule
             if self.check_charges_assigned(molecule, topology):
                 continue
@@ -4088,10 +4093,13 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
 
         force = super().create_force(system, topology, **kwargs)
 
-        for molecule in topology.molecules:
+        groupings = topology.identical_molecule_groups
+
+        for unique_mol_idx, group in groupings.items():
+            unique_mol = topology.molecule(unique_mol_idx)
 
             # If charges were already assigned, skip this molecule
-            if self.check_charges_assigned(molecule, topology):
+            if self.check_charges_assigned(unique_mol, topology):
                 continue
 
             # If the molecule wasn't already assigned charge values, calculate them here
@@ -4099,7 +4107,7 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
             try:
                 # We don't need to generate conformers here, since that will be done by default in
                 # compute_partial_charges with am1bcc if the use_conformers kwarg isn't defined
-                molecule.assign_partial_charges(
+                unique_mol.assign_partial_charges(
                     partial_charge_method="am1bcc", toolkit_registry=toolkit_registry
                 )
             except Exception as e:
@@ -4107,19 +4115,23 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
                 continue
 
             # Assign charges to relevant atoms
-            for atom in molecule.atoms:
-                molecule_atom_index = molecule.atom_index(atom)
-                topology_particle_index = topology.particle_index(atom)
-                particle_charge = molecule.partial_charges[molecule_atom_index]
+            for unique_mol_atom in unique_mol.atoms:
+                unique_mol_atom_index = unique_mol.atom_index(unique_mol_atom)
+                particle_charge = unique_mol.partial_charges[unique_mol_atom_index]
+                for mol_instance_idx, atom_map in group:
+                    mol_instance = topology.molecule(mol_instance_idx)
+                    mol_instance_atom_index = atom_map[unique_mol_atom_index]
+                    mol_instance_atom = mol_instance.atom(mol_instance_atom_index)
+                    topology_particle_index = topology.particle_index(mol_instance_atom)
 
-                # Retrieve nonbonded parameters for reference atom (charge not set yet)
-                _, sigma, epsilon = force.getParticleParameters(topology_particle_index)
-                # Set the nonbonded force with the partial charge
-                force.setParticleParameters(
-                    topology_particle_index, particle_charge, sigma, epsilon
-                )
-            # Finally, mark that charges were assigned for this reference molecule
-            self.mark_charges_assigned(molecule, topology)
+                    # Retrieve nonbonded parameters for reference atom (charge not set yet)
+                    _, sigma, epsilon = force.getParticleParameters(topology_particle_index)
+                    # Set the nonbonded force with the partial charge
+                    force.setParticleParameters(
+                        topology_particle_index, particle_charge, sigma, epsilon
+                    )
+                    # Finally, mark that charges were assigned for this reference molecule
+                    self.mark_charges_assigned(mol_instance, topology)
 
     # TODO: Move chargeModel and library residue charges to SMIRNOFF spec
     def postprocess_system(self, system, topology, **kwargs):
@@ -4262,17 +4274,20 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
         else:
             force = existing[0]
 
-        for molecule in topology.molecules:
+        groupings = topology.identical_molecule_groups
+
+        for unique_mol_idx, group in groupings.items():
+            unique_mol = topology.molecule(unique_mol_idx)
 
             # If charges were already assigned, skip this molecule
-            if self.check_charges_assigned(molecule, topology):
+            if self.check_charges_assigned(unique_mol, topology):
                 continue
 
             toolkit_registry = kwargs.get("toolkit_registry", GLOBAL_TOOLKIT_REGISTRY)
             try:
                 # If the molecule wasn't assigned parameters from a manually-input charge_mol, calculate them here
-                molecule.generate_conformers(n_conformers=self.number_of_conformers)
-                molecule.assign_partial_charges(
+                unique_mol.generate_conformers(n_conformers=self.number_of_conformers)
+                unique_mol.assign_partial_charges(
                     partial_charge_method=self.partial_charge_method,
                     toolkit_registry=toolkit_registry,
                 )
@@ -4283,11 +4298,15 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
             charges_to_assign = {}
 
             # Assign initial, un-incremented charges to relevant atoms
-            for particle in molecule.particles:
-                topology_particle_index = topology.particle_index(particle)
-                molecule_particle_index = molecule.particle_index(particle)
-                particle_charge = molecule.partial_charges[molecule_particle_index]
-                charges_to_assign[topology_particle_index] = particle_charge
+            for particle in unique_mol.particles:
+                unique_mol_particle_index = unique_mol.particle_index(particle)
+                particle_charge = unique_mol.partial_charges[unique_mol_particle_index]
+                for mol_instance_idx, atom_map in group:
+                    mol_instance = topology.molecule(mol_instance_idx)
+                    mol_instance_particle_index = atom_map[unique_mol_particle_index]
+                    mol_instance_particle = mol_instance.particle(mol_instance_particle_index)
+                    topology_particle_index = topology.particle_index(mol_instance_particle)
+                    charges_to_assign[topology_particle_index] = particle_charge
 
             # Find SMARTS-based matches for charge increments
             charge_increment_matches = self.find_matches(topology)
@@ -4338,7 +4357,9 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
                 )
 
             # Finally, mark that charges were assigned for this reference molecule
-            self.mark_charges_assigned(molecule, topology)
+            for mol_instance_idx, atom_map in group:
+                mol_instance = topology.molecule(mol_instance_idx)
+                self.mark_charges_assigned(mol_instance, topology)
 
 
 class GBSAHandler(ParameterHandler):


### PR DESCRIPTION
- [x] Add functionality to efficiently group identical molecules
- [x] Use new functionality to recover SMARTS matching performance
- [ ] Polish `Topology.identical_molecule_groups` docstring so actual humans can read it
- [x] Use new functionality to deduplicate molecules in special charge assignment cases (like ToolkitAM1BCC and friends)
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
