### PR TITLE
Fix #1150

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -16,9 +16,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 - [PR #1130](https://github.com/openforcefield/openforcefield/pull/1130): Running unit tests will
   no longer generate force field files in the local directory.
 - [PR #1151](https://github.com/openforcefield/openforcefield/pull/1151): Fixes 
-  [Issue #1151](https://github.com/openforcefield/openff-toolkit/issues/1151), in which calling 
-  [`Molecule.assign_fractional_bond_orders`](openff.toolkit.topology.Molecule.assign_fractional_bond_orders) with all
-  default arguments would lead to an error as a result of trying to lowercase `None`.
+  [Issue #1150](https://github.com/openforcefield/openff-toolkit/issues/1150), in which calling 
+  [`Molecule.assign_fractional_bond_orders`](openff.toolkit.topology.Molecule.assign_fractional_bond_orders)
+  with all default arguments would lead to an error as a result of trying to lowercase `None`.
 
 
 ### Examples added

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,6 +15,11 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   and no longer accepts input of NetworkX graphs.
 - [PR #1130](https://github.com/openforcefield/openforcefield/pull/1130): Running unit tests will
   no longer generate force field files in the local directory.
+- [PR #1151](https://github.com/openforcefield/openforcefield/pull/1151): Fixes 
+  [Issue #1151](https://github.com/openforcefield/openff-toolkit/issues/1151), in which calling 
+  [`Molecule.assign_fractional_bond_orders`](openff.toolkit.topology.Molecule.assign_fractional_bond_orders) with all
+  default arguments would lead to an error as a result of trying to lowercase `None`.
+
 
 ### Examples added
 

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -3655,6 +3655,9 @@ class TestMolecule:
         produce unexpected errors, but do not asses validity of results"""
         mol = Molecule.from_smiles("CCO")
 
+        # Test that default model works
+        mol.assign_fractional_bond_orders()
+
         mol.assign_fractional_bond_orders(
             bond_order_model=model,
         )

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -3545,7 +3545,6 @@ class FrozenMolecule(Serializable):
             If an invalid object is passed as the toolkit_registry parameter
 
         """
-        bond_order_model = bond_order_model.lower()
 
         if isinstance(toolkit_registry, ToolkitRegistry):
             return toolkit_registry.call(


### PR DESCRIPTION
- [x] Fixes #1150 by not lowercasing `bond_order_model` in `Molecule.assign_fractional_bond_orders`. Note that both `OpenEyeToolkitWrapper.assign_fractional_bond_orders` and `AmberToolsToolkitWrapper.assign_fractional_bond_orders` explicitly change `None` to `am1-wiberg` and perform lowercasing internally, so lowercasing the argument in `Molecule.assign_fractional_bond_orders` is redundant. 
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
