### PR TITLE
Deprecate particles

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -58,6 +58,9 @@ print(value_roundtrip)
 
 ## Current Development
 
+- [PR #XXXX](https://github.com/openforcefield/openff-toolkit/pull/XXX): Deprecates `Topology.particles`,
+  `Topology.n_particles`, `Topology.particle_index` as `Molecule` objects do not store virtual sites,
+  only atoms.
 - [PR #1297](https://github.com/openforcefield/openff-toolkit/pull/1297): Drops support
   for Python 3.7, following [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html).
 - [PR #1194](https://github.com/openforcefield/openforcefield/pull/1194): Adds

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -58,7 +58,7 @@ print(value_roundtrip)
 
 ## Current Development
 
-- [PR #XXXX](https://github.com/openforcefield/openff-toolkit/pull/XXX): Deprecates `Topology.particles`,
+- [PR #1303](https://github.com/openforcefield/openff-toolkit/pull/1303): Deprecates `Topology.particles`,
   `Topology.n_particles`, `Topology.particle_index` as `Molecule` objects do not store virtual sites,
   only atoms.
 - [PR #1297](https://github.com/openforcefield/openff-toolkit/pull/1297): Drops support

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -129,6 +129,28 @@ class TestTopology:
             ):
                 assert len([*getattr(topology, old_iterator)]) == 0
 
+        # Some particle-related methods are deprecated for reasons other than the `TopologyX` deprecation
+        with pytest.warns(
+            TopologyDeprecationWarning,
+            match="Topology.n_particles is deprecated. Use Topology.n_atoms instead.",
+        ):
+            assert topology.n_particles == 0
+
+        with pytest.warns(
+            TopologyDeprecationWarning,
+            match="Topology.particles is deprecated. Use Topology.atoms instead.",
+        ):
+            assert len([*topology.particles]) == 0
+
+        topology = Molecule.from_smiles("O").to_topology()
+        first_atom = [*topology.atoms][0]
+
+        with pytest.warns(
+            TopologyDeprecationWarning,
+            match="Topology.particle_index is deprecated. Use Topology.atom_index instead.",
+        ):
+            assert topology.particle_index(first_atom) == 0
+
     def test_reinitialization_box_vectors(self):
         topology = Topology()
         assert Topology(topology).box_vectors is None

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -88,6 +88,17 @@ if TYPE_CHECKING:
 #       Only support OEAroModel_MDL in RDKit version?
 
 
+def _molecule_deprecation(old_method, new_method):
+    warnings.warn(
+        f"Molecule.{old_method} is deprecated. Use Molecule.{new_method} instead.",
+        MoleculeDeprecationWarning,
+    )
+
+
+class MoleculeDeprecationWarning(UserWarning):
+    """Warning for deprecated portions of the Molecule API."""
+
+
 class Particle(Serializable):
     """
     Base class for all particles in a molecule.
@@ -2921,43 +2932,20 @@ class FrozenMolecule(Serializable):
         return len(self._impropers)
 
     @property
-    def particles(self) -> List[Particle]:
-        """
-        Iterate over all Particle objects in the molecule.
-        """
+    def particles(self) -> List[Atom]:
+        """DEPRECATED: Use Molecule.atoms instead."""
+        _molecule_deprecation("particles", "atoms")
+        return self.atoms
 
-        return self._atoms
-
-    def particle(self, index: int):
-        """
-        Get particle with a specified index.
-
-        Parameters
-        ----------
-        index : int
-
-        Returns
-        -------
-        atom: openff.toolkit.topology.Atom
-        """
+    def particle(self, index: int) -> Atom:
+        """DEPRECATED: Use Molecule.atom instead."""
+        _molecule_deprecation("particle", "atom")
         return self.atom(index)
 
-    def particle_index(self, particle):
-        """
-        Returns the index of a given particle in this molecule
-
-        Parameters
-        ----------
-        particle : openff.toolkit.topology.Particle
-
-        Returns
-        -------
-        index : int
-            The index of the given particle in this molecule
-        """
-        for index, mol_particle in enumerate(self.particles):
-            if particle is mol_particle:
-                return index
+    def particle_index(self, particle: Atom) -> int:
+        """DEPRECATED: Use Molecule.atom_index instead."""
+        _molecule_deprecation("particle_index", "atom_index")
+        return self.atom_index(particle)
 
     @property
     def atoms(self):

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -731,24 +731,6 @@ class Topology(Serializable):
                 topology_molecule_atom_start_index += molecule.n_atoms
         raise Exception("Atom not found in this Topology")
 
-    def particle_index(self, particle) -> int:
-        """
-        Returns the index of a given particle in this topology
-
-        Parameters
-        ----------
-        particle : openff.toolkit.topology.Particle
-
-        Returns
-        -------
-        index : int
-            The index of the given particle in this topology
-        """
-        for index, iter_particle in enumerate(self.particles):
-            if particle is iter_particle:
-                return index
-        raise Exception("Particle not found in this Topology")
-
     def molecule_index(self, molecule):
         """
         Returns the index of a given molecule in this topology
@@ -806,34 +788,6 @@ class Topology(Serializable):
         for molecule in self.molecules:
             for bond in molecule.bonds:
                 yield bond
-
-    @property
-    def n_particles(self) -> int:
-        """
-        Returns the number of particles (Atoms) in in this Topology.
-
-        Returns
-        -------
-        n_particles : int
-        """
-        n_particles = 0
-        for molecule in self.molecules:
-            n_particles += molecule.n_particles
-        return n_particles
-
-    @property
-    def particles(self):
-        """
-        Returns an iterator over the particles (Atoms) in this Topology. The
-        particles will be in order of ascending Topology index.
-
-        Returns
-        --------
-        particles : Iterable of Atom
-        """
-        for molecule in self.molecules:
-            for atom in molecule.atoms:
-                yield atom
 
     @property
     def n_angles(self):
@@ -2092,18 +2046,6 @@ class Topology(Serializable):
                 return molecule.bond(bond_molecule_index)
             this_molecule_start_index += molecule.n_bonds
 
-    def add_particle(self, particle):
-        """Add a Particle to the Topology.
-
-        Parameters
-        ----------
-        particle : Particle
-            The Particle to be added.
-            The Topology will take ownership of the Particle.
-
-        """
-        pass
-
     def add_molecule(self, molecule: Union[Molecule, _SimpleMolecule]) -> int:
         self._molecules.append(deepcopy(molecule))
         self._cached_chemically_identical_molecules = None
@@ -2242,3 +2184,20 @@ class Topology(Serializable):
         """DEPRECATED: Use Topology.molecules instead."""
         _topology_deprecation("topology_molecules", "molecules")
         return self.molecules
+
+    @property
+    def n_particles(self) -> int:
+        """DEPRECATED: Use Topology.n_atoms instead."""
+        _topology_deprecation("n_particles", "n_atoms")
+        return self.n_atoms
+
+    @property
+    def particles(self):
+        """DEPRECATED: Use Topology.molecules instead."""
+        _topology_deprecation("particles", "atoms")
+        return self.atoms
+
+    def particle_index(self, particle) -> int:
+        """DEPRECATED: Use Topology.atom_index instead."""
+        _topology_deprecation("particle_index", "atom_index")
+        return self.atom_index(particle)


### PR DESCRIPTION
Implements https://github.com/openforcefield/openff-toolkit/pull/1302#issuecomment-1132243705

There are a lot of method, variable, etc. names in the hierarchy implementation that name things `particle`, and I think maybe these should be `atom` instead?

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
