### PR TITLE
Speed up CI with `pytest-xdist`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       PACKAGE: openff
-      PYTEST_ARGS: -r fE --tb=short --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
+      PYTEST_ARGS: -r fE --tb=short -nauto --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
       NB_ARGS: -v --nbval-lax --ignore=examples/deprecated
 
     steps:

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -11,6 +11,7 @@ dependencies:
     # Testing
   - pytest
   - pytest-cov
+  - pytest-xdist
   - pytest-rerunfailures
   - nbval
   - codecov

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -10,6 +10,7 @@ dependencies:
     # Testing
   - pytest
   - pytest-cov
+  - pytest-xdist
   - pytest-rerunfailures
   - nbval
   - codecov

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -22,6 +22,7 @@ dependencies:
     # Test-only/optional/dev
   - pytest
   - pytest-cov
+  - pytest-xdist
   - pytest-rerunfailures
   - nbval
   - codecov


### PR DESCRIPTION
The unit tests are taking 12 minutes (not counting setup time) and I think we get 2 cores on each runner for free. This should be a free speedup.