### PR TITLE
Port #896 to biopolymer-topology-refactor branch

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -74,10 +74,7 @@ print(value_roundtrip)
   `openff.toolkit.app` module and re-exports for parameter types to the new `openff.toolkit.topology.parametertypes` module.
   This does not affect existing paths and gives some new, easier to remember paths to core objects.
 - [PR #1198](https://github.com/openforcefield/openforcefield/pull/1198): Ensure the vdW switch
-  width is correctly set and enabled. If the switch width is greater than the cutoff distance, it is
-  considered invalid and an exception
-  ([`InvalidSwitchingDistanceError`](openff.toolkit.utils.exceptions.InvalidSwitchingDistanceError))
-  is raised.
+  width is correctly set and enabled.
 
 ### Behaviors changed and bugfixes
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -73,6 +73,11 @@ print(value_roundtrip)
 - [PR #1192](https://github.com/openforcefield/openforcefield/pull/1192): Add re-exports for core classes to the new
   `openff.toolkit.app` module and re-exports for parameter types to the new `openff.toolkit.topology.parametertypes` module.
   This does not affect existing paths and gives some new, easier to remember paths to core objects.
+- [PR #1198](https://github.com/openforcefield/openforcefield/pull/1198): Ensure the vdW switch
+  width is correctly set and enabled. If the switch width is greater than the cutoff distance, it is
+  considered invalid and an exception
+  ([`InvalidSwitchingDistanceError`](openff.toolkit.utils.exceptions.InvalidSwitchingDistanceError))
+  is raised.
 
 ### Behaviors changed and bugfixes
 

--- a/openff/toolkit/tests/test_parameters.py
+++ b/openff/toolkit/tests/test_parameters.py
@@ -1753,6 +1753,7 @@ class TestvdWType:
     )
     @pytest.mark.parametrize(
         "method",
+        # It's possible that this test should not cover PME (LJ-PME), see comments in parameters.py
         ["PME", "cutoff"],
     )
     def test_switch_width(

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -70,7 +70,7 @@ import re
 from collections import OrderedDict, defaultdict
 from enum import Enum
 from itertools import combinations
-from typing import TYPE_CHECKING, Any, List, Optional, Type, Union
+from typing import Any, List, Optional, Type, Union
 
 from openff.units import unit
 from openff.utilities import requires_package
@@ -111,9 +111,6 @@ from openff.toolkit.utils.utils import (
     extract_serialized_units_from_dict,
     object_to_quantity,
 )
-
-if TYPE_CHECKING:
-    import openmm
 
 # =============================================================================================
 # CONFIGURE LOGGER
@@ -3712,7 +3709,7 @@ class vdWHandler(_NonbondedHandler):
             atom_matches, topology, [(atom,) for atom in topology.atoms]
         )
 
-    def _apply_switching_function(self, force: "openmm.NonbondedForce"):
+    def _apply_switching_function(self, force):
         """Apply a switching function to a NonbondedForce if self.switch_width is nonzero."""
         from openff.units.openmm import to_openmm
 

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -3687,6 +3687,10 @@ class vdWHandler(_NonbondedHandler):
 
                 force.setCutoffDistance(to_openmm(self.cutoff))
 
+        # This applies a switching function whether the vdW method is LJ-PME or cut-off. It's not clear if this is a
+        # valid combination of settings, if this is something that all engines would support, or if it even has an
+        # effect. In OpenMM, it can be applied but it might not have any effect. The SMIRNOFF spec offers no clear
+        # guidance on this combination, but it is possible that is may be revised in the future to do so.
         self._apply_switching_function(force)
 
         # Iterate over all defined Lennard-Jones types, allowing later matches to override earlier ones.

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -3686,7 +3686,7 @@ class vdWHandler(_NonbondedHandler):
                     force.setSwitchingDistance(
                         to_openmm(self.cutoff - self.switch_width)
                     )
-                    force.setUseSwitchingFunction(self.switch_width < self.cutoff)
+                    force.setUseSwitchingFunction(self.switch_width.m > 0)
 
         # If method is cutoff, then we currently support openMM's PME for periodic system and NoCutoff for nonperiodic
         elif self.method == "cutoff":
@@ -3708,7 +3708,7 @@ class vdWHandler(_NonbondedHandler):
                     force.setSwitchingDistance(
                         to_openmm(self.cutoff - self.switch_width)
                     )
-                    force.setUseSwitchingFunction(self.switch_width < self.cutoff)
+                    force.setUseSwitchingFunction(self.switch_width.m > 0)
 
         # Iterate over all defined Lennard-Jones types, allowing later matches to override earlier ones.
         atom_matches = self.find_matches(topology)

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -243,12 +243,6 @@ class SMIRNOFFSpecUnimplementedError(OpenFFToolkitException):
     """
 
 
-class InvalidSwitchingDistanceError(OpenFFToolkitException):
-    """
-    Exception for when a force field specifies a switch distance greater than the cutoff.
-    """
-
-
 class FractionalBondOrderInterpolationMethodUnsupportedError(OpenFFToolkitException):
     """
     Exception for when an unsupported fractional bond order interpolation assignment method is called.

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -243,6 +243,12 @@ class SMIRNOFFSpecUnimplementedError(OpenFFToolkitException):
     """
 
 
+class InvalidSwitchingDistanceError(OpenFFToolkitException):
+    """
+    Exception for when a force field specifies a switch distance greater than the cutoff.
+    """
+
+
 class FractionalBondOrderInterpolationMethodUnsupportedError(OpenFFToolkitException):
     """
     Exception for when an unsupported fractional bond order interpolation assignment method is called.


### PR DESCRIPTION
This PR ports https://github.com/openforcefield/openff-toolkit/pull/896 (by @SimonBoothroyd) to the "refactor" branch according to my proposal [here](https://github.com/openforcefield/openff-toolkit/pull/896), thereby closing it.

Two modifications include
1. Changes after clarifying that `switch_width` is the difference between the "switching distance" (i.e. `setSwitchingDistance`) and cutoff distance. For example, typical values are 9 Angstrom cutoff, 1 Angstrom switch with, and therefore an 8 Angstrom switching distance.
2. Raising an exception (`InvalidSwitchingDistanceError`) if the switch width is greater than the switch distance, which is not a sensible pairing of parameters.

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
