### PR TITLE
Remove some internal calls to deprecated API points

### DIFF
--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -2374,7 +2374,7 @@ class TestForceFieldChargeAssignment:
         for particle_index, expected_charge in expected_charges:
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == expected_charge
-        for particle_index in range(topology.n_topology_particles):
+        for particle_index in range(topology.n_particles):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q != (0.0 * unit.elementary_charge)
 
@@ -3061,14 +3061,12 @@ class TestForceFieldChargeAssignment:
             assert q == expected_charge
 
         # Ensure the last molecule (ethanol) had _some_ nonzero charge assigned by an AM1BCC implementation
-        for particle_index in range(len(expected_charges), top.n_topology_atoms - 1):
+        for particle_index in range(len(expected_charges), top.n_atoms - 1):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q != 0 * unit.elementary_charge
 
         # Ensure that iodine has a charge of -1, specified by charge increment model charge_method="formal charge"
-        q, sigma, epsilon = nonbondedForce.getParticleParameters(
-            top.n_topology_atoms - 1
-        )
+        q, sigma, epsilon = nonbondedForce.getParticleParameters(top.n_atoms - 1)
         assert q == -1.0 * openmm_unit.elementary_charge
 
     def test_assign_charges_to_molecule_in_parts_using_multiple_library_charges(self):
@@ -3183,7 +3181,7 @@ class TestForceFieldChargeAssignment:
         nonbondedForce = [
             f for f in omm_system.getForces() if type(f) == NonbondedForce
         ][0]
-        for particle_index in range(top.n_topology_atoms):
+        for particle_index in range(top.n_atoms):
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q != 0 * unit.elementary_charge
 
@@ -4231,9 +4229,7 @@ class TestForceFieldParameterAssignment:
                 idx
             ) == mod_bond_force.getBondParameters(idx)
 
