### PR TITLE
Fix `ParameterType.__repr__`

### DIFF
--- a/openff/toolkit/tests/test_parameters.py
+++ b/openff/toolkit/tests/test_parameters.py
@@ -1159,6 +1159,12 @@ class TestParameterType:
         assert param_dict["smirks"] == "[*:1]"
         assert len(param_dict.keys()) == 1
 
+    def test_repr(self):
+        class NamedType(ParameterType):
+            pass
+
+        assert NamedType(smirks="[*:1]").__repr__().startswith("<NamedType")
+
 
 class TestBondType:
     """Tests for the BondType class."""

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -1771,7 +1771,7 @@ class ParameterType(_ParameterAttributeHandler):
         super().__init__(allow_cosmetic_attributes=allow_cosmetic_attributes, **kwargs)
 
     def __repr__(self):
-        ret_str = "<{self.__class__.__name__} with "
+        ret_str = f"<{self.__class__.__name__} with "
         for attr, val in self.to_dict().items():
             ret_str += f"{attr}: {val}  "
         ret_str += ">"


### PR DESCRIPTION
I made a cosmetic regression, probably in #1286:


```python3
>>> ForceField("openff-2.0.0.offxml")['Bonds'].parameters[0]
<{self.__class__.__name__} with smirks: [#6X4:1]-[#6X4:2]  id: b1  length: 1.52190126495 angstrom  k: 529.2429715351 kilocalorie / angstrom ** 2 / mole  >
```

This annoys me, so this change fixes it:
```python3
>>> ForceField("openff-2.0.0.offxml")['Bonds'].parameters[0]
<BondType with smirks: [#6X4:1]-[#6X4:2]  id: b1  length: 1.52190126495 angstrom  k: 529.2429715351 kilocalorie / angstrom ** 2 / mole  >
```

and adds a tiny unit test to possibly prevent me from doing it again.