### PR TITLE
Expand on smirnoff spec in toolkit docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ import sphinx
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+# needs_sphinx = "4.4.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -57,6 +57,7 @@ autodoc_default_options = {
     "member-order": "bysource",
 }
 autodoc_preserve_defaults = True
+autodoc_typehints_format = "short"
 
 # Disable NumPy style attributes/methods expecting every method to have its own docs page
 numpydoc_class_members_toctree = False
@@ -66,15 +67,24 @@ numpydoc_show_class_members = False
 
 _python_doc_base = "https://docs.python.org/3.6"
 intersphinx_mapping = {
-    _python_doc_base: None,
-    "https://numpy.org/doc/stable": None,
-    "https://docs.scipy.org/doc/scipy/reference": None,
-    "https://scikit-learn.org/stable": None,
-    "http://docs.openmm.org/latest/api-python/": None,
-    "https://www.rdkit.org/docs": None,
-    "https://docs.eyesopen.com/toolkits/python/": None,
-    "https://www.mdtraj.org/1.9.5/": None,
+    "python": ("https://docs.python.org/3.6", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "scikit.learn": ("https://scikit-learn.org/stable", None),
+    "openmm": ("http://docs.openmm.org/latest/api-python/", None),
+    "rdkit": ("https://www.rdkit.org/docs", None),
+    "openeye": ("https://docs.eyesopen.com/toolkits/python/", None),
+    "mdtraj": ("https://www.mdtraj.org/1.9.5/", None),
+    "openff.interchange": (
+        "https://openff-interchange.readthedocs.io/en/stable/",
+        None,
+    ),
+    "openff.fragmenter": ("https://fragmenter.readthedocs.io/en/stable/", None),
 }
+myst_url_schemes = [
+    "http",
+    "https",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -8,6 +8,10 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ## Current development
 
+### Improved documentation and warnings
+
+- [PR #1173](https://github.com/openforcefield/openforcefield/pull/1173): Expand
+  on the SMIRNOFF section of the toolkit docs
 
 ## 0.10.2 Bugfix release
 

--- a/docs/users/smirnoff.md
+++ b/docs/users/smirnoff.md
@@ -1,2 +1,76 @@
-:::{include} ../../The-SMIRNOFF-force-field-format.md
+# SMIRNOFF (SMIRks Native Open Force Field)
+
+:::{hint} 
+The actual text of the SMIRNOFF specification has been moved to the
+[standards repository].
 :::
+
+OpenFF releases all its force fields in SMIRNOFF format. SMIRNOFF is a format
+developed by OpenFF; its specification can be found in our
+[standards repository]. SMIRNOFF-format force fields are distributed as XML
+files with the `.offxml` extension. Instead of using atom types like
+traditional force field formats, SMIRNOFF associates parameters directly with
+chemical groups using [SMARTS] and [SMIRKS], which are extensions of the
+popular SMILES serialization format for molecules. SMIRNOFF goes to great
+lengths to ensure reproducibility of results generated from its force fields.
+
+The OpenFF Toolkit is the reference implementation of the SMIRNOFF spec. The
+toolkit is responsible for reading and writing `.offxml` files, for
+facilitating their modification, and for applying them to a molecular system in
+order to produce an [`Interchange`] object. The OpenFF Interchange project then
+takes over and is responsible for [producing input files and data] for actual
+MD software. The toolkit strives to be backwards compatible with old versions
+of the spec, but owing to the vagaries of the arrow of time cannot be forward
+compatible. Trying to use an old version of the toolkit to load an `.OFFXML`
+file created with a new version of the spec will lead to an error.
+
+A simplified `.offxml` file for TIP3P water might look like this:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+    <Author>The Open Force Field Initiative</Author>
+    <Date>2021-08-16</Date>
+    <Constraints version="0.3">
+        <Constraint smirks="[#1:1]-[#8X2H2+0:2]-[#1]" id="c-tip3p-H-O" distance="0.9572 * angstrom"></Constraint>
+        <Constraint smirks="[#1:1]-[#8X2H2+0]-[#1:2]" id="c-tip3p-H-O-H" distance="1.5139006545247014 * angstrom"></Constraint>
+    </Constraints>
+    <vdW version="0.3" potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" cutoff="9.0 * angstrom" switch_width="1.0 * angstrom" method="cutoff">
+        <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" epsilon="0.1521 * mole**-1 * kilocalorie" id="n-tip3p-O" sigma="3.1507 * angstrom"></Atom>
+        <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" epsilon="0 * mole**-1 * kilocalorie" id="n-tip3p-H" sigma="1 * angstrom"></Atom>
+    </vdW>
+    <Electrostatics version="0.3" scale12="0.0" scale13="0.0" scale14="0.8333333333" scale15="1.0" cutoff="9.0 * angstrom" switch_width="0.0 * angstrom" method="PME"></Electrostatics>
+    <LibraryCharges version="0.3">
+        <LibraryCharge smirks="[#1]-[#8X2H2+0:1]-[#1]" charge1="-0.834 * elementary_charge" id="q-tip3p-O"></LibraryCharge>
+        <LibraryCharge smirks="[#1:1]-[#8X2H2+0]-[#1]" charge1="0.417 * elementary_charge" id="q-tip3p-H"></LibraryCharge>
+    </LibraryCharges>
+</SMIRNOFF>
+```
+
+:::{note} TIP3P's geometry is specified entirely by constraints, but SMIRNOFF
+   certainly supports a wide variety of bonded parameters and functional
+   forms.
+:::
+
+Note that this format specifies not just the individual parameters, but also their
+functional forms and units in very explicit terms. This both makes it easy to read
+and means that the correct implementation of each force is specifically defined,
+rather than being left up to the MD engine.
+
+The complicated part is that each parameter is specified by a SMIRKS code. These
+codes are SMARTS codes with an optional numerical index on some atoms given
+after a colon. This indexing system comes from SMIRKS. Each parameter expects a
+certain number of indexed atoms, and applies the force accordingly. Unindexed
+atoms are used to match the chemistry, but forces are not applied to them.
+SMARTS/SMIRKS codes are less intimidating than they look; `[#1]` matches any
+Hydrogen atom (atomic number 1), while `[#8X2H2+0]` matches an oxygen atom
+(atomic number 8) with some additional constraints. Dashes represent bonds. So
+`[#1]-[#8X2H2+0:1]-[#1]` represents an oxygen atom indexed as 1 connected to
+two unindexed hydrogen atoms. This system allows individual parameters to be as
+general or as specific as needed.
+
+[SMARTS]: https://www.daylight.com/dayhtml/doc/theory/theory.smarts.html
+[SMIRKS]: https://www.daylight.com/dayhtml/doc/theory/theory.smirks.html
+[standards repository]: https://openforcefield.github.io/standards/standards/smirnoff/
+[`Interchange`]: openff.interchange.components.interchange.Interchange
+[producing input files and data]: openff.interchange:using/output

--- a/docs/users/smirnoff.md
+++ b/docs/users/smirnoff.md
@@ -1,9 +1,10 @@
 # SMIRNOFF (SMIRks Native Open Force Field)
 
-:::{hint} 
-The actual text of the SMIRNOFF specification has been moved to the
-[standards repository].
-:::
+## The SMIRNOFF specification
+
+The SMIRNOFF specification can be found in the OpenFF [standards repository].
+
+## SMIRNOFF and the Toolkit
 
 OpenFF releases all its force fields in SMIRNOFF format. SMIRNOFF is a format
 developed by OpenFF; its specification can be found in our
@@ -74,3 +75,8 @@ general or as specific as needed.
 [standards repository]: https://openforcefield.github.io/standards/standards/smirnoff/
 [`Interchange`]: openff.interchange.components.interchange.Interchange
 [producing input files and data]: openff.interchange:using/output
+
+:::{hint} 
+This page is not the SMIRNOFF spec; it has been moved to the
+[standards repository].
+:::


### PR DESCRIPTION
The fabled smirnoff spec PR part 2 is here!

This PR expands the SMIRNOFF page in the toolkit docs to describe the role of the SMIRNOFF spec for newcomers to the toolkit, as well as its relevance to the toolkit.

- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
