### PR TITLE
Normalize package names in requires_package

### DIFF
--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -77,7 +77,8 @@ def requires_package(package_name):
             try:
                 importlib.import_module(package_name)
             except (ImportError, ModuleNotFoundError):
-                raise MissingDependencyError(package_name)
+                package_name_corrected = package_name.replace(".", "-")
+                raise MissingDependencyError(package_name_corrected)
             except Exception as e:
                 raise e
 


### PR DESCRIPTION
A minor nuisance, simply changing the `.` package name to `-` when printing out the "Try installing from conda with ... " line.

```
[openforcefield] cat bar.py                                                           9362b714  ✱
from openff.toolkit.utils.utils import requires_package


@requires_package("openff.recharge")
def foo():
    pass


foo()
[openforcefield] python bar.py                                                        9362b714  ✱
Warning: Unable to load toolkit 'OpenEye Toolkit'. The Open Force Field Toolkit does not require the OpenEye Toolkits, and can use RDKit/AmberTools instead. However, if you have a valid license for the OpenEye Toolkits, consider installing them for faster performance and additional file format support: https://docs.eyesopen.com/toolkits/python/quickstart-python/linuxosx.html OpenEye offers free Toolkit licenses for academics: https://www.eyesopen.com/academic-licensing
Traceback (most recent call last):
  File "/Users/mwt/software/openforcefield/openff/toolkit/utils/utils.py", line 81, in wrapper
    importlib.import_module(package_name)
  File "/Users/mwt/miniconda3/envs/evaluator-test-env/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'openff.recharge'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mwt/software/openforcefield/bar.py", line 9, in <module>
    foo()
  File "/Users/mwt/software/openforcefield/openff/toolkit/utils/utils.py", line 83, in wrapper
    raise MissingDependencyError(package_name)
openff.toolkit.utils.exceptions.MissingDependencyError: Missing dependency openff.recharge. Try installing it with

$ conda install openff.recharge -c conda-forge
[openforcefield] git checkout missing-dep-name                                        9362b714  ✱
Previous HEAD position was 9362b714 Refactor ring methods in Molecule class (#855)
Switched to branch 'missing-dep-name'
[openforcefield] python bar.py                                                missing-dep-name  ✱
Warning: Unable to load toolkit 'OpenEye Toolkit'. The Open Force Field Toolkit does not require the OpenEye Toolkits, and can use RDKit/AmberTools instead. However, if you have a valid license for the OpenEye Toolkits, consider installing them for faster performance and additional file format support: https://docs.eyesopen.com/toolkits/python/quickstart-python/linuxosx.html OpenEye offers free Toolkit licenses for academics: https://www.eyesopen.com/academic-licensing
Traceback (most recent call last):
  File "/Users/mwt/software/openforcefield/openff/toolkit/utils/utils.py", line 78, in wrapper
    importlib.import_module(package_name)
  File "/Users/mwt/miniconda3/envs/evaluator-test-env/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'openff.recharge'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mwt/software/openforcefield/bar.py", line 9, in <module>
    foo()
  File "/Users/mwt/software/openforcefield/openff/toolkit/utils/utils.py", line 81, in wrapper
    raise MissingDependencyError(package_name_corrected)
openff.toolkit.utils.exceptions.MissingDependencyError: Missing dependency openff-recharge. Try installing it with

$ conda install openff-recharge -c conda-forge
```

This is done in `openff-utilities` [here](https://github.com/openforcefield/openff-utilities/blob/v0.1.3/openff/utilities/exceptions.py#L35) if that swap-out can be done instead.