### PR TITLE
Do not fail codecov if upload fails

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -162,4 +162,3 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
-          fail_ci_if_error: true

--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -94,4 +94,3 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
-          fail_ci_if_error: true

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -128,4 +128,3 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
-          fail_ci_if_error: true


### PR DESCRIPTION
`codecov/codecov-action` fails if it's given too many reports for a single commit (at least from a public repo). This causes a false negative ❌ when a branch is stable and daily cron jobs run on it. This is a bad look for our READMEs. We can either

1. Turn off `fail_ci_if_error` and generally trust each other to not merge PRs that massively drop code coverage
2. Generate a token _for each repo_, configure it as a secret, and then configure workflows in each repo to point to the appropriate token.