### PR TITLE
Use `packaging.version` to manage SMIRNOFF section versions

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -58,6 +58,12 @@ print(value_roundtrip)
 
 ## Current Development
 
+- [PR #1279](https://github.com/openforcefield/openforcefield/pull/1279):
+  [`ParameterHandler.version`](openff.toolkit.typing.engines.smirnoff.parameters.ParameterHandler.version)
+  and the ``.version`` attribute of its subclasses is now a
+  [``Version``](https://packaging.pypa.io/en/latest/version.html#packaging.version.Version)
+  object. Previously it was a string, which is not safe for
+  [PEP440](https://www.python.org/dev/peps/pep-0440/#final-releases)-style versioning.
 - [PR #1250](https://github.com/openforcefield/openff-toolkit/pull/1250): Adds support for
   `return_topology` in the Interchange code path in
   [`create_openmm_system`](openff.toolkit.typing.engines.smirnoff.ForceField.create_openmm_system).

--- a/openff/toolkit/tests/test_parameters.py
+++ b/openff/toolkit/tests/test_parameters.py
@@ -14,6 +14,7 @@ import numpy
 import pytest
 from numpy.testing import assert_almost_equal
 from openff.units import unit
+from packaging.version import Version
 
 import openff.toolkit.typing.engines.smirnoff.parameters
 from openff.toolkit.topology import Molecule
@@ -688,8 +689,8 @@ class TestParameterHandler:
         """
 
         class MyPHSubclass(ParameterHandler):
-            _MIN_SUPPORTED_SECTION_VERSION = 0.3
-            _MAX_SUPPORTED_SECTION_VERSION = 2
+            _MIN_SUPPORTED_SECTION_VERSION = Version("0.3")
+            _MAX_SUPPORTED_SECTION_VERSION = Version("2")
 
         with pytest.raises(SMIRNOFFVersionError) as excinfo:
             my_ph = MyPHSubclass(version=0.1)
@@ -704,11 +705,11 @@ class TestParameterHandler:
         """Ensure that a ParameterHandler remembers the version that was set when it was initialized."""
 
         class MyPHSubclass(ParameterHandler):
-            _MIN_SUPPORTED_SECTION_VERSION = 0.3
-            _MAX_SUPPORTED_SECTION_VERSION = 2
+            _MIN_SUPPORTED_SECTION_VERSION = Version("0.3")
+            _MAX_SUPPORTED_SECTION_VERSION = Version("2")
 
         my_ph = MyPHSubclass(version=1.234)
-        assert my_ph.to_dict()["version"] == 1.234
+        assert my_ph.to_dict()["version"] == Version("1.234")
 
     def test_add_delete_cosmetic_attributes(self):
         """Test ParameterHandler.to_dict() function when some parameters are in

--- a/openff/toolkit/tests/test_parameters.py
+++ b/openff/toolkit/tests/test_parameters.py
@@ -694,6 +694,8 @@ class TestParameterHandler:
 
         with pytest.raises(SMIRNOFFVersionError) as excinfo:
             my_ph = MyPHSubclass(version=0.1)
+        with pytest.raises(Exception, match="Could not convert .*list"):
+            MyPHSubclass(version=[0])
         my_ph = MyPHSubclass(version=0.3)
         my_ph = MyPHSubclass(version=1)
         my_ph = MyPHSubclass(version="1.9")

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -62,8 +62,6 @@ __all__ = [
     "VirtualSiteTrivalentLonePairType",
 ]
 import abc
-from packaging.version import Version, parse
-
 import copy
 import functools
 import inspect
@@ -76,6 +74,7 @@ from typing import Any, List, Optional, Type, Union
 
 from openff.units import unit
 from openff.utilities import requires_package
+from packaging.version import Version, parse
 
 from openff.toolkit.topology import (
     ImproperDict,
@@ -1838,7 +1837,7 @@ class ParameterHandler(_ParameterAttributeHandler):
     _SMIRNOFF_VERSION_DEPRECATED = None
     # if deprecated, the first SMIRNOFF version number it is no longer used
     _MIN_SUPPORTED_SECTION_VERSION = Version("0.3")
-    _MAX_SUPPORTED_SECTION_VERSION =Version("0.3")
+    _MAX_SUPPORTED_SECTION_VERSION = Version("0.3")
 
     version = ParameterAttribute()
 
@@ -1857,15 +1856,16 @@ class ParameterHandler(_ParameterAttributeHandler):
         if isinstance(new_version, Version):
             pass
         elif isinstance(new_version, str):
-            new_version  = Version(new_version)
-        elif isinstance(new_version, float):
-            new_version  = Version(str(new_version))
+            new_version = Version(new_version)
+        elif isinstance(new_version, (float, int)):
+            new_version = Version(str(new_version))
         else:
-            raise Exception
+            raise Exception(f"Could not convert type {type(new_version)}")
 
         # Use PEP-440 compliant version number comparison, if requested
         if (new_version > self._MAX_SUPPORTED_SECTION_VERSION) or (
-            new_version < self._MIN_SUPPORTED_SECTION_VERSION):
+            new_version < self._MIN_SUPPORTED_SECTION_VERSION
+        ):
             raise SMIRNOFFVersionError(
                 f"SMIRNOFF offxml file was written with version {new_version}, but this version "
                 f"of ForceField only supports version {self._MIN_SUPPORTED_SECTION_VERSION} "
@@ -2685,15 +2685,21 @@ class BondHandler(ParameterHandler):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # Default value for fractional_bondorder_interpolation depends on section version
-        if self.version == 0.3 and "fractional_bondorder_method" not in kwargs:
+        if (
+            self.version == Version("0.3")
+            and "fractional_bondorder_method" not in kwargs
+        ):
             self.fractional_bondorder_method = "none"
-        elif self.version == 0.4 and "fractional_bondorder_method" not in kwargs:
+        elif (
+            self.version == Version("0.4")
+            and "fractional_bondorder_method" not in kwargs
+        ):
             self.fractional_bondorder_method = "AM1-Wiberg"
 
         # Default value for potential depends on section version
-        if self.version == 0.3 and "potential" not in kwargs:
+        if self.version == Version("0.3") and "potential" not in kwargs:
             self.potential = "harmonic"
-        elif self.version == 0.4 and "potential" not in kwargs:
+        elif self.version == Version("0.4") and "potential" not in kwargs:
             self.potential = "(k/2)*(r-length)^2"
 
     def check_handler_compatibility(self, other_handler):

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -62,6 +62,8 @@ __all__ = [
     "VirtualSiteTrivalentLonePairType",
 ]
 import abc
+from packaging.version import Version, parse
+
 import copy
 import functools
 import inspect
@@ -1835,8 +1837,8 @@ class ParameterHandler(_ParameterAttributeHandler):
     _SMIRNOFF_VERSION_INTRODUCED = 0.0
     _SMIRNOFF_VERSION_DEPRECATED = None
     # if deprecated, the first SMIRNOFF version number it is no longer used
-    _MIN_SUPPORTED_SECTION_VERSION = 0.3
-    _MAX_SUPPORTED_SECTION_VERSION = 0.3
+    _MIN_SUPPORTED_SECTION_VERSION = Version("0.3")
+    _MAX_SUPPORTED_SECTION_VERSION =Version("0.3")
 
     version = ParameterAttribute()
 
@@ -1850,18 +1852,20 @@ class ParameterHandler(_ParameterAttributeHandler):
         SMIRNOFFVersionError if an incompatible version is passed in.
 
         """
-        import packaging.version
-
         from openff.toolkit.typing.engines.smirnoff import SMIRNOFFVersionError
 
+        if isinstance(new_version, Version):
+            pass
+        elif isinstance(new_version, str):
+            new_version  = Version(new_version)
+        elif isinstance(new_version, float):
+            new_version  = Version(str(new_version))
+        else:
+            raise Exception
+
         # Use PEP-440 compliant version number comparison, if requested
-        if (
-            packaging.version.parse(str(new_version))
-            > packaging.version.parse(str(self._MAX_SUPPORTED_SECTION_VERSION))
-        ) or (
-            packaging.version.parse(str(new_version))
-            < packaging.version.parse(str(self._MIN_SUPPORTED_SECTION_VERSION))
-        ):
+        if (new_version > self._MAX_SUPPORTED_SECTION_VERSION) or (
+            new_version < self._MIN_SUPPORTED_SECTION_VERSION):
             raise SMIRNOFFVersionError(
                 f"SMIRNOFF offxml file was written with version {new_version}, but this version "
                 f"of ForceField only supports version {self._MIN_SUPPORTED_SECTION_VERSION} "
@@ -2660,7 +2664,7 @@ class BondHandler(ParameterHandler):
     _INFOTYPE = BondType  # class to hold force type info
     _OPENMMTYPE = "HarmonicBondForce"
     _DEPENDENCIES = [ConstraintHandler]  # ConstraintHandler must be executed first
-    _MAX_SUPPORTED_SECTION_VERSION = 0.4
+    _MAX_SUPPORTED_SECTION_VERSION = Version("0.4")
 
     # Use the _allow_only filter here because this class's implementation contains all the information about supported
     # potentials for this handler.
@@ -3040,7 +3044,7 @@ class ProperTorsionHandler(ParameterHandler):
     _KWARGS = ["partial_bond_orders_from_molecules"]
     _INFOTYPE = ProperTorsionType  # info type to store
     _OPENMMTYPE = "PeriodicTorsionForce"
-    _MAX_SUPPORTED_SECTION_VERSION = 0.4
+    _MAX_SUPPORTED_SECTION_VERSION = Version("0.4")
 
     potential = ParameterAttribute(
         default="k*(1+cos(periodicity*theta-phase))",
@@ -4318,7 +4322,7 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
         LibraryChargeHandler,
         ToolkitAM1BCCHandler,
     ]
-    _MAX_SUPPORTED_SECTION_VERSION = 0.4
+    _MAX_SUPPORTED_SECTION_VERSION = Version("0.4")
 
     number_of_conformers = ParameterAttribute(default=1, converter=int)
 


### PR DESCRIPTION
The toolkit currently tracks the version of each SMIRNOFF section in a corresponding `ParameterHandler.version`. These are stored as floats, however:

```python3
>>> from openff.toolkit.typing.engines.smirnoff import ElectrostaticsHandler
>>> type(ElectrostaticsHandler(version=0.3).version)
<class 'float'>
```

This is fine for now, but will cause issues in the future. This is commonly handled with PyPA's `packaging`, which is already a dependency used elsewhere. In a meeting today, @j-wags agreed to this change.

- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
