### PR TITLE
Add specific exception for Molecule.from_file with XYZ files

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,6 +15,10 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   and no longer accepts input of NetworkX graphs.
 - [PR #1130](https://github.com/openforcefield/openforcefield/pull/1130): Running unit tests will
   no longer generate force field files in the local directory.
+- [PR #1148](https://github.com/openforcefield/openforcefield/pull/1148): Adds a new exception
+  (`UnsupportedFileTypeError`](openff.toolkit.utils.exceptions.UnsupportedFileTypeError) and
+  descriptive error message when attempting to use
+  [`Molecule.from_file`](openff.toolkit.topology.Molecule.from_file) to parse XYZ/`.xyz` files.
 
 ### Examples added
 

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -59,7 +59,10 @@ from openff.toolkit.topology.molecule import (
     _networkx_graph_to_hill_formula,
 )
 from openff.toolkit.utils import get_data_file_path
-from openff.toolkit.utils.exceptions import ConformerGenerationError
+from openff.toolkit.utils.exceptions import (
+    ConformerGenerationError,
+    UnsupportedFileTypeError,
+)
 from openff.toolkit.utils.toolkits import (
     AmberToolsToolkitWrapper,
     OpenEyeToolkitWrapper,
@@ -1946,6 +1949,10 @@ class TestMolecule:
         }
 
         assert expected == actual
+
+    def test_from_xyz_unsupported(self):
+        with pytest.raises(UnsupportedFileTypeError):
+            Molecule.from_file("foo.xyz", file_format="xyz")
 
     @requires_rdkit
     def test_from_pdb_and_smiles(self):

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -57,6 +57,7 @@ from openff.toolkit.utils.exceptions import (
     InvalidConformerError,
     NotAttachedToMoleculeError,
     SmilesParsingError,
+    UnsupportedFileTypeError,
 )
 from openff.toolkit.utils.serialization import Serializable
 from openff.toolkit.utils.toolkits import (
@@ -4742,6 +4743,14 @@ class FrozenMolecule(Serializable):
             else:
                 file_format = file_path.split(".")[-1]
         file_format = file_format.upper()
+
+        if file_format == "XYZ":
+            raise UnsupportedFileTypeError(
+                "Parsing `.xyz` files is not currently supported because they lack sufficient "
+                "chemical information to be used with SMIRNOFF force fields. For more information, "
+                "see https://open-forcefield-toolkit.readthedocs.io/en/latest/faq.html or to provide "
+                "feedback please visit https://github.com/openforcefield/openff-toolkit/issues/1145."
+            )
 
         # Determine which toolkit to use (highest priority that's compatible with input type)
         if isinstance(toolkit_registry, ToolkitRegistry):

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -300,3 +300,7 @@ class MissingIndexedAttributeError(
     OpenFFToolkitException, IndexError, KeyError, AttributeError
 ):
     """Error raised when an indexed attribute does not exist"""
+
+
+class UnsupportedFileTypeError(OpenFFToolkitException):
+    """Error raised when attempting to parse an unsupported file type."""


### PR DESCRIPTION
Partial solution for confusing user experiences (#1137), possibly to be changed in the future pending decisions #1145

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
