### PR TITLE
Fix #837

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -100,6 +100,10 @@ print(value_roundtrip)
   `fractional_bondorder_method` kwarg to the 
   [`BondHandler`](openff.toolkit.typing.engines.smirnoff.parameters.BondHandler) initializer 
   was being ignored.
+- [PR #1214](https://github.com/openforcefield/openforcefield/pull/1214): A long overdue fix
+  for [Issue #837](https://github.com/openforcefield/openff-toolkit/issues/837)! If OpenEye is
+  available, the `ToolkitAM1BCCHandler` will use the ELF10 method to select conformers for AM1BCC
+  charge assignment. 
 
 ### Examples added
 

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -4196,10 +4196,17 @@ class ToolkitAM1BCCHandler(_NonbondedHandler):
             # If the molecule wasn't already assigned charge values, calculate them here
             toolkit_registry = kwargs.get("toolkit_registry", GLOBAL_TOOLKIT_REGISTRY)
             try:
+                # If OpenEye is available, use ELF10
+                partial_charge_method = "am1bcc"
+                for available_toolkit_wrapper in toolkit_registry.registered_toolkits:
+                    if "OpenEye" in str(available_toolkit_wrapper):
+                        partial_charge_method = "am1bccelf10"
+
                 # We don't need to generate conformers here, since that will be done by default in
                 # compute_partial_charges with am1bcc if the use_conformers kwarg isn't defined
                 unique_mol.assign_partial_charges(
-                    partial_charge_method="am1bcc", toolkit_registry=toolkit_registry
+                    partial_charge_method=partial_charge_method,
+                    toolkit_registry=toolkit_registry,
                 )
             except Exception as e:
                 warnings.warn(str(e), Warning)


### PR DESCRIPTION
- [x] Fix #837, making ToolkitAM1BCCHandler use ELF10 if OpenEye is available
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
