### PR TITLE
Add OpenMM 7.6+ requirement in release notes

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -96,6 +96,10 @@ print(value_roundtrip)
   unit-bearing quantities from OpenMM's unit module (`openmm.unit`) to
   [`openff-units`](https://github.com/openforcefield/openff-units), which itself is based off of
   [Pint](https://pint.readthedocs.io/en/stable/).
+- [PR #1230](https://github.com/openforcefield/openforcefield/pull/1230) removes safe imports from
+  the `simtk` namespace, which was deprecated in
+  [August 2021](https://github.com/openmm/openmm/releases/tag/7.6.0) with the release of OpenMM 7.6,
+  and therefore removes support for versions of OpenMM older than 7.6.
 - [PR #1118](https://github.com/openforcefield/openforcefield/pull/1118):
   [`Molecule.to_hill_formula`](openff.toolkit.topology.Molecule.to_hill_formula) is now a class method
   and no longer accepts input of NetworkX graphs.


### PR DESCRIPTION
A common user question is, and will continue to be, what versions of OpenMM are supported by different versions of the toolkit. It is possible that something like this should go in an FAQ or developers' guide, but here I'm just adding it to the release notes of the (only?) change that introduces a major compatibility shift. I authored this change (#1230) according to ours plans months ago, but somehow neglected to include it in the release notes then.

I'll merge this in 48 hours if not reviewed by then, as it's a minor change.