### PR TITLE
Fix `Topology` JSON serialization

### DIFF
--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -593,7 +593,6 @@ class TestTopology:
 
     # test_two_of_same_molecule
     # test_two_different_molecules
-    # test_to_from_dict
     # test_get_molecule
     # test_is_bonded
     # TODO: Test serialization
@@ -1249,6 +1248,37 @@ class TestTopology:
         ]
         for expected_id, residue in zip(expected_ids, residues):
             assert expected_id == residue.identifier
+
+
+class TestTopologySerialization:
+    @pytest.fixture
+    def oleic_acid(self):
+        """Simple floppy molecule that can be assured to have multiple conformers"""
+        return Molecule.from_smiles("CCCCCCCC\C=C/CCCCCCCC(O)=O")
+
+    @pytest.mark.parametrize(("with_conformers"), [True, False])
+    @pytest.mark.parametrize(("n_molecules"), [1, 2])
+    @pytest.mark.parametrize(("format"), ["dict", "json"])
+    def test_roundtrip(self, oleic_acid, with_conformers, n_molecules, format):
+
+        if with_conformers:
+            n_conformers = 2
+            oleic_acid.generate_conformers(n_conformers=n_conformers)
+        else:
+            n_conformers = 0
+
+        if format == "dict":
+            roundtrip = Topology.from_dict(
+                Topology.from_molecules(n_molecules * [oleic_acid]).to_dict()
+            )
+        elif format == "json":
+            roundtrip = Topology.from_json(
+                Topology.from_molecules(n_molecules * [oleic_acid]).to_json()
+            )
+
+        assert roundtrip.n_molecules == n_molecules
+        assert roundtrip.n_atoms == oleic_acid.n_atoms * n_molecules
+        assert [*roundtrip.molecules][0].n_conformers == n_conformers
 
 
 @pytest.mark.parametrize(

--- a/openff/toolkit/utils/serialization.py
+++ b/openff/toolkit/utils/serialization.py
@@ -484,7 +484,6 @@ def _contains_bytes(val) -> bool:
         return any([_contains_bytes(x) for x in val.values()])
     else:
         raise Exception(f"type {val}")
-    return False
 
 
 def _prep_numpy_data_for_json(data: Dict) -> Dict:


### PR DESCRIPTION
JSON serialization of `Topology` does not work when a molecule has conformers because there is no logic to ensure the bytes are converted into lists. Tests at 443ec7a should fail for this case.

Minimal reproduction (at 27490afb54176def982d9e0ef096b7bf363733bc):
```python3
>>> from openff.toolkit import *
>>> mol = Molecule.from_smiles("CCCCCCCC\C=C/CCCCCCCC(O)=O")
>>> mol.generate_conformers(n_conformers=2)
>>> Topology.from_json(mol.to_topology().to_json())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/utils/serialization.py", line 132, in to_json
    return json.dumps(d, indent=indent)
  File "/Users/mattthompson/miniconda3/envs/openff-dev/lib/python3.9/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/Users/mattthompson/miniconda3/envs/openff-dev/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Users/mattthompson/miniconda3/envs/openff-dev/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/Users/mattthompson/miniconda3/envs/openff-dev/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
