### PR TITLE
Temporarily support `return_topology` with Interchange export path

### DIFF
--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -41,4 +41,4 @@ dependencies:
   - qcengine
   - mdtraj
   - pip:
-    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.1
+    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.3

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -42,4 +42,4 @@ dependencies:
   - qcengine
   - mdtraj
   - pip:
-    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.1
+    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.3

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -51,4 +51,4 @@ dependencies:
     - types-toml
     - types-PyYAML
     - mongo-types
-    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.1
+    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.3

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -58,6 +58,9 @@ print(value_roundtrip)
 
 ## Current Development
 
+- [PR #1250](https://github.com/openforcefield/openff-toolkit/pull/1250): Adds support for
+  `return_topology` in the Interchange code path in
+  [`create_openmm_system`](openff.toolkit.typing.engines.smirnoff.ForceField.create_openmm_system).
 - [PR #964](https://github.com/openforcefield/openff-toolkit/pull/964): Adds initial implementation
   of atom metadata dictionaries.
 - [PR #1097](https://github.com/openforcefield/openff-toolkit/pull/1097): Deprecates TopologyMolecule.

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -4800,6 +4800,26 @@ class TestForceFieldParameterAssignment:
             )
 
 
+class TestInterchangeReturnTopology:
+    # TODO: Remove these tests when `return_topology` is deprecated in version 0.12.0
+    def test_deprecation_warning_raised(self):
+        """
+        Ensure that the deprecation warning is raised when `return_topology` is
+        used.
+        """
+        forcefield = ForceField("test_forcefields/test_forcefield.offxml", xml_ff_bo)
+
+        topology = create_ethanol().to_topology()
+        topology.box_vectors = unit.Quantity([4, 4, 4], unit.nanometer)
+
+        with pytest.warns(DeprecationWarning, match="results from param"):
+            omm_system, ret_top = forcefield.create_openmm_system(
+                topology,
+                use_interchange=True,
+                return_topology=True,
+            )
+
+
 class TestSmirnoffVersionConverter:
     @requires_openeye_mol2
     @pytest.mark.parametrize(

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -4812,7 +4812,9 @@ class TestInterchangeReturnTopology:
         topology = create_ethanol().to_topology()
         topology.box_vectors = unit.Quantity([4, 4, 4], unit.nanometer)
 
-        with pytest.warns(DeprecationWarning, match="results from param"):
+        with pytest.warns(
+            DeprecationWarning, match="DEPRECATED and will be removed in version 0.12.0"
+        ):
             omm_system, ret_top = forcefield.create_openmm_system(
                 topology,
                 use_interchange=True,

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -1274,9 +1274,11 @@ class ForceField:
                 return openmm_system
             else:
                 warning_msg = (
-                    f"kwarg `return_topology` is DEPRECATED and will be removed in a version 0.12.0 of the OpenFF "
-                    "Toolkit. Use `ForceField.create_interchange` for better manipulation of the topology that "
-                    "results from parameterization. Also see `Interchange.to_openmm_topology()`."
+                    f"The `create_openmm_system` kwarg `return_topology` is DEPRECATED and will be "
+                    "removed in version 0.12.0 of the OpenFF Toolkit. "
+                    "Use `ForceField.create_interchange` followed by `Interchange.topology`, "
+                    "`Interchange.to_openmm_topology`, and `Interchange.to_openmm` "
+                    "for long-term replacements for `return_topology` functionality."
                 )
                 warnings.warn(warning_msg, DeprecationWarning)
                 return openmm_system, copy.deepcopy(interchange.topology)

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -33,7 +33,7 @@ import os
 import pathlib
 import warnings
 from collections import OrderedDict
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Tuple, Union
 
 from openff.toolkit.topology.molecule import DEFAULT_AROMATICITY_MODEL
 from openff.toolkit.typing.engines.smirnoff.io import ParameterIOHandler
@@ -59,6 +59,8 @@ from openff.toolkit.utils.utils import (
 )
 
 if TYPE_CHECKING:
+    import openmm
+
     from openff.toolkit.topology import Topology
 
 deprecated_names = ["ParseError"]
@@ -1249,7 +1251,7 @@ class ForceField:
         topology: "Topology",
         use_interchange: bool = False,
         **kwargs,
-    ):
+    ) -> Union["openmm.System", Tuple["openmm.System", "Topology"]]:
         """Create an OpenMM System from this ForceField and a Topology.
 
         Parameters
@@ -1261,9 +1263,23 @@ class ForceField:
 
         """
         if use_interchange:
-            return self.create_interchange(topology, **kwargs,).to_openmm(
-                combine_nonbonded_forces=True,
+            return_topology = kwargs.pop("return_topology", False)
+
+            interchange = self.create_interchange(
+                topology,
+                **kwargs,
             )
+            openmm_system = interchange.to_openmm(combine_nonbonded_forces=True)
+            if not return_topology:
+                return openmm_system
+            else:
+                warning_msg = (
+                    f"kwarg `return_topology` is DEPRECATED and will be removed in a version 0.12.0 of the OpenFF "
+                    "Toolkit. Use `ForceField.create_interchange` for better manipulation of the topology that "
+                    "results from parameterization. Also see `Interchange.to_openmm_topology()`."
+                )
+                warnings.warn(warning_msg, DeprecationWarning)
+                return openmm_system, copy.deepcopy(interchange.topology)
         else:
             return self._old_create_openmm_system(topology, **kwargs)
 


### PR DESCRIPTION
In a recent meeting, @j-wags requested that `return_topology` be supported with the new Interchange export path. We agreed to shoehorn it into the 0.11.0 release with the intent to remove it in the 0.12.0 release. Interchange tracks a "post-parameterization" topology as a high-level attribute and also supports export to OpenMM topologies that consider virtual sites, something not currently supported in the toolkit.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
