### PR TITLE
Turn off `--warn-unused-ignores` to avoid false failures

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,7 +136,7 @@ jobs:
         run: pytest -r fE --tb=short openff/toolkit/tests/test_links.py
 
       - name: Run mypy
-        if: ${{ matrix.rdkit == true && matrix.openeye == true && }}
+        if: ${{ matrix.rdkit == true && matrix.openeye == true }}
         run: mypy --namespace-packages -p "openff.toolkit"
 
       - name: Run unit tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -136,7 +136,7 @@ jobs:
         run: pytest -r fE --tb=short openff/toolkit/tests/test_links.py
 
       - name: Run mypy
-        if: ${{ matrix.rdkit == true && matrix.openeye == true }}
+        if: ${{ matrix.rdkit == true && matrix.openeye == true && }}
         run: mypy --namespace-packages -p "openff.toolkit"
 
       - name: Run unit tests

--- a/openff/toolkit/utils/serialization.py
+++ b/openff/toolkit/utils/serialization.py
@@ -317,7 +317,7 @@ class Serializable(abc.ABC):
 
         yaml.SafeDumper.add_representer(
             OrderedDict,
-            lambda dumper, value: self._represent_odict(  # type: ignore[name-defined]
+            lambda dumper, value: self._represent_odict(
                 dumper, u"tag:yaml.org,2002:map", value
             ),
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ parentdir_prefix = openff-toolkit-
 [mypy]
 plugins = numpy.typing.mypy_plugin
 warn_unused_configs = True
-warn_unused_ignores = True
 show_error_codes = True
 disable_error_code = no-redef
 


### PR DESCRIPTION
I set up Mypy with [`--warn-unused-ignores`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-warn-unused-ignores), which actually throws an error. This has been causing what I see as false negative test failures in CI for a few weeks now. I've fixed it locally but I think the option should just be turned off in CI. It's not a bad idea to use it locally when making bigger changes.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
