### PR TITLE
Faster element lookups in mendeleev

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -84,8 +84,11 @@ from openff.toolkit.utils.utils import (
 # GLOBAL PARAMETERS
 # =============================================================================================
 
-MENDELEEV_ELEMENTS_DATAFRAME = fetch_table("elements")
-MENDELEEV_ELEMENTS_DATAFRAME.set_index("atomic_number")
+_MENDELEEV_ELEMENTS_DATAFRAME = fetch_table("elements")
+_ATOMIC_NUMBERS_TO_ELEMENTS = {
+    row.atomic_number: getattr(mendeleev, row.symbol)
+    for row in _MENDELEEV_ELEMENTS_DATAFRAME.itertuples()
+}
 
 # TODO: Can we have the `ALLOWED_*_MODELS` list automatically appear in the docstrings below?
 # TODO: Should `ALLOWED_*_MODELS` be objects instead of strings?
@@ -419,9 +422,7 @@ class Atom(Particle):
         -------
         mendeleev.models.Element
         """
-        return getattr(
-            mendeleev, MENDELEEV_ELEMENTS_DATAFRAME.loc[self.atomic_number, "symbol"]
-        )
+        return _ATOMIC_NUMBERS_TO_ELEMENTS[self.atomic_number]
 
     @property
     def atomic_number(self):
@@ -7258,11 +7259,8 @@ def _atom_nums_to_hill_formula(atom_nums: List[int]) -> str:
     Hill formula. See https://en.wikipedia.org/wiki/Chemical_formula#Hill_system"""
     from collections import Counter
 
-    atom_number_counts = Counter(atom_nums)
-    atom_symbol_counts = dict()
-    for atom_num, count in atom_number_counts.items():
-        symbol = MENDELEEV_ELEMENTS_DATAFRAME.loc[atom_num, "symbol"]
-        atom_symbol_counts[symbol] = count
+    atom_symbol_counts = Counter(_ATOMIC_NUMBERS_TO_ELEMENTS[atom_num].symbol
+                                 for atom_num in atom_nums)
 
     formula = []
     # Check for C and H first, to make a correct hill formula


### PR DESCRIPTION
- [x] Used tips from https://github.com/lmmentel/mendeleev/issues/7 to speed up element/symbol lookups, solving the performance regression identified in https://github.com/openforcefield/openff-toolkit/pull/951#issuecomment-1000428092
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase

Reproducing code from Matt's post above:

```python
import time

import numpy as np
from openff.toolkit.topology import Molecule, Topology

molecule = Molecule.from_smiles("CCO")

for n_molecules in np.logspace(0, 2.5, num=10, dtype=int):
    topology = Topology.from_molecules(n_molecules * [molecule])
    openmm_topology = topology.to_openmm()
    start_time = time.time()
    Topology.from_openmm(openmm_topology, unique_molecules=[molecule])
    print(n_molecules, time.time() - start_time)
```

Results before this PR:
```
0.6627719402313232
1 0.698512077331543
3 3.0817441940307617
6 4.673622131347656
12 8.500097036361694
24 22.013742923736572
46 47.690475940704346
87 73.42918682098389
166 154.51772904396057
316 233.0623791217804
```
results after this PR
```
1 0.002974987030029297
1 0.0026962757110595703
3 0.005962848663330078
6 0.014431953430175781
12 0.033457040786743164
24 0.050592899322509766
46 0.09189701080322266
87 0.16967487335205078
166 0.3632802963256836
316 0.8385882377624512
```


So, this gives a good performance improvement, however it makes a mendeleev table (`MENDELEEV_ELEMENTS_DATAFRAME`) at the module scope. I wonder if there's a cleaner way to do this?