### PR TITLE
Fix Molecule._ipython_display_ breaking without nglview

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -24,6 +24,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   [`Molecule.generate_conformers`](openff.toolkit.topology.Molecule.generate_conformers)
   using the OpenEye backend would use the stereochemistry from an existing conformer instead 
   of the stereochemistry from the molecular graph, leading to undefined behavior if the molecule had a 2D conformer. 
+- [PR #1158](https://github.com/openforcefield/openff-toolkit/pull/1158): Fixes the default
+  representation of [`Molecule`](openff.toolkit.topology.Molecule) failing in Jupyter notebooks when
+  NGLview is not installed.
 - [PR #1151](https://github.com/openforcefield/openforcefield/pull/1151): Fixes 
   [Issue #1150](https://github.com/openforcefield/openff-toolkit/issues/1150), in which calling 
   [`Molecule.assign_fractional_bond_orders`](openff.toolkit.topology.Molecule.assign_fractional_bond_orders)

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -3822,6 +3822,15 @@ class TestMoleculeVisualization:
 
         assert isinstance(mol.visualize(backend="openeye"), IPython.core.display.Image)
 
+    @pytest.mark.skipif(
+        has_pkg("nglview"),
+        reason="Test requires that NGLview is not installed",
+    )
+    def test_ipython_repr_no_nglview(self):
+        """Test that the default Molecule repr does not break when nglview is not installed"""
+        molecule = Molecule().from_smiles("CCO")
+        molecule._ipython_display_()
+
 
 class MyMol(FrozenMolecule):
     """

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -51,7 +51,7 @@ class IncompatibleUnitError(OpenFFToolkitException):
     """
 
 
-class MissingDependencyError(OpenFFToolkitException):
+class MissingDependencyError(OpenFFToolkitException, ImportError):
     """
     Exception for when an optional dependency is needed but not installed
 


### PR DESCRIPTION
Fixes #1157, which I _think_ was introduced in #1021 and a part of 0.10.1.

`nglview` is pulled in by all of our test environments, so the unit tests does not actually do anything on CI now. 

```
$ conda-tree whoneeds nglview                                 viz-no-nglview  ✈ ✱
['qcportal']
$ grep -r qcportal devtools                                   viz-no-nglview  ✈ ✱
devtools/conda-envs/rdkit.yaml:  - qcportal
devtools/conda-envs/openeye.yaml:  - qcportal
devtools/conda-envs/beta_rc_env.yaml:  - qcportal
devtools/conda-envs/test_env.yaml:  - qcportal
```

It fails locally before the fix (d37070b44af27e09174116b67f5d2c7b83549204); I guess you'll have to take me on my word there.

Reviewing this should include firing up a notebook and reproducing #1157 with and without these changes.

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
