### PR TITLE
Update docstrings and tests for deprecated Topology API

### DIFF
--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -115,12 +115,23 @@ class TestTopology:
 
     def test_deprecated_api_points(self):
         """Ensure that some of the API deprecated circa v0.11.0 still exist."""
+        from openff.toolkit.topology.topology import _TopologyDeprecationWarning
+
         topology = Topology()
+
         for key in ["molecules", "atoms", "bonds", "particles", "virtual_sites"]:
-            with pytest.warns(DeprecationWarning, match="Use Topology.*instead"):
-                assert getattr(topology, "n_topology_" + key) == 0
-            with pytest.warns(DeprecationWarning, match="Use Topology.*instead"):
-                assert len([*getattr(topology, "topology_" + key)]) == 0
+            old_iterator = "topology_" + key
+            old_counter = "n_topology_" + key
+            with pytest.warns(
+                _TopologyDeprecationWarning,
+                match=f"Topology.{old_counter} is deprecated. Use Topology.n_{key} instead.",
+            ):
+                assert getattr(topology, old_counter) == 0
+            with pytest.warns(
+                _TopologyDeprecationWarning,
+                match=f"Topology.{old_iterator} is deprecated. Use Topology.{key} instead.",
+            ):
+                assert len([*getattr(topology, old_iterator)]) == 0
 
     def test_reinitialization_box_vectors(self):
         topology = Topology()

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -115,7 +115,7 @@ class TestTopology:
 
     def test_deprecated_api_points(self):
         """Ensure that some of the API deprecated circa v0.11.0 still exist."""
-        from openff.toolkit.topology.topology import _TopologyDeprecationWarning
+        from openff.toolkit.topology.topology import TopologyDeprecationWarning
 
         topology = Topology()
 
@@ -123,12 +123,12 @@ class TestTopology:
             old_iterator = "topology_" + key
             old_counter = "n_topology_" + key
             with pytest.warns(
-                _TopologyDeprecationWarning,
+                TopologyDeprecationWarning,
                 match=f"Topology.{old_counter} is deprecated. Use Topology.n_{key} instead.",
             ):
                 assert getattr(topology, old_counter) == 0
             with pytest.warns(
-                _TopologyDeprecationWarning,
+                TopologyDeprecationWarning,
                 match=f"Topology.{old_iterator} is deprecated. Use Topology.{key} instead.",
             ):
                 assert len([*getattr(topology, old_iterator)]) == 0

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -53,11 +53,14 @@ if TYPE_CHECKING:
 # =============================================================================================
 
 
-def _TOPOLOGY_DEPRECATION_WARNING(old_method, new_method):
-    warnings.warn(
-        f"Topology.{old_method} is deprecated. Use Topology.{new_method} instead.",
-        DeprecationWarning,
-    )
+class _TopologyDeprecationWarning(DeprecationWarning):
+    def __init__(self, old_method, new_method):
+        self.message = (
+            f"Topology.{old_method} is deprecated. Use Topology.{new_method} instead."
+        )
+
+    def __str__(self):
+        return self.message
 
 
 class _TransformedDict(MutableMapping):
@@ -2196,126 +2199,77 @@ class Topology(Serializable):
 
     # DEPRECATED API POINTS
     @property
-    def n_topology_atoms(self):
-        """
-        Returns the number of atoms in in this Topology.
-
-        Returns
-        -------
-        n_topology_atoms : int
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("n_topology_atom", "n_atoms")
+    def n_topology_atoms(self) -> int:
+        """DEPRECATED: Use Topology.n_atoms instead."""
+        warnings.warn(_TopologyDeprecationWarning("n_topology_atoms", "n_atoms"))
         return self.n_atoms
 
     @property
     def topology_atoms(self):
-        """
-        Returns an iterator over the atoms in this Topology. These will be in ascending order of topology index.
-
-        Returns
-        -------
-        topology_atoms : Iterable of Atom
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("topology_atoms", "atoms")
+        """DEPRECATED: Use Topology.atoms instead."""
+        warnings.warn(_TopologyDeprecationWarning("topology_atoms", "atoms"))
         return self.atoms
 
     @property
     def n_topology_bonds(self) -> int:
-        """
-        Returns the number of bonds in in this Topology.
-
-        Returns
-        -------
-        n_bonds : int
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("n_topology_bonds", "n_bonds")
+        """DEPRECATED: Use Topology.n_bonds instead."""
+        warnings.warn(_TopologyDeprecationWarning("n_topology_bonds", "n_bonds"))
         return self.n_bonds
 
     @property
-    def topology_bonds(self) -> Generator["Bond", None, None]:
-        """Returns an iterator over the bonds in this Topology
-
-        Returns
-        -------
-        bonds: Iterable of Bond
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("topology_bonds", "bonds")
+    def topology_bonds(self):
+        """DEPRECATED: Use Topology.bonds instead."""
+        warnings.warn(_TopologyDeprecationWarning("topology_bonds", "bonds"))
         return self.bonds
 
     @property
     def n_topology_particles(self) -> int:
