### PR TITLE
[WIP] Friendlier default hierarchy scheme behavior

### DIFF
--- a/openff/toolkit/tests/create_molecules.py
+++ b/openff/toolkit/tests/create_molecules.py
@@ -320,7 +320,7 @@ def dipeptide_residues_perceived():
 
 def dipeptide_hierarchy_perceived():
     dipeptide_hierarchy_perceived = Molecule(dipeptide_residues_perceived())
-    dipeptide_hierarchy_perceived._add_default_hierarchy_schemes()
+    dipeptide_hierarchy_perceived.add_default_hierarchy_schemes()
     dipeptide_hierarchy_perceived.perceive_hierarchy()
     return dipeptide_hierarchy_perceived
 
@@ -338,7 +338,7 @@ def cyx_residues_perceived():
 
 def cyx_hierarchy_perceived():
     cyx_hierarchy_perceived = Molecule(cyx_residues_perceived())
-    cyx_hierarchy_perceived._add_default_hierarchy_schemes()
+    cyx_hierarchy_perceived.add_default_hierarchy_schemes()
     cyx_hierarchy_perceived.perceive_hierarchy()
     return cyx_hierarchy_perceived
 

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -600,7 +600,6 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         oemol = offmol.to_openeye()
         oechem.OEPerceiveChiral(oemol)
         oechem.OE3DToInternalStereo(oemol)
-        print(f"Number of atoms after sanitization: {oemol.NumAtoms()}")
 
         # Aromaticity is re-perceived in this call
         offmol_w_stereo_and_aro = self.from_openeye(oemol, allow_undefined_stereo=True)


### PR DESCRIPTION
- [x] Make `Molecule.from_polymer_pdb` initialize molecules with residue and chain iterators
- [x] Make `Molecule.add_default_hierarchy_schemes` public
- [ ] Update pre-alpha notebook to work with new API and behavior
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
