### PR TITLE
Simplify pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,20 @@
 ci:
   autoupdate_schedule: "monthly"
+files: ^openff|(^examples/((?!deprecated).)*$)
 repos:
 - repo: https://github.com/psf/black
   rev: 22.3.0
   hooks:
   - id: black
-    files: ^openff
-    args: [--check]
   - id: black-jupyter
-    files: ^examples/((?!deprecated).)*$
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:
   - id: isort
-    files: ^openff
-    args: [--check]
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.3.1
   hooks:
     - id: nbqa-pyupgrade
-      files: ^examples/((?!deprecated).)*$
       args:
         - --py37-plus
     - id: nbqa-isort
-      files: ^examples/((?!deprecated).)*$

--- a/examples/conformer_energies/conformer_energies.py
+++ b/examples/conformer_energies/conformer_energies.py
@@ -1,11 +1,12 @@
 import argparse
 
 import openmm
+from openff.units.openmm import from_openmm, to_openmm
+from openmm import app
+from openmm import unit as openmm_unit
 from rdkit.Chem import rdMolAlign
-from openmm import unit as openmm_unit, app
-from openff.units.openmm import to_openmm, from_openmm
 
-from openff.toolkit import Molecule, Topology, ForceField
+from openff.toolkit import ForceField, Molecule, Topology
 from openff.toolkit.utils import RDKitToolkitWrapper
 
 

--- a/examples/examples_helper.py
+++ b/examples/examples_helper.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Copy the openff-toolkit examples suite to a local directory"""
 
-from pathlib import Path
-from os import environ
-from shutil import copytree, ignore_patterns
 import argparse
+from os import environ
+from pathlib import Path
+from shutil import copytree, ignore_patterns
 
 
 class NoExamplesLibraryError(Exception):


### PR DESCRIPTION
This better safeguards against it accidentally modifying something in `examples/deprecated/` and will make it auto-apply easy fixes in PRs (but not until the default branch is updated).