### PR TITLE
Fix a redundant unit tag

### DIFF
--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1025,9 +1025,8 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
                 # Store with implicit units until we're sure this conformer exists
                 positions = np.zeros(shape=[n_atoms, 3], dtype=np.float64)
                 for oe_id in conf.GetCoords().keys():
-                    off_atom_coords = unit.Quantity(
-                        conf.GetCoords()[oe_id], unit.angstrom
-                    )
+                    # implicitly in angstrom
+                    off_atom_coords = conf.GetCoords()[oe_id]
                     off_atom_index = off_to_oe_idx[oe_id]
                     positions[off_atom_index, :] = off_atom_coords
                 all_zeros = not np.any(positions)


### PR DESCRIPTION
A small error in #1217 was producing a redundant trip between array and unit-bearing quantity. Conveniently, a helpful warning is thrown:

```python3
>>> from openff.toolkit import Molecule
>>> Molecule.from_smiles("O")
/Users/mwt/software/openforcefield/openff/toolkit/utils/openeye_wrapper.py:1032: UnitStrippedWarning: The unit of the quantity is stripped when downcasting to ndarray.
  positions[off_atom_index, :] = off_atom_coords
Molecule with name '' and SMILES '[H]O[H]'
```