### PR TITLE
Cherry pick #1160 into topology-biopolymer-refactor

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -106,6 +106,10 @@ print(value_roundtrip)
   for [Issue #837](https://github.com/openforcefield/openff-toolkit/issues/837)! If OpenEye is
   available, the `ToolkitAM1BCCHandler` will use the ELF10 method to select conformers for AM1BCC
   charge assignment. 
+- [PR #1160](https://github.com/openforcefield/openforcefield/pull/1160): Fixes the bug identified in
+  [Issue #1159](https://github.com/openforcefield/openff-toolkit/issues/1159), in which the order of 
+  atoms defining a `BondChargeVirtualSite` (and possibly other virtual sites types too) might be reversed 
+  if the `match` attribute of the virtual site has a value of `"once"`.
 
 ### Examples added
 

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -2254,6 +2254,58 @@ class TestForceFieldVirtualSites:
 
         self._test_physical_parameters(toolkit_registry, *args.values())
 
+    def test_orientation_preserved_if_match_once(self):
+        """
+        Test that orientation-mangling bug from https://github.com/openforcefield/openff-toolkit/issues/1159
+        is resolved.
+        """
+        force_field = ForceField()
+
+        vsite_handler = force_field.get_parameter_handler("VirtualSites")
+        vsite_handler.add_parameter(
+            parameter_kwargs={
+                "smirks": "[#6:2]=[#8:1]",
+                "name": "EP",
+                "type": "BondCharge",
+                "distance": 0.7 * unit.nanometers,
+                "match": "once",
+                "charge_increment1": 0.2 * unit.elementary_charge,
+                "charge_increment2": 0.1 * unit.elementary_charge,
+                "sigma": 1.0 * unit.angstrom,
+                "epsilon": 2.0 / 4.184 * unit.kilocalorie_per_mole,
+            }
+        )
+
+        molecule = Molecule.from_mapped_smiles("[O:2]=[C:1]=[O:3]")
+
+        omm_system: System
+        omm_system, topology = force_field.create_openmm_system(
+            molecule.to_topology(), return_topology=True
+        )
+
+        omm_particle_tuples = []
+        for i in range(omm_system.getNumParticles()):
+
+            if not omm_system.isVirtualSite(i):
+                continue
+
+            omm_v_site = omm_system.getVirtualSite(i)
+
+            omm_particle_tuples.append(
+                tuple(
+                    omm_v_site.getParticle(j)
+                    for j in range(omm_v_site.getNumParticles())
+                )
+            )
+        assert (1, 0) in omm_particle_tuples
+        assert (2, 0) in omm_particle_tuples
+        for molecule in topology.reference_molecules:
+            for v_site in molecule.virtual_sites:
+                for particle in v_site.particles:
+                    # correct particle.orientation is (1,0) and (2,0)
+                    # and not (0, 1), (0, 2)
+                    assert particle.orientation in omm_particle_tuples
+
 
 class TestForceFieldChargeAssignment:
     @pytest.mark.parametrize(

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -5276,8 +5276,7 @@ class VirtualSiteHandler(_NonbondedHandler):
             # has the match setting, which ultimately decides which orientations
             # to include.
             if self.match == "once":
-                key = self.transformed_dict_cls.key_transform(orientations[0])
-                orientations = [key]
+                orientations = [orientations[0]]
                 # else all matches wanted, so keep whatever was matched.
 
             base_args = {


### PR DESCRIPTION
Cherry picks the merge commit from #1160 into the topology-biopolymer-refactor branch (needed for interchange adoption tests)
