### PR TITLE
Add section to FAQ on AM1-BCC issues with large ligands

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -84,6 +84,11 @@ and then try rerunning and/or reinstalling the Toolkit.
 
 No! This is the intended behavior. The force field parameters of a molecule should be independent of both their chemical environment and conformation so that they can be used and compared across different contexts. When applying AM1BCC partial charges, the toolkit achieves a deterministic output by ignoring the input conformation and producing several new conformations for the same molecule. Partial charges are then computed based on these conformations. This behavior can be controlled with the `use_conformers` argument to the [assign_partial_charges()](openff.toolkit.topology.Molecule.assign_partial_charges) and [compute_partial_charges_am1bcc()](openff.toolkit.topology.Molecule.compute_partial_charges_am1bcc) methods of the [Molecule](openff.toolkit.topology.Molecule) class.
 
+## Parameterizing my system, which contains a large molecule, is taking forever. What's wrong?
+
+The mainline OpenFF force fields use AM1-BCC to assign partial charges (via the `<ToolkitAM1BCCHandler>` tag in the OFFXML file). This method unfortunately scales poorly with the size of a molecule and ligands roughly 100 atoms or larger may take so long (i.e. 10 minutes or more) that it seems like your code is simply hanging indefinitely. If you have OpenEye license and OpenEye Toolkits installed, the OpenFF Toolkit will instead use `quacpac`, which can offer better performance on large molecules. (Otherwise, it uses AmberTool's `sqm`, which is free to use.)
+
+In the future, the use of AM1-BCC in OpenFF force fields may be replaced with method(s) that perform better and scale better with molecule size, but (as of April 2022) these are still in an experimental phase.
 
 ## How can I distribute my own force fields in SMIRNOFF format?
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -86,7 +86,7 @@ No! This is the intended behavior. The force field parameters of a molecule shou
 
 ## Parameterizing my system, which contains a large molecule, is taking forever. What's wrong?
 
-The mainline OpenFF force fields use AM1-BCC to assign partial charges (via the `<ToolkitAM1BCCHandler>` tag in the OFFXML file). This method unfortunately scales poorly with the size of a molecule and ligands roughly 100 atoms or larger may take so long (i.e. 10 minutes or more) that it seems like your code is simply hanging indefinitely. If you have OpenEye license and OpenEye Toolkits [installed](installation/openeye), the OpenFF Toolkit will instead use `quacpac`, which can offer better performance on large molecules. (Otherwise, it uses AmberTool's `sqm`, which is free to use.)
+The mainline OpenFF force fields use AM1-BCC to assign partial charges (via the `<ToolkitAM1BCCHandler>` tag in the OFFXML file). This method unfortunately scales poorly with the size of a molecule and ligands roughly 100 atoms (about 40 heavy atoms) or larger may take so long (i.e. 10 minutes or more) that it seems like your code is simply hanging indefinitely. If you have an OpenEye license and OpenEye Toolkits [installed](installation/openeye), the OpenFF Toolkit will instead use `quacpac`, which can offer better performance on large molecules. Otherwise, it uses AmberTool's `sqm`, which is free to use.
 
 In the future, the use of AM1-BCC in OpenFF force fields may be replaced with method(s) that perform better and scale better with molecule size, but (as of April 2022) these are still in an experimental phase.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -86,7 +86,7 @@ No! This is the intended behavior. The force field parameters of a molecule shou
 
 ## Parameterizing my system, which contains a large molecule, is taking forever. What's wrong?
 
-The mainline OpenFF force fields use AM1-BCC to assign partial charges (via the `<ToolkitAM1BCCHandler>` tag in the OFFXML file). This method unfortunately scales poorly with the size of a molecule and ligands roughly 100 atoms or larger may take so long (i.e. 10 minutes or more) that it seems like your code is simply hanging indefinitely. If you have OpenEye license and OpenEye Toolkits installed, the OpenFF Toolkit will instead use `quacpac`, which can offer better performance on large molecules. (Otherwise, it uses AmberTool's `sqm`, which is free to use.)
+The mainline OpenFF force fields use AM1-BCC to assign partial charges (via the `<ToolkitAM1BCCHandler>` tag in the OFFXML file). This method unfortunately scales poorly with the size of a molecule and ligands roughly 100 atoms or larger may take so long (i.e. 10 minutes or more) that it seems like your code is simply hanging indefinitely. If you have OpenEye license and OpenEye Toolkits [installed](installation/openeye), the OpenFF Toolkit will instead use `quacpac`, which can offer better performance on large molecules. (Otherwise, it uses AmberTool's `sqm`, which is free to use.)
 
 In the future, the use of AM1-BCC in OpenFF force fields may be replaced with method(s) that perform better and scale better with molecule size, but (as of April 2022) these are still in an experimental phase.
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,4 +1,4 @@
-name: openforcefield
+name: openff-toolkit-docs
 channels:
     # Avoids crashing RTD machines by pulling an empty cudatoolkit pacakge
     - jaimergp/label/unsupported-cudatoolkit-shim
@@ -22,6 +22,10 @@ dependencies:
     - rdkit
     - ambertools
     - packaging
+    - openff-units
+    - openff-utilities
+    - cached_property
+    - cachetools
     # Serialization: Should these be optional?
     - toml
     - bson

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,8 @@
 
 # Installation
 
+(installation/conda)=
+
 ## Installing via `conda`
 
 The simplest way to install the Open Force Field Toolkit is via the [conda](https://docs.conda.io/en/latest/) package manager.
@@ -65,6 +67,8 @@ $ conda update -c conda-forge openff-toolkit
 ```
 
 Note that this may update other packages or install new packages if the most recent release of the Toolkit requires it.
+
+(installation/source)=
 
 ## Installing from source
 
@@ -144,6 +148,8 @@ It provides most of the functionality that the OpenFF Toolkit relies on.
 
 AmberTools is a collection of free tools provided with the Amber MD software and installed by default with the `openff-toolkit` package. 
 It provides a free implementation of functionality required by OpenFF Toolkit and not provided by RDKit.
+
+(installation/openeye)=
 
 ### OpenEye
 


### PR DESCRIPTION
This has come up twice in the past week or so, which I think warrants an entry here. I chose to leave out a few topics in order to be brief, but can add any back if they're seen as necessary. That includes

* Explaining that biopolymer force fields will use library charges, bypassing this issue for proteins
* That the AM1-BCC calculation only takes place once per unique molecule, so this isn't an issue for boxes of many not-incredibly-large molecules
* `charge_from_molecules` (I'm personally not a huge fan of this patten, but I see why it must exist)