-        for bond1, bond2 in zip(
-            omm_sys_top.topology_bonds, mod_omm_sys_top.topology_bonds
-        ):
+        for bond1, bond2 in zip(omm_sys_top.bonds, mod_omm_sys_top.bonds):
             # 'approx()' because https://github.com/openforcefield/openff-toolkit/issues/994
             assert bond1.fractional_bond_order == pytest.approx(
                 bond2.fractional_bond_order

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -104,12 +104,11 @@ class TestTopology:
     def test_empty(self):
         """Test creation of empty topology"""
         topology = Topology()
-        # assert topology.n_reference_molecules == 0
-        assert topology.n_topology_molecules == 0
-        assert topology.n_topology_atoms == 0
-        assert topology.n_topology_bonds == 0
-        assert topology.n_topology_particles == 0
-        assert topology.n_topology_virtual_sites == 0
+        assert topology.n_molecules == 0
+        assert topology.n_atoms == 0
+        assert topology.n_bonds == 0
+        assert topology.n_particles == 0
+        assert topology.n_virtual_sites == 0
         assert topology.box_vectors is None
         assert not topology.is_periodic
         assert len(topology.constrained_atom_pairs.items()) == 0
@@ -179,71 +178,66 @@ class TestTopology:
         """Test creation of a OpenFF Topology object from a SMILES string"""
         topology = Topology.from_molecules(ethane_from_smiles)
 
-        # assert topology.n_reference_molecules == 1
-        assert topology.n_topology_molecules == 1
-        assert topology.n_topology_atoms == 8
-        assert topology.n_topology_bonds == 7
-        assert topology.n_topology_particles == 8
-        assert topology.n_topology_virtual_sites == 0
+        assert topology.n_molecules == 1
+        assert topology.n_atoms == 8
+        assert topology.n_bonds == 7
+        assert topology.n_particles == 8
+        assert topology.n_virtual_sites == 0
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
 
         topology.add_molecule(ethane_from_smiles)
 
-        # assert topology.n_reference_molecules == 1
-        assert topology.n_topology_molecules == 2
-        assert topology.n_topology_atoms == 16
-        assert topology.n_topology_bonds == 14
-        assert topology.n_topology_particles == 16
-        assert topology.n_topology_virtual_sites == 0
+        assert topology.n_molecules == 2
+        assert topology.n_atoms == 16
+        assert topology.n_bonds == 14
+        assert topology.n_particles == 16
+        assert topology.n_virtual_sites == 0
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
 
     def test_from_smiles_unique_mols(self, ethane_from_smiles, propane_from_smiles):
         """Test the addition of two different molecules to a topology"""
         topology = Topology.from_molecules([ethane_from_smiles, propane_from_smiles])
-        assert topology.n_topology_molecules == 2
-        # assert topology.n_reference_molecules == 2
+        assert topology.n_molecules == 2
 
-    def test_n_topology_atoms(self, ethane_from_smiles):
+    def test_n_atoms(self, ethane_from_smiles):
         """Test n_atoms function"""
         topology = Topology()
-        assert topology.n_topology_atoms == 0
-        assert topology.n_topology_bonds == 0
+        assert topology.n_atoms == 0
+        assert topology.n_bonds == 0
         topology.add_molecule(ethane_from_smiles)
-        assert topology.n_topology_atoms == 8
-        assert topology.n_topology_bonds == 7
+        assert topology.n_atoms == 8
+        assert topology.n_bonds == 7
 
-    def test_n_topology_atoms_with_vsites(
-        self, ethane_from_smiles_w_vsites, tip5_water
-    ):
+    def test_n_atoms_with_vsites(self, ethane_from_smiles_w_vsites, tip5_water):
         """Test n_atoms function when vsites are present"""
         topology = Topology()
-        assert topology.n_topology_atoms == 0
-        assert topology.n_topology_bonds == 0
+        assert topology.n_atoms == 0
+        assert topology.n_bonds == 0
         topology.add_molecule(ethane_from_smiles_w_vsites)
-        assert topology.n_topology_atoms == 8
-        assert topology.n_topology_bonds == 7
+        assert topology.n_atoms == 8
+        assert topology.n_bonds == 7
 
         topology = Topology()
-        assert topology.n_topology_atoms == 0
-        assert topology.n_topology_bonds == 0
+        assert topology.n_atoms == 0
+        assert topology.n_bonds == 0
         topology.add_molecule(tip5_water)
-        assert topology.n_topology_atoms == 3
-        assert topology.n_topology_bonds == 2
+        assert topology.n_atoms == 3
+        assert topology.n_bonds == 2
 
-    def test_n_topology_virtual_sites(self, ethane_from_smiles_w_vsites, tip5_water):
+    def test_n_virtual_sites(self, ethane_from_smiles_w_vsites, tip5_water):
         """Test n_atoms function"""
         topology = Topology()
-        assert topology.n_topology_virtual_sites == 0
+        assert topology.n_virtual_sites == 0
         topology.add_molecule(ethane_from_smiles_w_vsites)
-        assert topology.n_topology_virtual_sites == 2
+        assert topology.n_virtual_sites == 2
 
         topology = Topology()
-        assert topology.n_topology_virtual_sites == 0
+        assert topology.n_virtual_sites == 0
         topology.add_molecule(tip5_water)
-        assert topology.n_topology_virtual_sites == 1
-        assert topology.n_topology_particles == 5
+        assert topology.n_virtual_sites == 1
+        assert topology.n_particles == 5
 
     def test_get_atom(self, ethane_from_smiles):
         """Test Topology.atom function (atom lookup from index)"""
@@ -266,7 +260,7 @@ class TestTopology:
         with pytest.raises(Exception) as context:
             topology_atom = topology.atom(8)
 
-    def test_topology_atom_element_properties(self, toluene_from_sdf):
+    def test_atom_element_properties(self, toluene_from_sdf):
         """
         Test element-like getters of TopologyAtom atomic number. In 0.11.0, Atom.element
         was removed and replaced with Atom.atomic_number and Atom.symbol.
@@ -327,9 +321,9 @@ class TestTopology:
         """Test Topology.virtual_site function (get virtual site from index)"""
         topology = Topology()
         topology.add_molecule(ethane_from_smiles_w_vsites)
-        assert topology.n_topology_virtual_sites == 2
+        assert topology.n_sites == 2
         topology.add_molecule(propane_from_smiles_w_vsites)
-        assert topology.n_topology_virtual_sites == 4
+        assert topology.n_virtual_sites == 4
         with pytest.raises(Exception) as context:
             topology_vsite = topology.virtual_site(-1)
         with pytest.raises(Exception) as context:
@@ -344,16 +338,16 @@ class TestTopology:
         assert topology_vsite4.type == "BondChargeVirtualSite"
 
         n_equal_atoms = 0
-        for topology_atom in topology.topology_atoms:
+        for atom in topology.atoms:
             for vsite in topology.topology_virtual_sites:
                 for vsite_atom in vsite.atoms:
-                    if topology_atom == vsite_atom:
+                    if atom == vsite_atom:
                         n_equal_atoms += 1
 
         # There are four virtual sites -- Two BondCharges with 2 atoms, and two MonovalentLonePairs with 3 atoms
         assert n_equal_atoms == 10
 
-    def test_topology_particles_virtualsites_indexed_last(
+    def test_particles_virtualsites_indexed_last(
         self, ethane_from_smiles_w_vsites, propane_from_smiles_w_vsites
     ):
         """
@@ -369,7 +363,7 @@ class TestTopology:
         # Iterate through all TopologyParticles, ensuring that all atoms appear
         # before all virtualsides
         reading_atoms = True
-        for particle in topology.topology_particles:
+        for particle in topology.particles:
             if reading_atoms:
                 if isinstance(particle, Atom):
                     pass
@@ -378,9 +372,7 @@ class TestTopology:
             elif not (reading_atoms):
                 assert isinstance(particle, VirtualParticle)
 
-    def test_topology_virtual_site_particle_start_index(
-        self, propane_from_smiles_w_vsites
-    ):
+    def test_virtual_site_particle_start_index(self, propane_from_smiles_w_vsites):
 
         topology = Topology()
         topology.add_molecule(propane_from_smiles_w_vsites)
@@ -584,10 +576,6 @@ class TestTopology:
     # test_two_different_molecules
     # test_to_from_dict
     # test_get_molecule
-    # test_get_topology_atom
-    # test_get_topology_bond
-    # test_get_topology_virtual_site
-    # test_get_topology_molecule
     # test_is_bonded
     # TODO: Test serialization
 
@@ -605,8 +593,7 @@ class TestTopology:
         molecules = [create_ethanol(), create_cyclohexane()]
 
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
-        # assert topology.n_reference_molecules == 2
-        assert topology.n_topology_molecules == 239
+        assert topology.n_molecules == 239
 
     def test_from_openmm_missing_reference(self):
         """Test creation of an OpenFF Topology object from an OpenMM Topology when missing a unique molecule"""
@@ -674,27 +661,22 @@ class TestTopology:
 
         # The round-trip OpenFF Topology is identical to the original.
         # The reference molecules are the same.
-        assert (
-            off_topology.n_reference_molecules
-            == off_topology_copy.n_reference_molecules
-        )
+        assert off_topology.n_molecules == off_topology_copy.n_molecules
         reference_molecules_copy = list(off_topology_copy.reference_molecules)
         for ref_mol_idx, ref_mol in enumerate(off_topology.reference_molecules):
             assert ref_mol == reference_molecules_copy[ref_mol_idx]
 
         # The number of topology molecules is the same.
-        assert (
-            off_topology.n_topology_molecules == off_topology_copy.n_topology_molecules
-        )
+        assert off_topology.n_molecules == off_topology_copy.n_molecules
 
         # Check atoms.
-        assert off_topology.n_topology_atoms == off_topology_copy.n_topology_atoms
-        for atom_idx, atom in enumerate(off_topology.topology_atoms):
+        assert off_topology.n_atoms == off_topology_copy.n_atoms
+        for atom_idx, atom in enumerate(off_topology.atoms):
             atom_copy = off_topology_copy.atom(atom_idx)
             assert atom.atomic_number == atom_copy.atomic_number
 
         # Check bonds.
-        for bond_idx, bond in enumerate(off_topology.topology_bonds):
+        for bond_idx, bond in enumerate(off_topology.bonds):
             # bond_copy = off_topology_copy.bond(bond_idx)
             bond_copy = off_topology_copy.get_bond_between(
                 off_topology.atom_index(bond.atoms[0]),
@@ -726,8 +708,8 @@ class TestTopology:
         ]
         top = Topology.from_mdtraj(trj.top, unique_molecules=unique_molecules)
 
-        assert top.n_topology_molecules == 2
-        assert top.n_topology_bonds == 26
+        assert top.n_molecules == 2
+        assert top.n_bonds == 26
 
     @requires_rdkit
     def test_to_file_vsites(self):

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -113,6 +113,15 @@ class TestTopology:
         assert not topology.is_periodic
         assert len(topology.constrained_atom_pairs.items()) == 0
 
+    def test_deprecated_api_points(self):
+        """Ensure that some of the API deprecated circa v0.11.0 still exist."""
+        topology = Topology()
+        for key in ["molecules", "atoms", "bonds", "particles", "virtual_sites"]:
+            with pytest.warns(DeprecationWarning, match="Use Topology.*instead"):
+                assert getattr(topology, "n_topology_" + key) == 0
+            with pytest.warns(DeprecationWarning, match="Use Topology.*instead"):
+                assert len([*getattr(topology, "topology_" + key)]) == 0
+
     def test_reinitialization_box_vectors(self):
         topology = Topology()
         assert Topology(topology).box_vectors is None

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -321,7 +321,7 @@ class TestTopology:
         """Test Topology.virtual_site function (get virtual site from index)"""
         topology = Topology()
         topology.add_molecule(ethane_from_smiles_w_vsites)
-        assert topology.n_sites == 2
+        assert topology.n_virtual_sites == 2
         topology.add_molecule(propane_from_smiles_w_vsites)
         assert topology.n_virtual_sites == 4
         with pytest.raises(Exception) as context:
@@ -339,7 +339,7 @@ class TestTopology:
 
         n_equal_atoms = 0
         for atom in topology.atoms:
-            for vsite in topology.topology_virtual_sites:
+            for vsite in topology.virtual_sites:
                 for vsite_atom in vsite.atoms:
                     if atom == vsite_atom:
                         n_equal_atoms += 1

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5051,7 +5051,7 @@ class FrozenMolecule(Serializable):
 
         """
         # TODO: Ensure we are dealing with an OpenFF Topology object
-        if topology.n_topology_molecules != 1:
+        if topology.n_molecules != 1:
             raise ValueError("Topology must contain exactly one molecule")
         molecule = [i for i in topology.reference_molecules][0]
         return cls(molecule)

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -718,7 +718,7 @@ class ForceField:
         if set(assigned_set) != set(topology_set):
             # Form informative error message
             msg = f"{name}: Mismatch between valence terms added and topological terms expected.\n"
-            atoms = [atom for atom in topology.topology_atoms]
+            atoms = [atom for atom in topology.atoms]
             if len(assigned_set.difference(topology_set)) > 0:
                 msg += "Valence terms created that are not present in Topology:\n"
                 msg += render_atoms(assigned_set.difference(topology_set))
@@ -1333,7 +1333,7 @@ class ForceField:
         # create_force call
         # This means that even though virtual sites may have been created via
         # the molecule API, an empty VirtualSites tag must exist in the FF
-        for atom in topology.topology_atoms:
+        for atom in topology.atoms:
             # addParticle(mass.m_as(unit.dalton)) would be safer but slower
             system.addParticle(atom.mass.m)
 
@@ -1570,7 +1570,7 @@ class ForceField:
             molecule.to_topology(), return_topology=True, **kwargs
         )
 
-        if top_with_charges.n_topology_virtual_sites != 0:
+        if top_with_charges.n_virtual_sites != 0:
             raise PartialChargeVirtualSitesError(
                 "get_partial_charges is not supported on molecules with virtual sites"
             )

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -3461,7 +3461,7 @@ class _NonbondedHandler(ParameterHandler):
             system.addForce(force)
             # Create all atom particles. Virtual site particles are handled in
             # in its own handler
-            for _ in topology.topology_atoms:
+            for _ in topology.atoms:
                 force.addParticle(0.0, 1.0, 0.0)
         else:
             force = existing[0]
@@ -4197,15 +4197,13 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
                     mol_instance = topology.molecule(mol_instance_idx)
                     mol_instance_atom_index = atom_map[unique_mol_atom_index]
                     mol_instance_atom = mol_instance.atom(mol_instance_atom_index)
-                    topology_particle_index = topology.particle_index(mol_instance_atom)
+                    particle_index = topology.particle_index(mol_instance_atom)
 
                     # Retrieve nonbonded parameters for reference atom (charge not set yet)
-                    _, sigma, epsilon = force.getParticleParameters(
-                        topology_particle_index
-                    )
+                    _, sigma, epsilon = force.getParticleParameters(particle_index)
                     # Set the nonbonded force with the partial charge
                     force.setParticleParameters(
-                        topology_particle_index,
+                        particle_index,
                         to_openmm(particle_charge),
                         sigma,
                         epsilon,
@@ -4399,10 +4397,8 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
                     mol_instance_particle = mol_instance.particle(
                         mol_instance_particle_index
                     )
-                    topology_particle_index = topology.particle_index(
-                        mol_instance_particle
-                    )
-                    charges_to_assign[topology_particle_index] = particle_charge
+                    particle_index = topology.particle_index(mol_instance_particle)
+                    charges_to_assign[particle_index] = particle_charge
 
             # Find SMARTS-based matches for charge increments
             charge_increment_matches = self.find_matches(topology)
@@ -4446,10 +4442,10 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
                         charges_to_assign[top_particle_idx] += charge_increment
 
             # Set the incremented charges on the System particles
-            for topology_particle_index, charge_to_assign in charges_to_assign.items():
-                _, sigma, epsilon = force.getParticleParameters(topology_particle_index)
+            for particle_index, charge_to_assign in charges_to_assign.items():
+                _, sigma, epsilon = force.getParticleParameters(particle_index)
                 force.setParticleParameters(
-                    topology_particle_index,
+                    particle_index,
                     to_openmm(charge_to_assign),
                     sigma,
                     epsilon,
@@ -4693,10 +4689,10 @@ class GBSAHandler(ParameterHandler):
         # To keep it simple, we DO NOT pre-populate the particles in the GBSA force here.
         # We call addParticle further below instead.
         # These lines are commented out intentionally as an example of what NOT to do.
-        # for topology_particle in topology.topology_particles:
+        # for particle in topology.particles:
         # gbsa_force.addParticle([0.0, 1.0, 0.0])
 
-        params_to_add = [[] for _ in topology.topology_particles]
+        params_to_add = [[] * topology.n_particles]
         for atom_key, atom_match in atom_matches.items():
             atom_idx = atom_key[0]
             gbsatype = atom_match.parameter_type

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -4692,7 +4692,7 @@ class GBSAHandler(ParameterHandler):
         # for particle in topology.particles:
         # gbsa_force.addParticle([0.0, 1.0, 0.0])
 
-        params_to_add = [[] * topology.n_particles]
+        params_to_add = [[] for _ in range(topology.n_particles)]
         for atom_key, atom_match in atom_matches.items():
             atom_idx = atom_key[0]
             gbsatype = atom_match.parameter_type


### PR DESCRIPTION
I noticed while working on downstream tests that several deprecated API points are called internally to the toolkit, mostly stuff like `topology_molecules`, `n_topology_molecules`, etc. This PR removes some of them, but probably not all.