### PR TITLE
Implement object_to_quantity for openmm quantities

### DIFF
--- a/openff/toolkit/tests/test_utils.py
+++ b/openff/toolkit/tests/test_utils.py
@@ -91,11 +91,17 @@ def test_dimensionless_units():
 
 def test_object_to_quantity_accepts_openmm():
     from openff.toolkit.utils.utils import object_to_quantity
-    import openmm.unit
+    import openmm
     val = object_to_quantity(1. * openmm.unit.angstrom)
     assert val == 1. * unit.angstrom
     val = object_to_quantity(1. * openmm.unit.nanometer)
     assert val == 10. * unit.angstrom
+    val = object_to_quantity([2. * openmm.unit.angstrom,
+                              2. * openmm.unit.nanometer,
+                              2. * openmm.unit.dimensionless])
+    assert val == [2. * unit.angstrom,
+                   20. * unit.angstrom,
+                   2 * unit.dimensionless]
 
 
 def test_sort_smirnoff_dict():

--- a/openff/toolkit/tests/test_utils.py
+++ b/openff/toolkit/tests/test_utils.py
@@ -89,6 +89,14 @@ def test_dimensionless_units():
 
     assert unit_value == unit.dimensionless
 
+def test_object_to_quantity_accepts_openmm():
+    from openff.toolkit.utils.utils import object_to_quantity
+    import openmm.unit
+    val = object_to_quantity(1. * openmm.unit.angstrom)
+    assert val == 1. * unit.angstrom
+    val = object_to_quantity(1. * openmm.unit.nanometer)
+    assert val == 10. * unit.angstrom
+
 
 def test_sort_smirnoff_dict():
     from collections import OrderedDict

--- a/openff/toolkit/tests/test_utils.py
+++ b/openff/toolkit/tests/test_utils.py
@@ -89,19 +89,24 @@ def test_dimensionless_units():
 
     assert unit_value == unit.dimensionless
 
+
 def test_object_to_quantity_accepts_openmm():
-    from openff.toolkit.utils.utils import object_to_quantity
     import openmm
-    val = object_to_quantity(1. * openmm.unit.angstrom)
-    assert val == 1. * unit.angstrom
-    val = object_to_quantity(1. * openmm.unit.nanometer)
-    assert val == 10. * unit.angstrom
-    val = object_to_quantity([2. * openmm.unit.angstrom,
-                              2. * openmm.unit.nanometer,
-                              2. * openmm.unit.dimensionless])
-    assert val == [2. * unit.angstrom,
-                   20. * unit.angstrom,
-                   2 * unit.dimensionless]
+
+    from openff.toolkit.utils.utils import object_to_quantity
+
+    val = object_to_quantity(1.0 * openmm.unit.angstrom)
+    assert val == 1.0 * unit.angstrom
+    val = object_to_quantity(1.0 * openmm.unit.nanometer)
+    assert val == 10.0 * unit.angstrom
+    val = object_to_quantity(
+        [
+            2.0 * openmm.unit.angstrom,
+            2.0 * openmm.unit.nanometer,
+            2.0 * openmm.unit.dimensionless,
+        ]
+    )
+    assert val == [2.0 * unit.angstrom, 20.0 * unit.angstrom, 2 * unit.dimensionless]
 
 
 def test_sort_smirnoff_dict():

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -437,7 +437,7 @@ def _(obj):
 
 try:
     from openff.units.openmm import from_openmm
-    import openmm.unit
+    import openmm
     @object_to_quantity.register(openmm.unit.Quantity)
     def _(obj):
         return from_openmm(obj)

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -435,6 +435,15 @@ def _(obj):
 def _(obj):
     return unit.Quantity(obj)
 
+try:
+    from openff.units.openmm import from_openmm
+    import openmm.unit
+    @object_to_quantity.register(openmm.unit.Quantity)
+    def _(obj):
+        return from_openmm(obj)
+except ImportError:
+    pass
+
 
 def extract_serialized_units_from_dict(input_dict):
     """

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -437,8 +437,9 @@ def _(obj):
 
 
 try:
-    from openff.units.openmm import from_openmm
     import openmm
+    from openff.units.openmm import from_openmm
+
     @object_to_quantity.register(openmm.unit.Quantity)
     def _(obj):
         return from_openmm(obj)


### PR DESCRIPTION
In the switch to OpenFF units, the ParameterAttribute setters no longer accept OpenMM units. Since many of our users now have workflows that require calling OpenFF setters using OpenMM units, this simple fix can keep the door open for them.

- [x] Implements support for openmm units in `object_to_quantity` if `openmm.unit` is importable
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
