### PR TITLE
Switch from Numpydoc to Napoleon for rendering numpy-style docstrings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ import sphinx
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "numpydoc",
+    "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",
     "sphinx.ext.todo",
@@ -57,12 +57,13 @@ autodoc_default_options = {
     "member-order": "bysource",
 }
 autodoc_preserve_defaults = True
+autodoc_typehints_format = "short"
 
-# Disable NumPy style attributes/methods expecting every method to have its own docs page
-numpydoc_class_members_toctree = False
-# Disable numpydoc rendering methods twice
-# https://stackoverflow.com/questions/34216659/sphinx-autosummary-produces-two-summaries-for-each-class
-numpydoc_show_class_members = False
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False
+napoleon_attr_annotations = True
+napoleon_custom_sections = [("attributes", "params_style")]
+napoleon_use_rtype = False
 
 _python_doc_base = "https://docs.python.org/3.6"
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,6 +64,7 @@ napoleon_google_docstring = False
 napoleon_attr_annotations = True
 napoleon_custom_sections = [("attributes", "params_style")]
 napoleon_use_rtype = False
+napoleon_use_param = True
 
 _python_doc_base = "https://docs.python.org/3.6"
 intersphinx_mapping = {

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,13 +7,13 @@ channels:
 dependencies:
     - pip
     # readthedocs dependencies
-    - numpydoc
     - myst-nb
     - myst-parser>=0.13.6
     - docutils
     - sphinx-notfound-page
+    - sphinx>=4.4,<5
     # conda build dependencies
-    - python==3.8.0
+    - python=3.8
     - setuptools
     - numpy
     - openmm

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,7 @@
    contain the root `toctree` directive.
 
 .. _openff-toolkit-index:
+
 Open Force Field Toolkit
 ========================
 

--- a/docs/users/molecule_cookbook.ipynb
+++ b/docs/users/molecule_cookbook.ipynb
@@ -18,7 +18,7 @@
     "1. Using other tools, assemble a graph of a molecule, including all of its atoms, bonds, bond orders, formal charges, and stereochemistry[^rs]\n",
     "2. Use that information to construct a [`Molecule`](openff.toolkit.topology.Molecule)\n",
     "3. Combine a number of `Molecule` objects to construct a [`Topology`](openff.toolkit.topology.Topology)\n",
-    "4. Call [`ForceField.create_openmm_system(topology)`](openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system) to create an OpenMM [`System`](simtk.openmm.openmm.System) (or, in the near future, an OpenFF [`Interchange`](https://github.com/openforcefield/openff-interchange) for painless conversion to all sorts of MD formats)\n",
+    "4. Call [`ForceField.create_openmm_system(topology)`](openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.create_openmm_system) to create an OpenMM [`System`](openmm.openmm.System) (or, in the near future, an OpenFF [`Interchange`](https://github.com/openforcefield/openff-interchange) for painless conversion to all sorts of MD formats)\n",
     "\n",
     "So let's take a look at every way there is to construct a molecule! We'll use zwitterionic L-alanine as an example biomolecule with all the tricky bits - a stereocenter, non-zero formal charges, and bonds of different orders.\n",
     "\n",
@@ -574,7 +574,7 @@
    "source": [
     "### From an OpenMM `Topology`\n",
     "\n",
-    "The [`Topology.from_openmm()`](openff.toolkit.topology.Topology.from_openmm) method constructs an OpenFF `Topology` from an OpenMM [`Topology`](simtk.openmm.app.topology.Topology). The method requires that all the unique molecules in the `Topology` are provided as OpenFF `Molecule` objects, as the structure of an OpenMM `Topology` doesn't include the concept of a molecule. When using this method to create a `Molecule`, this limitation means that the method really only offers a pathway to reorder the atoms of a `Molecule` to match that of the OpenMM `Topology`."
+    "The [`Topology.from_openmm()`](openff.toolkit.topology.Topology.from_openmm) method constructs an OpenFF `Topology` from an OpenMM [`Topology`](openmm.app.topology.Topology). The method requires that all the unique molecules in the `Topology` are provided as OpenFF `Molecule` objects, as the structure of an OpenMM `Topology` doesn't include the concept of a molecule. When using this method to create a `Molecule`, this limitation means that the method really only offers a pathway to reorder the atoms of a `Molecule` to match that of the OpenMM `Topology`."
    ]
   },
   {
@@ -584,7 +584,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from simtk.openmm.app.pdbfile import PDBFile\n",
+    "from openmm.app.pdbfile import PDBFile\n",
     "\n",
     "openmm_topology = PDBFile('zw_l_alanine.pdb').getTopology()\n",
     "openff_topology = Topology.from_openmm(openmm_topology, unique_molecules=[zw_l_alanine])\n",

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1288,14 +1288,17 @@ class TopologyMolecule:
         """
         Return canonicalized pairs of atoms whose shortest separation is `exactly` n bonds.
         Only pairs with increasing atom indices are returned.
+
         Parameters
         ----------
         n: int
             The number of bonds separating atoms in each pair
+
         Returns
         -------
         neighbors: iterator of tuple of TopologyAtom
             Tuples (len 2) of atom that are separated by ``n`` bonds.
+
         Notes
         -----
         The criteria used here relies on minimum distances; when there are multiple valid
@@ -1954,14 +1957,17 @@ class Topology(Serializable):
         """
         Return canonicalized pairs of atoms whose shortest separation is `exactly` n bonds.
         Only pairs with increasing atom indices are returned.
+
         Parameters
         ----------
         n: int
             The number of bonds separating atoms in each pair
+
         Returns
         -------
         neighbors: iterator of tuple of TopologyAtom
             Tuples (len 2) of atom that are separated by ``n`` bonds.
+
         Notes
         -----
         The criteria used here relies on minimum distances; when there are multiple valid

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -113,16 +113,16 @@ def get_available_force_fields(full_paths=False):
     ``openff-forcefields`` package is installed, this should include several
     .offxml files such as ``openff-1.0.0.offxml``\ .
 
-     Parameters
-     ----------
-     full_paths : bool, default=False
-         If False, return the name of each available \*.offxml file.
-         If True, return the full path to each available \*.offxml file.
+    Parameters
+    ----------
+    full_paths : bool, default=False
+        If False, return the name of each available \*.offxml file.
+        If True, return the full path to each available \*.offxml file.
 
-     Returns
-     -------
-     available_force_fields : List[str]
-         List of available force field files
+    Returns
+    -------
+    available_force_fields : List[str]
+        List of available force field files
 
     """
     installed_paths = _get_installed_offxml_dir_paths()
@@ -167,25 +167,9 @@ class ForceField:
     The force field definition is processed by these handlers to populate the ``ForceField`` object model data
     structures that can easily be manipulated via the API:
 
-    Processing a :class:`Topology` object defining a chemical system will then call all :class`ParameterHandler`
+    Processing a :class:`Topology` object defining a chemical system will then call all :class:`ParameterHandler`
     objects in an order guaranteed to satisfy the declared processing order constraints of each
-    :class`ParameterHandler`.
-
-    Attributes
-    ----------
-    parameters : dict of str : list of ParameterType
-        ``parameters[tagname]`` is the instantiated :class:`ParameterHandler` class that handles parameters associated
-        with the force ``tagname``.
-        This is the primary means of retrieving and modifying parameters, such as
-        ``parameters['vdW'][0].sigma *= 1.1``
-    parameter_object_handlers : dict of str : ParameterHandler class
-        Registered list of :class:`ParameterHandler` classes that will handle different force field tags to create the parameter object model.
-        ``parameter_object_handlers[tagname]`` is the :class:`ParameterHandler` that will be instantiated to process the force field definition section ``tagname``.
-        :class:`ParameterHandler` classes are registered when the ForceField object is created, but can be manipulated afterwards.
-    parameter_io_handlers : dict of str : ParameterIOHandler class
-        Registered list of :class:`ParameterIOHandler` classes that will handle serializing/deserializing the parameter object model to string or file representations, such as XML.
-        ``parameter_io_handlers[iotype]`` is the :class:`ParameterHandler` that will be instantiated to process the serialization scheme ``iotype``.
-        :class:`ParameterIOHandler` classes are registered when the ForceField object is created, but can be manipulated afterwards.
+    :class:`ParameterHandler`.
 
     Examples
     --------
@@ -290,7 +274,7 @@ class ForceField:
 
         Load multiple SMIRNOFF parameter sets:
 
-        forcefield = ForceField('test_forcefields/test_forcefield.offxml', 'test_forcefields/tip3p.offxml')
+        >>> forcefield = ForceField('test_forcefields/test_forcefield.offxml', 'test_forcefields/tip3p.offxml')
 
         Load a parameter set from a string:
 

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -1039,7 +1039,7 @@ class ForceField:
         Parameters
         ----------
         source : str or bytes or file-like object
-            File define the SMIRNOFF force field to be loaded
+            File defining the SMIRNOFF force field to be loaded
             Currently, only `the SMIRNOFF XML format <https://openforcefield.github.io/standards/standards/smirnoff/>`_ is supported.
             The file may be an absolute file path, a path relative to the current working directory, a path relative to this module's data subdirectory
             (for built in force fields), or an open file-like object with a ``read()`` method from which the force field XML data can be loaded.

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -845,7 +845,9 @@ class ForceField:
         allow_cosmetic_attributes : bool, optional. Default = False
             Whether to permit non-spec kwargs present in the source.
 
-        .. notes ::
+        Notes
+        -----
+
            * New SMIRNOFF sections are handled independently, as if they were specified in the same file.
            * If a SMIRNOFF section that has already been read appears again, its definitions are appended to the end of the previously-read
              definitions if the sections are configured with compatible attributes; otherwise, an ``IncompatibleTagException`` is raised.

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -354,7 +354,8 @@ class ForceField:
 
         Raises
         ------
-        SMIRNOFFVersionError if an incompatible version is passed in.
+        SMIRNOFFVersionError
+            If an incompatible version is passed in.
 
         """
         import packaging.version
@@ -403,9 +404,11 @@ class ForceField:
 
         Raises
         ------
-        SMIRNOFFAromaticityError if an incompatible aromaticity model is passed in.
+        SMIRNOFFAromaticityError
+            If an incompatible aromaticity model is passed in.
 
-        .. notes ::
+        Notes
+        -----
            * Currently, the only supported aromaticity model is 'OEAroModel_MDL'.
 
         """
@@ -531,7 +534,8 @@ class ForceField:
 
         Raises
         ------
-        Exception if two ParameterIOHandlers are attempted to be registered for the same file format.
+        Exception
+            If two ParameterIOHandlers are attempted to be registered for the same file format.
 
         """
         for parameter_io_handler_class in parameter_io_handler_classes:
@@ -729,7 +733,8 @@ class ForceField:
 
         Raises
         ------
-        KeyError if there is no ParameterHandler for the given tagname
+        KeyError
+            If there is no ParameterHandler for the given tagname
         """
         # If there are no kwargs for the handler, initialize handler_kwargs as an empty dict
         skip_version_check = False
@@ -781,7 +786,8 @@ class ForceField:
 
         Raises
         ------
-        KeyError if there is no ParameterIOHandler for the given tagname
+        KeyError
+            If there is no ParameterIOHandler for the given tagname
         """
         # Uppercase the format string to avoid case mismatches
         io_format = io_format.upper()
@@ -1032,11 +1038,10 @@ class ForceField:
 
         Parameters
         ----------
-        source : str or bytes
-            sources : string or file-like object or open file handle or URL (or iterable of these)
-            A list of files defining the SMIRNOFF force field to be loaded
+        source : str or bytes or file-like object
+            File define the SMIRNOFF force field to be loaded
             Currently, only `the SMIRNOFF XML format <https://openforcefield.github.io/standards/standards/smirnoff/>`_ is supported.
-            Each entry may be an absolute file path, a path relative to the current working directory, a path relative to this module's data subdirectory
+            The file may be an absolute file path, a path relative to the current working directory, a path relative to this module's data subdirectory
             (for built in force fields), or an open file-like object with a ``read()`` method from which the force field XML data can be loaded.
 
         Returns


### PR DESCRIPTION
Numpydoc seems to be broken at the moment. In Interchange and BespokeFit, we use Napoleon, which is built in to Sphinx, to do the same things. This this has one or two direct benefits, like adding links to some types specified in docstrings, but mostly it brings the Toolkit in line with our other projects and simplifies the build environment. It's also distributed with Sphinx, so is less likely to break when it updates.

This PR also includes some corrections and clean ups to docstrings. All of these are existing errors, not the result of any difference in rendering between numpydoc and napoleon.

- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
