### PR TITLE
Fix PDB writing from `OpenEyeToolkitWrapper`

### DIFF
--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -852,7 +852,6 @@ class TestOpenEyeToolkitWrapper:
         pdb = sio.getvalue()
         assert pdb.count("END") == 7
 
-
     def test_write_pdb_preserving_atom_names(self):
         """
         Make sure OpenEyeToolkitWrapper preserves unique atom names when writing to PDB.
@@ -865,9 +864,9 @@ class TestOpenEyeToolkitWrapper:
         sio = StringIO()
         mol.to_file(sio, "pdb", toolkit_registry=toolkit)
         mol_from_pdb = sio.getvalue()
-        assert 'C1' in mol_from_pdb
-        assert 'C2' in mol_from_pdb
-        assert 'O1' in mol_from_pdb
+        assert "C1" in mol_from_pdb
+        assert "C2" in mol_from_pdb
+        assert "O1" in mol_from_pdb
 
     def test_write_pdb_preserving_atom_order(self):
         """
@@ -2624,9 +2623,9 @@ class TestRDKitToolkitWrapper:
         sio = StringIO()
         mol.to_file(sio, "pdb", toolkit_registry=toolkit)
         mol_from_pdb = sio.getvalue()
-        assert 'C1' in mol_from_pdb
-        assert 'C2' in mol_from_pdb
-        assert 'O1' in mol_from_pdb
+        assert "C1" in mol_from_pdb
+        assert "C2" in mol_from_pdb
+        assert "O1" in mol_from_pdb
 
     # Unskip this when we implement PDB-reading support for RDKitToolkitWrapper
     @pytest.mark.skip

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -896,6 +896,29 @@ class TestOpenEyeToolkitWrapper:
         assert water_from_pdb_split[1].split()[2].rstrip() == "O"
         assert water_from_pdb_split[2].split()[2].rstrip() == "H"
 
+    def test_pdb_conect_and_hetatm(self):
+        """Test that OpenEyeToolkitWrapper writes PDB files with CONECT and HETATM records and no ATOM records."""
+        molecule = Molecule.from_smiles("CC(=O)NC1=CC=C(C=C1)O")
+        molecule.generate_conformers(n_conformers=1)
+
+        molecule.to_file(
+            "acetaminophen_openeye.pdb",
+            "PDB",
+            ToolkitRegistry([OpenEyeToolkitWrapper()]),
+        )
+
+        with open("acetaminophen_openeye.pdb") as f:
+            pdb_lines = f.readlines()
+
+        assert "ATOM" not in pdb_lines
+        assert (
+            len([row for row in pdb_lines if row.startswith("HETATM")])
+            == molecule.n_atoms
+        )
+        assert (
+            len([row for row in pdb_lines if row.startswith("CONECT")]) == 10
+        )  # 20 bonds, 10 lines of CONECT
+
     def test_get_sdf_coordinates(self):
         """Test OpenEyeToolkitWrapper for importing a single set of coordinates from a sdf file"""
 

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -852,9 +852,26 @@ class TestOpenEyeToolkitWrapper:
         pdb = sio.getvalue()
         assert pdb.count("END") == 7
 
+
+    def test_write_pdb_preserving_atom_names(self):
+        """
+        Make sure OpenEyeToolkitWrapper preserves unique atom names when writing to PDB.
+        """
+        from io import StringIO
+
+        toolkit = OpenEyeToolkitWrapper()
+        mol = create_ethanol()
+        mol.generate_unique_atom_names()
+        sio = StringIO()
+        mol.to_file(sio, "pdb", toolkit_registry=toolkit)
+        mol_from_pdb = sio.getvalue()
+        assert 'C1' in mol_from_pdb
+        assert 'C2' in mol_from_pdb
+        assert 'O1' in mol_from_pdb
+
     def test_write_pdb_preserving_atom_order(self):
         """
-        Make sure OpenEye does not rearrange hydrogens when writing PDBs
+        Make sure OpenEyeToolkitWrapper does not rearrange hydrogens when writing PDBs
         (reference: https://github.com/openforcefield/openff-toolkit/issues/475).
         """
         from io import StringIO
@@ -2594,6 +2611,22 @@ class TestRDKitToolkitWrapper:
         pdb = sio.getvalue()
         for i in range(1, 8):
             assert f"MODEL        {i}" in pdb
+
+    def test_write_pdb_preserving_atom_names(self):
+        """
+        Make sure RDKitToolkitWrapper preserves unique atom names when writing to PDB.
+        """
+        from io import StringIO
+
+        toolkit = RDKitToolkitWrapper()
+        mol = create_ethanol()
+        mol.generate_unique_atom_names()
+        sio = StringIO()
+        mol.to_file(sio, "pdb", toolkit_registry=toolkit)
+        mol_from_pdb = sio.getvalue()
+        assert 'C1' in mol_from_pdb
+        assert 'C2' in mol_from_pdb
+        assert 'O1' in mol_from_pdb
 
     # Unskip this when we implement PDB-reading support for RDKitToolkitWrapper
     @pytest.mark.skip

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -419,6 +419,17 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         # Issue #475 (https://github.com/openforcefield/openff-toolkit/issues/475)
         # dfhahn's workaround: Using OEWritePDBFile does not alter the atom arrangement
         if file_format.lower() == "pdb":
+
+            # OEPerceiveResidues overwrites the atom names that we just wrote, so save them and put them back
+            # https://github.com/openforcefield/openff-toolkit/pull/848#issuecomment-825306336
+
+            atom_names = [oeatom.GetName() for oeatom in oemol.GetAtoms()]
+
+            oechem.OEPerceiveResidues(oemol)
+
+            for oeatom, atom_name in zip(oemol.GetAtoms(), atom_names):
+                oeatom.SetName(atom_name)
+
             if oemol.NumConfs() > 1:
                 for conf in oemol.GetConfs():
                     oechem.OEWritePDBFile(ofs, conf, oechem.OEOFlavor_PDB_BONDS)


### PR DESCRIPTION
Follow-on from #848 by @j-wags 

- [ ] Ensure atom ordering is not changed in unexpected ways (https://github.com/openforcefield/openff-toolkit/pull/848#issuecomment-1144955309)
- [x] Fix #845
- [x] Fix #1307 
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
