### PR TITLE
Update versions of actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -161,7 +161,7 @@ jobs:
           pytest -v --doctest-glob="docs/*.rst" docs/
 
       - name: Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.0.0
         with:
           file: ./coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -25,7 +25,7 @@ jobs:
       PYTEST_ARGS: -r fE --tb=short --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
 
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2.4.0
         with:
           fetch-depth: 2
 
@@ -91,7 +91,7 @@ jobs:
           mypy --namespace-packages -p "openff.toolkit"
 
       - name: Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.0.0
         with:
           file: ./coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -131,7 +131,7 @@ jobs:
           pytest $NB_ARGS examples
 
       - name: Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@v3.0.0
         with:
           file: ./coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -68,7 +68,7 @@ jobs:
         ls build
 
     - name: Upload installer as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}_py${{ matrix.python-version }}.sh  
         path: toolkit-installer-constructor/build/openff-toolkit*/openff-toolkit*.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.4.0
 
-      - uses: actions/setup-python@v2.3.1
+      - uses: actions/setup-python@v3.1.2
         with:
           python-version: '3.7'
 


### PR DESCRIPTION
I manually updated the versions of various upstream actions used in our automation. This probably fixes recent issues of codecov reports being rejected by their service (major version difference).

There's probably a way to run a Dependabot equivalent locally, but that would take too long to get up and running so I made these changes manually. Things look okay, having checked each one manually:

```
(openff-dev) [openforcefield] grep -r "uses:" .github/workflows                                          autoupdates  ✱
.github/workflows/installer.yml:    - uses: actions/checkout@v2.4.0
.github/workflows/installer.yml:    - uses: conda-incubator/setup-miniconda@v2.1.1
.github/workflows/installer.yml:      uses: actions/upload-artifact@v3
.github/workflows/release.yml:      uses: richardsimko/update-tag@v1
.github/workflows/lint.yml:      - uses: actions/checkout@v2.4.0
.github/workflows/lint.yml:      - uses: actions/setup-python@v3.1.2
.github/workflows/conda.yml:      - uses: actions/checkout@v2.4.0
.github/workflows/conda.yml:      - uses: conda-incubator/setup-miniconda@v2.1.1
.github/workflows/conda.yml:      - uses: conda-incubator/setup-miniconda@v2.1.1
.github/workflows/examples.yml:      - uses: actions/checkout@v2.4.0
.github/workflows/examples.yml:      - uses: conda-incubator/setup-miniconda@v2.1.1
.github/workflows/examples.yml:        uses: codecov/codecov-action@v3.0.0
.github/workflows/CI.yml:      - uses: actions/checkout@v2.4.0
.github/workflows/CI.yml:        uses: conda-incubator/setup-miniconda@v2.1.1
.github/workflows/CI.yml:        uses: codecov/codecov-action@v3.0.0
.github/workflows/beta_rc.yaml:      - uses: actions/checkout@v2.4.0
.github/workflows/beta_rc.yaml:      - uses: conda-incubator/setup-miniconda@v2.1.1
.github/workflows/beta_rc.yaml:        uses: codecov/codecov-action@v3.0.0