### PR TITLE
Port #1176

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,28 +1,16 @@
-# .readthedocs.yaml
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: 2
-
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-
 build:
-  image: latest
+  os: ubuntu-20.04
   tools:
     python: "mambaforge-4.10"
-
 python:
-  version: 3.8
   install:
-    - method: setuptools
-      path: .
-
-# Build PDF in addition to default HTML and JSON
-formats:
-    - pdf
-
+  - method: setuptools
+    path: .
 conda:
   environment: docs/environment.yml
+formats:
+- pdf

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,8 @@ sphinx:
 
 build:
   image: latest
+  tools:
+    python: "mambaforce-4.10"
 
 python:
   version: 3.8

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ sphinx:
 build:
   image: latest
   tools:
-    python: "mambaforce-4.10"
+    python: "mambaforge-4.10"
 
 python:
   version: 3.8

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,11 +10,10 @@ dependencies:
     - numpydoc
     - myst-nb
     - myst-parser>=0.13.6
-    - testpath==0.3.1
     - docutils
     - sphinx-notfound-page
     # conda build dependencies
-    - python
+    - python==3.8.0
     - setuptools
     - numpy
     - openmm


### PR DESCRIPTION
While working on another project, I got a popup that this project's docs were still built with a temporary something-or-other to force `mamba` as a `conda` replacement. I clicked out of the notification and it is gone forever, but I think it's basically https://github.com/readthedocs/readthedocs.org/issues/8623. I was confused for a while until I noticed that their bot already did most of the work in #1176. So I guess this just amounts to pulling that change in here.