### PR TITLE
Let Dependabot update actions in the 0.11.0 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch:
+      - "master"
+      - "topology-biopolymer-refactor"


### PR DESCRIPTION
On a temporary basis. It's probably not a big deal but some of our actions are multiple major versions out of date.