### PR TITLE
Performance improvements in from_openeye

### DIFF
--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -963,7 +963,8 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             oe_idx = oeatom.GetIdx()
             map_id = oeatom.GetMapIdx()
             atomic_number = oeatom.GetAtomicNum()
-            formal_charge = oeatom.GetFormalCharge() * unit.elementary_charge
+            # Carry with implicit units of elementary charge to skip unit checks in _add_atom
+            formal_charge = oeatom.GetFormalCharge()
             is_aromatic = oeatom.IsAromatic()
             stereochemistry = OpenEyeToolkitWrapper._openeye_cip_atom_stereochemistry(
                 oemol, oeatom
@@ -1020,24 +1021,21 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         if hasattr(oemol, "GetConfs"):
             for conf in oemol.GetConfs():
                 n_atoms = molecule.n_atoms
-                positions = unit.Quantity(
-                    np.zeros(shape=[n_atoms, 3], dtype=np.float64), unit.angstrom
-                )
+                # Store with implicit units until we're sure this conformer exists
+                positions = np.zeros(shape=[n_atoms, 3], dtype=np.float64)
                 for oe_id in conf.GetCoords().keys():
                     off_atom_coords = unit.Quantity(
                         conf.GetCoords()[oe_id], unit.angstrom
                     )
                     off_atom_index = off_to_oe_idx[oe_id]
                     positions[off_atom_index, :] = off_atom_coords
-                if (positions == 0 * unit.angstrom).all() and n_atoms > 1:
+                all_zeros = not np.any(positions)
+                if all_zeros and n_atoms > 1:
                     continue
-                molecule._add_conformer(positions)
+                molecule._add_conformer(unit.Quantity(positions, unit.angstrom))
 
-        # Copy partial charges, if present
-        partial_charges = unit.Quantity(
-            np.zeros(shape=molecule.n_atoms, dtype=np.float64),
-            unit.elementary_charge,
-        )
+        # Store charges with implicit units in this scope
+        unitless_charges = np.zeros(shape=molecule.n_atoms, dtype=np.float64)
 
         # If all OEAtoms have a partial charge of NaN, then the OFFMol should
         # have its partial_charges attribute set to None
@@ -1046,14 +1044,16 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             oe_idx = oe_atom.GetIdx()
             off_idx = off_to_oe_idx[oe_idx]
             unitless_charge = oe_atom.GetPartialCharge()
-            if not math.isnan(unitless_charge):
-                any_partial_charge_is_not_nan = True
-                # break
-            charge = unitless_charge * unit.elementary_charge
-            partial_charges[off_idx] = charge
+            # Once this is True, skip the isnancheck
+            if not any_partial_charge_is_not_nan:
+                if not math.isnan(unitless_charge):
+                    any_partial_charge_is_not_nan = True
+            unitless_charges[off_idx] = unitless_charge
 
         if any_partial_charge_is_not_nan:
-            molecule.partial_charges = partial_charges
+            molecule.partial_charges = unit.Quantity(
+                unitless_charges, unit.elementary_charge
+            )
         else:
             molecule.partial_charges = None
 
@@ -1822,7 +1822,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             for atom_index, coordinates in oe_conformer.GetCoords().items():
                 conformer[atom_index, :] = coordinates
 
-            conformers.append(conformer * unit.angstrom)
+            conformers.append(unit.Quantity(conformer, unit.angstrom))
 
         molecule._conformers = conformers
 


### PR DESCRIPTION
OpenMM quantities are generally as quick and lightweight as
corresponding NumPy arrays, but Pint units tend to be slower. Most of
these changes simply defer unit tagging until a final step, carrying
values with implicit units in some internal functions where the units
are known and can be expected not to vary.

I used a quick benchmark that I think is representative of a typical use case and dropped the execution time of `Molecule.from_openeye` from roughly 22 ms to 5 ms. This is still a regression from roughly 3 ms in v0.10.3, but it's much more palatable.

https://gist.github.com/mattwthompson/3a085559a9e5d040b8439870e01f9410


There's surely more improvements to be found here and elsewhere.


- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
