### PR TITLE
Update test environments

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,7 +105,7 @@ jobs:
           # force uninstall openff-toolkit-base since it's only pulled in when
           # Interchange is installed with conda. Un-comment this when testing
           # against a conda build of Interchange.
-          # conda remove --force openff-toolkit openff-toolkit-base
+          conda remove --force openff-toolkit openff-toolkit-base
           python setup.py develop --no-deps
 
       - name: Install test plugins

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,6 @@ jobs:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       PACKAGE: openff
       PYTEST_ARGS: -r fE --tb=short -nauto --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
-      NB_ARGS: -v --nbval-lax --ignore=examples/deprecated
 
     steps:
       - uses: actions/checkout@v2.4.0
@@ -104,8 +103,9 @@ jobs:
           # While Interchange is being installed with pip, there is no need to
           # force uninstall openff-toolkit-base since it's only pulled in when
           # Interchange is installed with conda. Un-comment this when testing
-          # against a conda build of Interchange.
-          conda remove --force openff-toolkit openff-toolkit-base
+          # against a conda build of Interchange. (It may also be pulled down
+          # by `openmmforcefields` and should be removed in that case a well.)
+          # conda remove --force openff-toolkit openff-toolkit-base
           python setup.py develop --no-deps
 
       - name: Install test plugins

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -123,10 +123,6 @@ jobs:
             NB_ARGS+=" --ignore=examples/conformer_energies"
             NB_ARGS+=" --ignore=examples/using_smirnoff_in_amber_or_gromacs"
           fi
-          # https://github.com/openforcefield/openff-toolkit/pull/1232#issuecomment-1080889858
-          NB_ARGS+=" --ignore=examples/toolkit_showcase/toolkit_showcase.ipynb"
-          NB_ARGS+=" --ignore=examples/swap_amber_parameters/swap_existing_ligand_parameters_with_openmmforcefields.ipynb"
-
           NB_ARGS+=" --ignore=examples/using_smirnoff_in_amber_or_gromacs/export_with_interchange.ipynb"
 
           # REMOVE THIS LINE BEFORE 0.11.0 RELEASE

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -124,6 +124,9 @@ jobs:
             NB_ARGS+=" --ignore=examples/using_smirnoff_in_amber_or_gromacs"
           fi
           NB_ARGS+=" --ignore=examples/using_smirnoff_in_amber_or_gromacs/export_with_interchange.ipynb"
+          # https://github.com/openforcefield/openff-toolkit/pull/1232#issuecomment-1080889858
+          NB_ARGS+=" --ignore=examples/toolkit_showcase/toolkit_showcase.ipynb"
+          NB_ARGS+=" --ignore=examples/swap_amber_parameters/swap_existing_ligand_parameters_with_openmmforcefields.ipynb"
 
           # REMOVE THIS LINE BEFORE 0.11.0 RELEASE
           NB_ARGS+=" --ignore=examples/virtual_sites/vsite_showcase.ipynb"

--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - python
   - pip
   - packaging
-  - openmm
+  - openmm >=7.6
   - openff-forcefields
   - smirnoff99Frosst
   - numpy

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -21,7 +21,8 @@ dependencies:
   - parmed
   - openeye-toolkits
   - packaging
-  - openmmforcefields
+    # Removed until a compatible release is made
+# - openmmforcefields
   - openmm =>7.6
   - openff-forcefields
   - openff-units >=0.1.6

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -21,10 +21,8 @@ dependencies:
   - parmed
   - openeye-toolkits
   - packaging
-    # Removed until a new release which targets openff-toolkit is made.
-#  - openmmforcefields
-  # Unpin when https://github.com/openmm/openmm/issues/3495 is resolved
-  - openmm =7.6
+  - openmmforcefields
+  - openmm =>7.6
   - openff-forcefields
   - openff-units >=0.1.6
   - openff-utilities
@@ -42,4 +40,4 @@ dependencies:
   - qcengine
   - mdtraj
   - pip:
-    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.3
+    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.4

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -20,10 +20,8 @@ dependencies:
   - ambertools
   - rdkit
   - packaging
-    # Removed until a new release which targets openff-toolkit is made.
-#  - openmmforcefields
-  # Unpin when https://github.com/openmm/openmm/issues/3495 is resolved
-  - openmm =7.6
+  - openmmforcefields
+  - openmm >=7.6
   - openff-forcefields
   - openff-units >=0.1.6
   - openff-utilities
@@ -41,4 +39,4 @@ dependencies:
   - qcengine
   - mdtraj
   - pip:
-    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.3
+    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.4

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -20,7 +20,8 @@ dependencies:
   - ambertools
   - rdkit
   - packaging
-  - openmmforcefields
+    # Removed until a compatible release is made
+# - openmmforcefields
   - openmm >=7.6
   - openff-forcefields
   - openff-units >=0.1.6

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,6 +8,7 @@ dependencies:
   - pip
   - packaging
   - openmm >=7.6
+  - openmmforcefields
   - openff-forcefields
   - openff-units >=0.1.6
   - openff-utilities

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -7,8 +7,7 @@ dependencies:
   - python
   - pip
   - packaging
-  # Unpin when https://github.com/openmm/openmm/issues/3495 is resolved
-  - openmm =7.6
+  - openmm >=7.6
   - openff-forcefields
   - openff-units >=0.1.6
   - openff-utilities
@@ -48,4 +47,4 @@ dependencies:
     - types-toml
     - types-PyYAML
     - mongo-types
-    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.3
+    - git+https://github.com/openforcefield/openff-interchange.git@v0.2.0-alpha.4

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,7 +8,8 @@ dependencies:
   - pip
   - packaging
   - openmm >=7.6
-  - openmmforcefields
+    # Removed until a compatible release is made
+# - openmmforcefields
   - openff-forcefields
   - openff-units >=0.1.6
   - openff-utilities


### PR DESCRIPTION
* I have tagged a new alpha version of Interchange (`v0.2.0-alpha.4`)
* https://github.com/openmm/openmm/issues/3495 is not resolved, but the broken packages are unavailable so we should be able to back the pins down to lower constraints
* It's possible that a recent version of `openmmforcefields` is compatible with our stack, so I'm giving that a spin