-        """
-        Returns the number of topology particles (TopologyAtoms and TopologyVirtualSites) in in this Topology.
-
-        Returns
-        -------
-        n_topology_particles : int
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("n_topology_particles", "n_particles")
+        """DEPRECATED: Use Topology.n_particles instead."""
+        warnings.warn(
+            _TopologyDeprecationWarning("n_topology_particles", "n_particles")
+        )
         return self.n_particles
 
     @property
     def topology_particles(self):
-        """Returns an iterator over the particles (TopologyAtoms and TopologyVirtualSites) in this Topology. The
-        TopologyAtoms will be in order of ascending Topology index.
-
-        Returns
-        --------
-        topology_particles : Iterable of TopologyAtom and TopologyVirtualSite
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("topology_particles", "particles")
+        """DEPRECATED: Use Topology.particles instead."""
+        warnings.warn(_TopologyDeprecationWarning("topology_particles", "particles"))
         return self.particles
 
     @property
     def n_topology_virtual_sites(self) -> int:
-        """
-        Deprecated - Use Topology.n_virtual_sites instead.
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("n_topology_virtual_sites", "n_virtual_sites")
+        """DEPRECATED: Use Topology.n_virtual_sites instead."""
+        warnings.warn(
+            _TopologyDeprecationWarning("n_topology_virtual_sites", "n_virtual_sites")
+        )
         return self.n_virtual_sites
 
     @property
     def topology_virtual_sites(self):
-        """Get an iterator over the virtual sites in this Topology
-
-        Returns
-        -------
-        topology_virtual_sites : Iterable of TopologyVirtualSite
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("topology_virtual_sites", "virtual_sites")
+        """DEPRECATED: Use Topology.virtual_sites instead."""
+        warnings.warn(
+            _TopologyDeprecationWarning("topology_virtual_sites", "virtual_sites")
+        )
         return self.virtual_sites
 
     @property
     def n_reference_molecules(self) -> int:
-        """
-        Returns the number of reference (unique) molecules in in this Topology.
-
-        Returns
-        -------
-        n_reference_molecules : int
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("n_reference_molecules", "n_molecules")
+        """DEPRECATED: Use Topology.n_molecules instead."""
+        warnings.warn(
+            _TopologyDeprecationWarning("n_reference_molecules", "n_molecules")
+        )
         return self.n_molecules
 
     @property
     def n_topology_molecules(self) -> int:
-        """
-        Returns the number of topology molecules in in this Topology.
-
-        Returns
-        -------
-        n_topology_molecules : int
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("n_topology_molecules", "n_molecules")
+        """DEPRECATED: Use Topology.n_molecules instead."""
+        warnings.warn(
+            _TopologyDeprecationWarning("n_topology_molecules", "n_molecules")
+        )
         return self.n_molecules
 
     @property
     def topology_molecules(self):
-        """Returns an iterator over all the TopologyMolecules in this Topology
-
-        Returns
-        -------
-        topology_molecules : Iterable of TopologyMolecule
-        """
-        _TOPOLOGY_DEPRECATION_WARNING("topology_molecules", "molecules")
+        """DEPRECATED: Use Topology.molecules instead."""
+        warnings.warn(_TopologyDeprecationWarning("topology_molecules", "molecules"))
         return self.molecules

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -53,14 +53,15 @@ if TYPE_CHECKING:
 # =============================================================================================
 
 
-class _TopologyDeprecationWarning(DeprecationWarning):
-    def __init__(self, old_method, new_method):
-        self.message = (
-            f"Topology.{old_method} is deprecated. Use Topology.{new_method} instead."
-        )
+def _topology_deprecation(old_method, new_method):
+    warnings.warn(
+        f"Topology.{old_method} is deprecated. Use Topology.{new_method} instead.",
+        TopologyDeprecationWarning,
+    )
 
-    def __str__(self):
-        return self.message
+
+class TopologyDeprecationWarning(UserWarning):
+    """Warning for deprecated portions of the Topology API."""
 
 
 class _TransformedDict(MutableMapping):
@@ -2201,75 +2202,65 @@ class Topology(Serializable):
     @property
     def n_topology_atoms(self) -> int:
         """DEPRECATED: Use Topology.n_atoms instead."""
