### PR TITLE
Add tests and custom exceptions for index lookups in Topology

### DIFF
--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -31,6 +31,7 @@ from openff.toolkit.tests.utils import (
     requires_rdkit,
 )
 from openff.toolkit.topology import (
+    Atom,
     ImproperDict,
     Molecule,
     TagSortedDict,
@@ -45,10 +46,12 @@ from openff.toolkit.utils import (
     RDKitToolkitWrapper,
 )
 from openff.toolkit.utils.exceptions import (
+    AtomNotInTopologyError,
     DuplicateUniqueMoleculeError,
     InvalidBoxVectorsError,
     InvalidPeriodicityError,
     MissingUniqueMoleculesError,
+    MoleculeNotInTopologyError,
 )
 
 
@@ -245,6 +248,32 @@ class TestTopology:
 
         with pytest.raises(Exception):
             topology.atom(8)
+
+    def test_atom_index(self):
+        topology = create_ethanol().to_topology()
+
+        for index in range(topology.n_atoms):
+            atom = topology.atom(index)
+            assert topology.atom_index(atom) == index
+
+        ghost_atom = Atom(atomic_number=1, formal_charge=0, is_aromatic=False)
+
+        with pytest.raises(AtomNotInTopologyError):
+            topology.atom_index(ghost_atom)
+
+    def test_molecule_index(self):
+        molecules = [Molecule.from_smiles("CCO"), Molecule.from_smiles("O")]
+
+        topology = Topology.from_molecules(molecules)
+
+        for index in range(topology.n_molecules):
+            molecule = topology.molecule(index)
+            assert topology.molecule_index(molecule) == index
+
+        ghost_molecule = Molecule.from_smiles("N")
+
+        with pytest.raises(MoleculeNotInTopologyError):
+            topology.molecule_index(ghost_molecule)
 
     def test_atom_element_properties(self):
         """

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -27,11 +27,13 @@ from openff.toolkit.topology._mm_molecule import _SimpleBond, _SimpleMolecule
 from openff.toolkit.typing.chemistry import ChemicalEnvironment
 from openff.toolkit.utils import quantity_to_string, string_to_quantity
 from openff.toolkit.utils.exceptions import (
+    AtomNotInTopologyError,
     DuplicateUniqueMoleculeError,
     InvalidAromaticityModelError,
     InvalidBoxVectorsError,
     InvalidPeriodicityError,
     MissingUniqueMoleculesError,
+    MoleculeNotInTopologyError,
     NotBondedError,
 )
 from openff.toolkit.utils.serialization import Serializable
@@ -722,6 +724,10 @@ class Topology(Serializable):
         -------
         index : int
             The index of the given atom in this topology
+
+        Raises
+        ------
+        AtomNotInTopologyError : If the given atom is not in this topology
         """
         topology_molecule_atom_start_index = 0
         for molecule in self.molecules:
@@ -729,8 +735,9 @@ class Topology(Serializable):
                 return molecule.atom_index(atom) + topology_molecule_atom_start_index
             else:
                 topology_molecule_atom_start_index += molecule.n_atoms
-        raise Exception("Atom not found in this Topology")
+        raise AtomNotInTopologyError("Atom not found in this Topology")
 
+    # TODO: Should we have particles at all (iterators, objects, etc.)?
     def particle_index(self, particle) -> int:
         """
         Returns the index of a given particle in this topology
@@ -761,11 +768,16 @@ class Topology(Serializable):
         -------
         index : int
             The index of the given molecule in this topology
+
+        Raises
+        ------
+        MoleculeNotInTopologyError : If the given atom is not in this topology
         """
         for index, iter_molecule in enumerate(self.molecules):
             if molecule is iter_molecule:
                 return index
-        raise Exception("Molecule not found in this Topology")
+
+        raise MoleculeNotInTopologyError("Molecule not found in this Topology")
 
     def molecule_atom_start_index(self, molecule):
         """

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -111,6 +111,18 @@ class NotAttachedToMoleculeError(OpenFFToolkitException):
     """Exception for when a component does not belong to a Molecule object, but is queried"""
 
 
+class NotInTopologyError(OpenFFToolkitException):
+    """An object was not found in a topology."""
+
+
+class AtomNotInTopologyError(NotInTopologyError):
+    """An atom was not found in a topology."""
+
+
+class MoleculeNotInTopologyError(NotInTopologyError):
+    """A molecule was not found in a topology."""
+
+
 class InvalidAtomMetadataError(OpenFFToolkitException):
     """The program attempted to set atom metadata to an invalid type"""
 


### PR DESCRIPTION
While working on #1276, I found that `Topology.molecule_index` was only ever used in the machinery that checks which molecules had charges assigned to them. I added a couple of unit tests, custom exceptions, and updated some docstrings.

I noticed there are a lot of bits in the `Topology` API that deal with particles, i.e.

```
    @property
    def particles(self):
        for molecule in self.molecules:
            for atom in molecule.atoms:
                yield atom
```

@j-wags would you accept a PR that removes or deprecates the concept of a "particle" since virtual sites are no longer a part of `Molecule` objects?

- [ ] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
