### PR TITLE
Fix adding conformers with OpenMM units

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -27,7 +27,6 @@ import numpy as np
 import pytest
 from openff.units import unit
 from openff.units.elements import MASSES, SYMBOLS
-from openmm import unit as openmm_unit
 
 from openff.toolkit.tests.create_molecules import (
     create_acetaldehyde,
@@ -2492,6 +2491,8 @@ class TestMolecule:
 
     def test_add_conformers(self):
         """Test addition of conformers to a molecule"""
+        from openmm import unit as openmm_unit
+
         # Define a methane molecule
         molecule = Molecule()
         molecule.name = "methane"
@@ -2606,7 +2607,6 @@ class TestMolecule:
         assert molecule.n_conformers == 3
         assert molecule.conformers[2][0][0] == 10.0 * unit.angstrom
 
-        # Add a conformer with units of nanometers
         conf_nonsense_units = unit.Quantity(
             np.array(
                 [
@@ -2621,6 +2621,26 @@ class TestMolecule:
         )
         with pytest.raises(Exception) as excinfo:
             molecule.add_conformer(conf_nonsense_units)
+
+        conf_openmm_units = openmm_unit.Quantity(
+            np.array(
+                [
+                    [1.0, 2.0, 3.0],
+                    [4.0, 5.0, 6.0],
+                    [7.0, 8.0, 9.0],
+                    [10.0, 11.0, 12.0],
+                    [13.0, 14.0, 15],
+                ]
+            ),
+            openmm_unit.angstrom,
+        )
+        molecule.add_conformer(conf_openmm_units)
+
+        assert molecule.conformers[-1][0][0].m_as(unit.angstrom) == 1.0
+        assert molecule.conformers[-1][-1][-1].m_as(unit.angstrom) == 15.0
+
+        with pytest.raises(Exception) as excinfo:
+            molecule.add_conformer(conf_unitless)
 
         # Add a conformer with no units
         conf_unitless = np.array(

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -61,7 +61,11 @@ from openff.toolkit.topology.molecule import (
     SmilesParsingError,
 )
 from openff.toolkit.utils import get_data_file_path
-from openff.toolkit.utils.exceptions import ConformerGenerationError
+from openff.toolkit.utils.exceptions import (
+    ConformerGenerationError,
+    IncompatibleUnitError,
+    InvalidConformerError,
+)
 from openff.toolkit.utils.toolkits import (
     AmberToolsToolkitWrapper,
     OpenEyeToolkitWrapper,
@@ -2551,7 +2555,7 @@ class TestMolecule:
             ),
             unit.angstrom,
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(InvalidConformerError):
             molecule.add_conformer(conf_missing_z)
 
         conf_too_few_atoms = unit.Quantity(
@@ -2565,7 +2569,7 @@ class TestMolecule:
             ),
             unit.angstrom,
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(InvalidConformerError):
             molecule.add_conformer(conf_too_few_atoms)
 
         # Add a conformer with too many coordinates
@@ -2582,12 +2586,12 @@ class TestMolecule:
             ),
             unit.angstrom,
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(InvalidConformerError):
             molecule.add_conformer(conf_too_many_atoms)
 
         # Add a conformer with no coordinates
         conf_no_coordinates = unit.Quantity(np.array([]), unit.angstrom)
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(InvalidConformerError):
             molecule.add_conformer(conf_no_coordinates)
 
         # Add a conforer with units of nanometers
@@ -2619,7 +2623,7 @@ class TestMolecule:
             ),
             unit.joule,
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(IncompatibleUnitError):
             molecule.add_conformer(conf_nonsense_units)
 
         conf_openmm_units = openmm_unit.Quantity(
@@ -2639,9 +2643,6 @@ class TestMolecule:
         assert molecule.conformers[-1][0][0].m_as(unit.angstrom) == 1.0
         assert molecule.conformers[-1][-1][-1].m_as(unit.angstrom) == 15.0
 
-        with pytest.raises(Exception) as excinfo:
-            molecule.add_conformer(conf_unitless)
-
         # Add a conformer with no units
         conf_unitless = np.array(
             [
@@ -2652,7 +2653,7 @@ class TestMolecule:
                 [13.0, 14.0, 15],
             ]
         )
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(IncompatibleUnitError):
             molecule.add_conformer(conf_unitless)
 
     @pytest.mark.parametrize("molecule", mini_drug_bank())


### PR DESCRIPTION
In #1249 it was made obvious that I didn't test the case of adding a conformer with OpenMM units. The functionality was there but that particular test case was missing. I also found the code to be hard to follow and updated it in hopes of it being more maintainable.

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
