### PR TITLE
Fix incorrect assignment of TIP3P parameters in Sage

### DIFF
--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -3274,6 +3274,21 @@ class TestForceFieldChargeAssignment:
 
         compare_partial_charges(using_kwarg, using_library_charges)
 
+    def test_sage_tip3p_charges(self):
+        """Ensure tip3p charges packaged with sage are applied over AM1-BCC charges.
+        https://github.com/openforcefield/openff-toolkit/issues/1199"""
+        sage = ForceField("openff-2.0.0.offxml")
+
+        topology = Molecule.from_smiles("O").to_topology()
+
+        system = sage.create_openmm_system(topology)
+
+        force = [f for f in system.getForces() if type(f) == openmm.NonbondedForce][0]
+
+        found_charges = [force.getParticleParameters(i)[0]._value for i in range(3)]
+
+        assert np.allclose(found_charges, [-0.834, 0.417, 0.417])
+
 
 # ======================================================================
 # TEST CONSTRAINTS

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -3976,7 +3976,7 @@ class LibraryChargeHandler(_NonbondedHandler):
     _INFOTYPE = LibraryChargeType  # info type to store
     _DEPENDENCIES = [vdWHandler, ElectrostaticsHandler]
 
-    def find_matches(self, entity, unique=True):
+    def find_matches(self, entity, unique=False):
         """Find the elements of the topology/molecule matched by a parameter type.
 
         Parameters


### PR DESCRIPTION
#1199 

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