-        warnings.warn(_TopologyDeprecationWarning("n_topology_atoms", "n_atoms"))
+        _topology_deprecation("n_topology_atoms", "n_atoms")
         return self.n_atoms
 
     @property
     def topology_atoms(self):
         """DEPRECATED: Use Topology.atoms instead."""
-        warnings.warn(_TopologyDeprecationWarning("topology_atoms", "atoms"))
+        _topology_deprecation("topology_atoms", "atoms")
         return self.atoms
 
     @property
     def n_topology_bonds(self) -> int:
         """DEPRECATED: Use Topology.n_bonds instead."""
-        warnings.warn(_TopologyDeprecationWarning("n_topology_bonds", "n_bonds"))
+        _topology_deprecation("n_topology_bonds", "n_bonds")
         return self.n_bonds
 
     @property
     def topology_bonds(self):
         """DEPRECATED: Use Topology.bonds instead."""
-        warnings.warn(_TopologyDeprecationWarning("topology_bonds", "bonds"))
+        _topology_deprecation("topology_bonds", "bonds")
         return self.bonds
 
     @property
     def n_topology_particles(self) -> int:
         """DEPRECATED: Use Topology.n_particles instead."""
-        warnings.warn(
-            _TopologyDeprecationWarning("n_topology_particles", "n_particles")
-        )
+        _topology_deprecation("n_topology_particles", "n_particles")
         return self.n_particles
 
     @property
     def topology_particles(self):
         """DEPRECATED: Use Topology.particles instead."""
-        warnings.warn(_TopologyDeprecationWarning("topology_particles", "particles"))
+        _topology_deprecation("topology_particles", "particles")
         return self.particles
 
     @property
     def n_topology_virtual_sites(self) -> int:
         """DEPRECATED: Use Topology.n_virtual_sites instead."""
-        warnings.warn(
-            _TopologyDeprecationWarning("n_topology_virtual_sites", "n_virtual_sites")
-        )
+        _topology_deprecation("n_topology_virtual_sites", "n_virtual_sites")
         return self.n_virtual_sites
 
     @property
     def topology_virtual_sites(self):
         """DEPRECATED: Use Topology.virtual_sites instead."""
-        warnings.warn(
-            _TopologyDeprecationWarning("topology_virtual_sites", "virtual_sites")
-        )
+        _topology_deprecation("topology_virtual_sites", "virtual_sites")
         return self.virtual_sites
 
     @property
     def n_reference_molecules(self) -> int:
         """DEPRECATED: Use Topology.n_molecules instead."""
-        warnings.warn(
-            _TopologyDeprecationWarning("n_reference_molecules", "n_molecules")
-        )
+        _topology_deprecation("n_reference_molecules", "n_molecules")
         return self.n_molecules
 
     @property
     def n_topology_molecules(self) -> int:
         """DEPRECATED: Use Topology.n_molecules instead."""
-        warnings.warn(
-            _TopologyDeprecationWarning("n_topology_molecules", "n_molecules")
-        )
+        _topology_deprecation("n_topology_molecules", "n_molecules")
         return self.n_molecules
 
     @property
     def topology_molecules(self):
         """DEPRECATED: Use Topology.molecules instead."""
-        warnings.warn(_TopologyDeprecationWarning("topology_molecules", "molecules"))
+        _topology_deprecation("topology_molecules", "molecules")
         return self.molecules


### PR DESCRIPTION
No linked issue, but the ask is

> Ensure that `Topology.{n_,}topology_{atoms,particles,bonds,virtual_sites}` API points are still accessible, but that they give deprecation warnings

I forgot I already did this in the final states of getting #1204 through, but this provided an opportunity to
* Make the deprecation warning a custom warning class (subclassing from `UserWarning`)
* Tidy up some docstrings

```python3
>>> from openff.toolkit import Molecule
>>> topology = Molecule.from_smiles("O").to_topology()
/Users/mwt/software/openforcefield/openff/toolkit/utils/openeye_wrapper.py:1032: UnitStrippedWarning: The unit of the quantity is stripped when downcasting to ndarray.
  positions[off_atom_index, :] = off_atom_coords
>>> topology.topology_bonds
/Users/mwt/software/openforcefield/openff/toolkit/topology/topology.py:57: TopologyDeprecationWarning: Topology.topology_bonds is deprecated. Use Topology.bonds instead.
  warnings.warn(
<generator object Topology.bonds at 0x7fa7d9a15190>
```

**Feedback needed:** Should this raise `UserWarning` (visible to all users) or `DeprecationWarning` (not visible to most users)?

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
