### PR TITLE
Use dicts to map between Identical molecules and atom maps

### DIFF
--- a/openff/toolkit/utils/serialization.py
+++ b/openff/toolkit/utils/serialization.py
@@ -317,7 +317,7 @@ class Serializable(abc.ABC):
 
         yaml.SafeDumper.add_representer(
             OrderedDict,
-            lambda dumper, value: self._represent_odict(  # type: ignore[name-defined]
+            lambda dumper, value: self._represent_odict(
                 dumper, u"tag:yaml.org,2002:map", value
             ),
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ parentdir_prefix = openff-toolkit-
 [mypy]
 plugins = numpy.typing.mypy_plugin
 warn_unused_configs = True
-warn_unused_ignores = True
 show_error_codes = True
 disable_error_code = no-redef
 


### PR DESCRIPTION
This PR implements a small change to `Topology.identical_molecule_groups` that I request, see [here](https://github.com/openforcefield/openff-toolkit/pull/951#issuecomment-1006942523). Currently, the function returns a nested structure in which lists are uses to map between (topology) molecule indices and atom maps in a way that a dictionary is more naturally suited for.

To illustrate the behavior change, I split out the [docexample](https://github.com/openforcefield/openff-toolkit/blob/3a81f9efc0997d8661da534589405a52fdd3c19e/openff/toolkit/topology/topology.py#L1200) into a script:
```
$ python ex.py
{0: [[0, {0: 0, 1: 1, 2: 2}], [1, {0: 1, 1: 0, 2: 2}]]}
$ git checkout identical-molecules-dict
$ python ex.py
{0: [{0: {0: 0, 1: 1, 2: 2}}, {1: {0: 1, 1: 0, 2: 2}}]}
```

- [ ] Mypy passing locally
- [ ] Mypy passing in CI
- [ ] No (new) tests failing in CI
