### PR TITLE
Fix topology serialization / reinitialization

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -18,7 +18,6 @@ TODO:
   serialized OFFMols.
 
 """
-
 import copy
 import os
 import pickle
@@ -26,9 +25,9 @@ from tempfile import NamedTemporaryFile
 
 import numpy as np
 import pytest
+from mendeleev import element
 from openff.units import unit
 from openmm import unit as openmm_unit
-from openmm.app import element
 
 from openff.toolkit.tests.create_molecules import (
     create_acetaldehyde,
@@ -303,31 +302,28 @@ class TestAtom:
         atom1 = Atom(6, 1 * unit.elementary_charge, False)
         assert atom1.formal_charge == 1 * unit.elementary_charge
 
-    def test_atom_properties(self):
+    @pytest.mark.parametrize("atomic_number", range(1, 118))
+    def test_atom_properties(self, atomic_number):
         """Test that atom properties are correctly populated and gettable"""
         formal_charge = 0 * unit.elementary_charge
         is_aromatic = False
-        # Attempt to create all elements supported by OpenMM
-        elements = [
-            getattr(element, name)
-            for name in dir(element)
-            if (type(getattr(element, name)) == element.Element)
-        ]
-        # The above runs into a problem with deuterium (fails name assertion)
-        elements.remove(element.deuterium)
-        for this_element in elements:
-            atom = Atom(
-                this_element.atomic_number,
-                formal_charge,
-                is_aromatic,
-                name=this_element.name,
-            )
-            assert atom.atomic_number == this_element.atomic_number
-            assert atom.element == this_element
-            assert atom.mass == this_element.mass
-            assert atom.formal_charge == formal_charge
-            assert atom.is_aromatic == is_aromatic
-            assert atom.name == this_element.name
+
+        this_element = element(atomic_number)
+
+        atom = Atom(
+            this_element.atomic_number,
+            formal_charge,
+            is_aromatic,
+            name=this_element.name,
+        )
+        assert atom.atomic_number == this_element.atomic_number
+        # Equality comparison fails with mendeleev v0.9.0 and older,
+        # should be fixed when a new release is made
+        # assert atom.element == this_element
+        assert atom.formal_charge == formal_charge
+        assert atom.is_aromatic == is_aromatic
+        assert atom.name == this_element.name
+        assert atom.mass == this_element.mass
 
     def test_atom_metadata(self):
         """Test that atom metadata behaves as expected"""
@@ -3390,13 +3386,11 @@ class TestMolecule:
         # Create chiral molecule
         toolkit_wrapper = OpenEyeToolkitWrapper()
         molecule = Molecule()
-        atom_C = molecule.add_atom(
-            element.carbon.atomic_number, 0, False, stereochemistry="R", name="C"
-        )
-        atom_H = molecule.add_atom(element.hydrogen.atomic_number, 0, False, name="H")
-        atom_Cl = molecule.add_atom(element.chlorine.atomic_number, 0, False, name="Cl")
-        atom_Br = molecule.add_atom(element.bromine.atomic_number, 0, False, name="Br")
-        atom_F = molecule.add_atom(element.fluorine.atomic_number, 0, False, name="F")
+        atom_C = molecule.add_atom(6, 0, False, stereochemistry="R", name="C")
+        atom_H = molecule.add_atom(1, 0, False, name="H")
+        atom_Cl = molecule.add_atom(17, 0, False, name="Cl")
+        atom_Br = molecule.add_atom(35, 0, False, name="Br")
+        atom_F = molecule.add_atom(35, 0, False, name="F")
         molecule.add_bond(atom_C, atom_H, 1, False)
         molecule.add_bond(atom_C, atom_Cl, 1, False)
         molecule.add_bond(atom_C, atom_Br, 1, False)
@@ -3459,13 +3453,11 @@ class TestMolecule:
         # Create chiral molecule
         toolkit_wrapper = RDKitToolkitWrapper()
         molecule = Molecule()
-        atom_C = molecule.add_atom(
-            element.carbon.atomic_number, 0, False, stereochemistry="R", name="C"
-        )
-        atom_H = molecule.add_atom(element.hydrogen.atomic_number, 0, False, name="H")
-        atom_Cl = molecule.add_atom(element.chlorine.atomic_number, 0, False, name="Cl")
-        atom_Br = molecule.add_atom(element.bromine.atomic_number, 0, False, name="Br")
-        atom_F = molecule.add_atom(element.fluorine.atomic_number, 0, False, name="F")
+        atom_C = molecule.add_atom(6, 0, False, stereochemistry="R", name="C")
+        atom_H = molecule.add_atom(1, 0, False, name="H")
+        atom_Cl = molecule.add_atom(17, 0, False, name="Cl")
+        atom_Br = molecule.add_atom(35, 0, False, name="Br")
+        atom_F = molecule.add_atom(9, 0, False, name="F")
         molecule.add_bond(atom_C, atom_H, 1, False)
         molecule.add_bond(atom_C, atom_Cl, 1, False)
         molecule.add_bond(atom_C, atom_Br, 1, False)

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -116,6 +116,8 @@ class TestTopology:
 
     def test_reinitialization_box_vectors(self):
         topology = Topology()
+        assert Topology(topology).box_vectors is None
+
         topology.box_vectors = [1, 2, 3] * unit.nanometer
         topology_copy = Topology(topology)
 

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -114,6 +114,13 @@ class TestTopology:
         assert not topology.is_periodic
         assert len(topology.constrained_atom_pairs.items()) == 0
 
+    def test_reinitialization_box_vectors(self):
+        topology = Topology()
+        topology.box_vectors = [1, 2, 3] * unit.nanometer
+        topology_copy = Topology(topology)
+
+        assert (topology.box_vectors == topology_copy.box_vectors).all()
+
     def test_box_vectors(self):
         """Test the getter and setter for box_vectors"""
         topology = Topology()

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -142,6 +142,7 @@ class TestTopology:
         for bad_vectors in [
             bad_shape_vectors,
             bad_units_vectors,
+            bad_type_vectors,
             unitless_vectors,
         ]:
             with pytest.raises(InvalidBoxVectorsError):

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -126,12 +126,17 @@ class TestTopology:
     def test_box_vectors(self):
         """Test the getter and setter for box_vectors"""
         topology = Topology()
-        good_box_vectors = unit.Quantity(np.eye(3) * 20 * unit.angstrom)
-        one_dim_vectors = unit.Quantity(np.ones(3) * 20 * unit.angstrom)
-        list_vectors = [20, 20, 20] * unit.angstrom
-        bad_shape_vectors = unit.Quantity(np.ones(2) * 20 * unit.angstrom)
-        bad_units_vectors = unit.Quantity(np.ones(3) * 20 * unit.year)
+        good_box_vectors = unit.Quantity(np.eye(3) * 20, unit.angstrom)
+        one_dim_vectors = unit.Quantity(np.ones(3) * 20, unit.angstrom)
+        list_vectors = unit.Quantity([20, 20, 20], unit.angstrom)
+        list_list_vectors = unit.Quantity(
+            [[20, 0, 0], [0, 20, 0], [0, 0, 20]], unit.angstrom
+        )
+        bad_shape_vectors = unit.Quantity(np.ones(2) * 20, unit.angstrom)
+        bad_units_vectors = unit.Quantity(np.ones(3) * 20, unit.year)
+        bad_type_vectors = unit.Quantity(1.0, unit.nanometer)
         unitless_vectors = np.array([10, 20, 30])
+
         assert topology.box_vectors is None
 
         for bad_vectors in [
@@ -143,7 +148,12 @@ class TestTopology:
                 topology.box_vectors = bad_vectors
             assert topology.box_vectors is None
 
-        for good_vectors in [good_box_vectors, one_dim_vectors, list_vectors]:
+        for good_vectors in [
+            good_box_vectors,
+            one_dim_vectors,
+            list_vectors,
+            list_list_vectors,
+        ]:
             topology.box_vectors = good_vectors
             assert (topology.box_vectors == good_vectors * np.eye(3)).all()
 

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -576,7 +576,7 @@ class Topology(Serializable):
                 )
         else:
             raise InvalidBoxVectorsError(
-                f"Cannot set box vectors with object of type {box_vectors.shape}"
+                f"Cannot set box vectors with object of type {type(box_vectors)}"
             )
 
         self._box_vectors = box_vectors

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -574,13 +574,10 @@ class Topology(Serializable):
                 raise InvalidBoxVectorsError(
                     f"Box vectors must be shape (3, 3). Found shape {box_vectors.shape}"
                 )
-        elif isinstance(box_vectors, list):
-            if len(box_vectors) == 3:
-                box_vectors = box_vectors * np.eye(3)
-            else:
-                raise InvalidBoxVectorsError(
-                    f"Box vectors must be shape (3, 3). Found shape {box_vectors.shape}"
-                )
+        else:
+            raise InvalidBoxVectorsError(
+                f"Cannot set box vectors with object of type {box_vectors.shape}"
+            )
 
         self._box_vectors = box_vectors
 

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1343,7 +1343,6 @@ class Topology(Serializable):
         else:
             # The box_vectors setters _should_ ensure (3, 3) shape, and
             # to_dict enforces this at serialization time
-            charges_shape = (self.n_atoms,)
             box_vectors_unitless = deserialize_numpy(
                 topology_dict["box_vectors"],
                 (3, 3),

--- a/openff/toolkit/utils/serialization.py
+++ b/openff/toolkit/utils/serialization.py
@@ -317,7 +317,7 @@ class Serializable(abc.ABC):
 
         yaml.SafeDumper.add_representer(
             OrderedDict,
-            lambda dumper, value: self._represent_odict(  # type: ignore[name-defined]
+            lambda dumper, value: self._represent_odict(
                 dumper, u"tag:yaml.org,2002:map", value
             ),
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,6 @@ parentdir_prefix = openff-toolkit-
 [mypy]
 plugins = numpy.typing.mypy_plugin
 warn_unused_configs = True
-warn_unused_ignores = True
 show_error_codes = True
 disable_error_code = no-redef
 


### PR DESCRIPTION
**In the refactor branch only** I found I couldn't re-initialize a `Topology` if it already had box vectors, and after some digging I believe the cause is me not considering this case when I re-wrote the serialization methods. There was also some bad logic that slipped in, mostly because there wasn't yet a test for this behavior.

```
In [1]: from openff.toolkit.topology import Topology

In [2]: from openff.units import unit

In [3]: foo = Topology()

In [4]: foo.box_vectors = [1, 2, 3] * unit.nanometer

In [5]: Topology(foo)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/miniconda3/envs/openff-dev/lib/python3.7/site-packages/pint/quantity.py in __getattr__(self, item)
   1889         try:
-> 1890             return getattr(self._magnitude, item)
   1891         except AttributeError:

AttributeError: 'float' object has no attribute '_value'

During handling of the above exception, another exception occurred:

AttributeError                            Traceback (most recent call last)
<ipython-input-5-7a14f5f6a055> in <module>
----> 1 Topology(foo)

~/software/openforcefield/openff/toolkit/topology/topology.py in __init__(self, other)
    424         # TODO: Try to construct Topology copy from `other` if specified
    425         if isinstance(other, Topology):
--> 426             self.copy_initializer(other)
    427         elif isinstance(other, FrozenMolecule):
    428             self.from_molecules([other])

~/software/openforcefield/openff/toolkit/topology/topology.py in copy_initializer(self, other)
   1277     def copy_initializer(self, other):
   1278         other_dict = copy.deepcopy(other.to_dict())
-> 1279         self._initialize_from_dict(other_dict)
   1280
   1281     def to_dict(self):

~/software/openforcefield/openff/toolkit/topology/topology.py in _initialize_from_dict(self, topology_dict)
   1325             self._box_vectors = None
   1326         else:
-> 1327             self.box_vectors = string_to_quantity(topology_dict["box_vectors"])
   1328         for molecule_dict in topology_dict["molecules"]:
   1329             new_mol = Molecule.from_dict(molecule_dict)

~/software/openforcefield/openff/toolkit/topology/topology.py in box_vectors(self, box_vectors)
    575                     f"Box vectors must be shape (3, 3). Found shape {box_vectors.shape}"
    576                 )
--> 577         elif isinstance(box_vectors._value, list):
    578             if len(box_vectors) == 3:
    579                 box_vectors._value *= np.eye(3)

~/miniconda3/envs/openff-dev/lib/python3.7/site-packages/pint/quantity.py in __getattr__(self, item)
   1892             raise AttributeError(
   1893                 "Neither Quantity object nor its magnitude ({}) "
-> 1894                 "has attribute '{}'".format(self._magnitude, item)
   1895             )
   1896

AttributeError: Neither Quantity object nor its magnitude (0.0) has attribute '_value'

In [6]: foo.box_vectors = None

In [7]: Topology(foo)
Out[7]: <openff.toolkit.topology.topology.Topology at 0x7f88343099d0>
```

This operation is going to be common in Interchange; one of the first things that happens in `Interchange.from_smirnoff` is deepcopying the input topology. This should prevent bad behavior like reported in https://github.com/openforcefield/openff-interchange/issues/141 and also enable the "pre-" and "post-parameterization" dual topology design discussed in a few places (#748 ?)
- [x] Reproduction
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
