### PR TITLE
Update tests for `openff-units` 0.1.6

### DIFF
--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -26,7 +26,7 @@ dependencies:
   # Unpin when https://github.com/openmm/openmm/issues/3495 is resolved
   - openmm =7.6
   - openff-forcefields
-  - openff-units >=0.1.5
+  - openff-units >=0.1.6
   - openff-utilities
   - smirnoff99Frosst
   - cachetools

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -25,7 +25,7 @@ dependencies:
   # Unpin when https://github.com/openmm/openmm/issues/3495 is resolved
   - openmm =7.6
   - openff-forcefields
-  - openff-units >=0.1.5
+  - openff-units >=0.1.6
   - openff-utilities
   - smirnoff99Frosst
   - cachetools

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   # Unpin when https://github.com/openmm/openmm/issues/3495 is resolved
   - openmm =7.6
   - openff-forcefields
-  - openff-units >=0.1.5
+  - openff-units >=0.1.6
   - openff-utilities
   - smirnoff99Frosst
   - numpy

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -2375,7 +2375,7 @@ class TestForceFieldChargeAssignment:
         # Fail because nonintegral charges aren't allowed
         with pytest.raises(
             NonintegralMoleculeChargeException,
-            match="Partial charge sum [(]1.40001 e[)] for molecule",
+            match="Partial charge sum [(]1.40001 e.*[)] for molecule",
         ):
             omm_system = forcefield.create_openmm_system(
                 topology,

--- a/openff/toolkit/tests/test_parameters.py
+++ b/openff/toolkit/tests/test_parameters.py
@@ -1283,7 +1283,7 @@ class TestBondType:
         param_dict = p1.to_dict()
         with pytest.raises(
             ValueError,
-            match="Requested output unit cal is not compatible with quantity unit Å.",
+            match="Requested output unit cal.* is not compatible with quantity unit angstrom.",
         ) as context:
             param_dict_unitless, attached_units = detach_units(
                 param_dict, output_units={"length_unit": unit.calorie}


### PR DESCRIPTION
The last release of `openff-units` changed some string formatting, which broke a couple of unit tests. This PR updates the test environments and some `pytest.raises(match=...)` regex accordingly.
