### PR TITLE
Remove deprecated exceptions

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -35,6 +35,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   reference molecule from their `.molecule` attribute.
 - [PR #1155](https://github.com/openforcefield/openforcefield/pull/1155): Ensures big-endian
   byte order of NumPy arrays when serialized to dictionaries or files formats except JSON.
+- [PR #1156](https://github.com/openforcefield/openforcefield/pull/1156): Removes `ParseError` and
+  `MessageException`, which has been deprecated since version 0.10.0.
 
 ### Examples added
 

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -4044,7 +4044,7 @@ def test_license_check(monkeypatch):
     assert OpenEyeToolkitWrapper()._check_licenses()
     assert OpenEyeToolkitWrapper().is_available()
 
-    from openff.toolkit.utils.toolkits import requires_openeye_module
+    from openff.toolkit.utils.openeye_wrapper import requires_openeye_module
 
     @requires_openeye_module("oeszybki")
     def func_using_extraneous_openeye_module():

--- a/openff/toolkit/tests/test_utils.py
+++ b/openff/toolkit/tests/test_utils.py
@@ -133,16 +133,3 @@ def test_sort_smirnoff_dict():
     assert smirnoff_dict == OrderedDict(
         sort_smirnoff_dict(forcefield._to_smirnoff_data())
     )
-
-
-def test_import_message_exception_raises_warning(caplog):
-    # TODO: Remove when removing MessageException
-    msg = "DEPRECATED and will be removed in a future release of the OpenFF Toolkit"
-
-    with pytest.warns(DeprecationWarning, match=msg):
-        from openff.toolkit.utils.exceptions import MessageException
-
-    with pytest.warns(None) as rec:
-        from openff.toolkit.utils.exceptions import SMILESParseError
-
-    assert len(rec) == 0

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -63,23 +63,6 @@ from openff.toolkit.utils.utils import (
     requires_package,
 )
 
-deprecated_names = ["ParseError"]
-
-
-def __getattr__(name):
-    if name in deprecated_names:
-        warnings.filterwarnings("default", category=DeprecationWarning)
-        warning_msg = f"{name} is DEPRECATED and will be removed in a future release of the OpenFF Toolkit."
-        warnings.warn(warning_msg, DeprecationWarning)
-
-        if name == "ParseError":
-            from openff.toolkit.utils.exceptions import _DeprecatedParseError
-
-            return _DeprecatedParseError
-
-    raise AttributeError(f"module {__name__} has no attribute {name}")
-
-
 # =============================================================================================
 # CONFIGURE LOGGER
 # =============================================================================================

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -31,7 +31,6 @@ import copy
 import logging
 import os
 import pathlib
-import warnings
 from collections import OrderedDict
 from typing import List
 

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -1,40 +1,7 @@
 import warnings
 
-deprecated_names = ["MessageException", "ParseError"]
 
-# TODO: Remove in January 2022
-# TODO: When _DepcreatedMessageException is removed, this should be removed. Also
-#       include in release notes that ParseError no longer exists
-def __getattr__(name):
-    if name in deprecated_names:
-        warnings.filterwarnings("default", category=DeprecationWarning)
-        warning_msg = f"{name} is DEPRECATED and will be removed in a future release of the OpenFF Toolkit."
-        if name == "MessageException":
-            warning_msg += (
-                " All custom exceptions now inherit from OpenFFToolkitException, "
-                "which should be used as a replacement for MessageException. Import it via "
-                "`from openff.toolkit.utils.exceptions import OpenFFToolkitException`."
-            )
-        warnings.warn(warning_msg, DeprecationWarning)
-        return globals()[f"_Deprecated{name}"]
-    raise AttributeError(f"module {__name__} has no attribute {name}")
-
-
-# TODO: Remove in January 2022
-class _DeprecatedMessageException(Exception):
-    """DEPRECATED: A base class for exceptions that print out a string given in their constructor"""
-
-    def __init__(self, msg):
-        super().__init__(self, msg)
-        self.msg = msg
-
-    def __str__(self):
-        return self.msg
-
-
-# TODO: Remove _DeprecatedMessageException (the import here and its definition above)
-# and make this exception only import from Exception
-class OpenFFToolkitException(_DeprecatedMessageException):
+class OpenFFToolkitException(Exception):
     """Base exception for custom exceptions raised by the OpenFF Toolkit"""
 
     def __init__(self, msg):
@@ -208,12 +175,7 @@ class SMIRNOFFAromaticityError(OpenFFToolkitException):
     """
 
 
-# TODO: Remove in January 2022
-class _DeprecatedParseError(_DeprecatedMessageException):
-    """DEPRECATED: Error for when a SMIRNOFF data structure is not parseable by a ForceField"""
-
-
-class SMIRNOFFParseError(OpenFFToolkitException, _DeprecatedParseError):
+class SMIRNOFFParseError(OpenFFToolkitException):
     """
     Error for when a SMIRNOFF data structure is not parseable by a ForceField
     """

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -1,6 +1,3 @@
-import warnings
-
-
 class OpenFFToolkitException(Exception):
     """Base exception for custom exceptions raised by the OpenFF Toolkit"""
 

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -58,7 +58,6 @@ __all__ = (
 
 
 import logging
-import warnings
 
 from openff.toolkit.utils.ambertools_wrapper import AmberToolsToolkitWrapper
 from openff.toolkit.utils.base_wrapper import ToolkitWrapper
@@ -89,10 +88,7 @@ from openff.toolkit.utils.exceptions import (
     ToolkitUnavailableException,
     UndefinedStereochemistryError,
 )
-from openff.toolkit.utils.openeye_wrapper import (
-    OpenEyeToolkitWrapper,
-    requires_openeye_module,
-)
+from openff.toolkit.utils.openeye_wrapper import OpenEyeToolkitWrapper
 from openff.toolkit.utils.rdkit_wrapper import RDKitToolkitWrapper
 from openff.toolkit.utils.toolkit_registry import ToolkitRegistry
 

--- a/openff/toolkit/utils/toolkits.py
+++ b/openff/toolkit/utils/toolkits.py
@@ -96,19 +96,6 @@ from openff.toolkit.utils.openeye_wrapper import (
 from openff.toolkit.utils.rdkit_wrapper import RDKitToolkitWrapper
 from openff.toolkit.utils.toolkit_registry import ToolkitRegistry
 
-deprecated_names = ["MessageException"]
-
-# TODO: Remove in January 2022, see _DeprecatedMessageException in openff/toolkit/utils/exceptions.py
-def __getattr__(name):
-    if name in deprecated_names:
-        warnings.filterwarnings("default", category=DeprecationWarning)
-        from openff.toolkit.utils.exceptions import MessageException
-
-        return MessageException
-        # return globals()[f"MessageException"]
-    raise AttributeError(f"module {__name__} has no attribute {name}")
-
-
 # =============================================================================================
 # CONFIGURE LOGGER
 # =============================================================================================


### PR DESCRIPTION
In #1021 we added some deprecated exceptions with the plan to remove them in January 2022.

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
