### PR TITLE
Fix more calls to deprecated methods

### DIFF
--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -2073,8 +2073,8 @@ class TestForceFieldChargeAssignment:
         for particle_index, expected_charge in expected_charges:
             q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
             assert q == expected_charge
-        for particle_index in range(topology.n_particles):
-            q, sigma, epsilon = nonbondedForce.getParticleParameters(particle_index)
+        for atom_index in range(topology.n_atoms):
+            q, sigma, epsilon = nonbondedForce.getParticleParameters(atom_index)
             assert q != (0.0 * unit.elementary_charge)
 
     @pytest.mark.parametrize(

--- a/openff/toolkit/tests/test_mm_molecule.py
+++ b/openff/toolkit/tests/test_mm_molecule.py
@@ -43,7 +43,6 @@ class TestMMMolecule:
         water.add_bond(0, 1)
         water.add_bond(0, 2)
         assert water.n_atoms == 3
-        assert water.n_particles == 3
         assert water.n_bonds == 2
         assert water.n_conformers == 0
 
@@ -53,11 +52,6 @@ class TestMMMolecule:
 
         assert water.get_bond_between(0, 1) is water.bond(0)
         assert water.get_bond_between(0, 2) is water.bond(1)
-
-    def test_atom_particle_iterators(self, water):
-
-        for atom, particle in zip(water.atoms, water.particles):
-            assert atom is particle
 
     def test_hill_formula(
         self,

--- a/openff/toolkit/tests/test_parameters.py
+++ b/openff/toolkit/tests/test_parameters.py
@@ -1486,7 +1486,7 @@ class TestProperTorsionType:
         the indices are not consecutive and a SMIRNOFFSpecError is raised
         """
         with pytest.raises(
-            SMIRNOFFSpecError, match="Unexpected kwarg \(phase3: 31 deg\)*."
+            SMIRNOFFSpecError, match=r"Unexpected kwarg \(phase3: 31 deg\)*."
         ):
             ProperTorsionHandler.ProperTorsionType(
                 smirks="[*:1]-[*:2]-[*:3]-[*:4]",
@@ -1621,7 +1621,7 @@ class TestProperTorsionType:
         AND we are doing bond order interpolation
         """
         with pytest.raises(
-            SMIRNOFFSpecError, match="Unexpected kwarg \(k3_bondorder1*."
+            SMIRNOFFSpecError, match=r"Unexpected kwarg \(k3_bondorder1*."
         ):
             ProperTorsionHandler.ProperTorsionType(
                 smirks="[*:1]-[*:2]-[*:3]-[*:4]",

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -1734,7 +1734,7 @@ class TestOpenEyeToolkitWrapper:
         expected_error = (
             "Bond order model 'not a real bond order model' is not supported by "
             "OpenEyeToolkitWrapper. Supported models are "
-            "\['am1-wiberg', 'am1-wiberg-elf10', 'pm3-wiberg', 'pm3-wiberg-elf10'\]"
+            r"\['am1-wiberg', 'am1-wiberg-elf10', 'pm3-wiberg', 'pm3-wiberg-elf10'\]"
         )
 
         with pytest.raises(ValueError, match=expected_error):

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -107,7 +107,6 @@ class TestTopology:
         assert topology.n_molecules == 0
         assert topology.n_atoms == 0
         assert topology.n_bonds == 0
-        assert topology.n_particles == 0
         assert topology.box_vectors is None
         assert not topology.is_periodic
         assert len(topology.constrained_atom_pairs.items()) == 0
@@ -222,7 +221,6 @@ class TestTopology:
         assert topology.n_molecules == 1
         assert topology.n_atoms == 8
         assert topology.n_bonds == 7
-        assert topology.n_particles == 8
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
 
@@ -230,7 +228,6 @@ class TestTopology:
         assert topology.n_molecules == 2
         assert topology.n_atoms == 16
         assert topology.n_bonds == 14
-        assert topology.n_particles == 16
         assert topology.box_vectors is None
         assert len(topology.constrained_atom_pairs.items()) == 0
 
@@ -1174,7 +1171,7 @@ class TestTopologySerialization:
     @pytest.fixture
     def oleic_acid(self):
         """Simple floppy molecule that can be assured to have multiple conformers"""
-        return Molecule.from_smiles("CCCCCCCC\C=C/CCCCCCCC(O)=O")
+        return Molecule.from_smiles(r"CCCCCCCC\C=C/CCCCCCCC(O)=O")
 
     @pytest.mark.parametrize(("with_conformers"), [True, False])
     @pytest.mark.parametrize(("n_molecules"), [1, 2])

--- a/openff/toolkit/topology/_mm_molecule.py
+++ b/openff/toolkit/topology/_mm_molecule.py
@@ -65,10 +65,6 @@ class _SimpleMolecule:
         return len(self.atoms)
 
     @property
-    def n_particles(self) -> int:
-        return len(self.atoms)
-
-    @property
     def n_bonds(self) -> int:
         return len(self.bonds)
 
@@ -97,10 +93,6 @@ class _SimpleMolecule:
 
     def particle(self, index) -> int:
         return self.atom(index)
-
-    @property
-    def particles(self):
-        return self.atoms
 
     def particle_index(self, particle) -> int:
         return self.atom_index(particle)

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -1347,7 +1347,7 @@ class ForceField:
         bond_particle_indices = []
 
         bond_particle_indices = [
-            (topology.particle_index(bond.atom1), topology.particle_index(bond.atom2))
+            (topology.atom_index(bond.atom1), topology.atom_index(bond.atom2))
             for bond in topology.bonds
         ]
 

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -590,7 +590,7 @@ class MappedParameterAttribute(ParameterAttribute):
 
 
 class IndexedMappedParameterAttribute(ParameterAttribute):
-    r"""The attribute of a parameter with an unspecified number of terms, where
+    """The attribute of a parameter with an unspecified number of terms, where
     each term is a mapping.
 
     Some parameters can be associated to multiple terms,
@@ -1606,7 +1606,7 @@ class ParameterList(list):
 
 # TODO: Rename to better reflect role as parameter base class?
 class ParameterType(_ParameterAttributeHandler):
-    r"""
+    """
     Base class for SMIRNOFF parameter types.
 
     This base class provides utilities to create new parameter types. See

--- a/openff/toolkit/utils/builtin_wrapper.py
+++ b/openff/toolkit/utils/builtin_wrapper.py
@@ -3,7 +3,6 @@ Built-in ToolkitWrapper for very basic functionality. Intended for testing and n
 """
 __all__ = ("BuiltInToolkitWrapper",)
 
-import numpy as np
 from openff.units import unit
 
 from openff.toolkit.utils import base_wrapper
@@ -123,14 +122,12 @@ class BuiltInToolkitWrapper(base_wrapper.ToolkitWrapper):
                 strict_n_conformers=strict_n_conformers,
             )
 
-        partial_charges = unit.Quantity(
-            np.zeros((molecule.n_particles)), unit.elementary_charge
-        )
         if partial_charge_method == "zeroes":
-            pass
+            partial_charges = unit.Quantity(
+                molecule.n_atoms * [0], unit.elementary_charge
+            )
         elif partial_charge_method == "formal_charge":
-            for part_idx, particle in enumerate(molecule.particles):
-                partial_charges[part_idx] = particle.formal_charge
+            partial_charges = [atom.formal_charge for atom in molecule.atoms]
 
         molecule.partial_charges = partial_charges
 

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1237,7 +1237,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         return oemol, off_to_oe_idx
 
     def to_openeye(self, molecule, aromaticity_model=DEFAULT_AROMATICITY_MODEL):
-        r"""
+        """
         Create an OpenEye molecule using the specified aromaticity model
 
         ``OEAtom`` s have a different set of allowed value for partial
@@ -1840,7 +1840,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         clear_existing=True,
         make_carboxylic_acids_cis=False,
     ):
-        r"""
+        """
         Generate molecule conformers using OpenEye Omega.
 
         .. warning :: This API is experimental and subject to change.

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -910,7 +910,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         _cls=None,
         make_carboxylic_acids_cis=False,
     ):
-        r"""
+        """
         Generate molecule conformers using RDKit.
 
         .. warning :: This API is experimental and subject to change.


### PR DESCRIPTION
This is a bit of a follow-on to #1303, some common toolkit calls result in invalid deprecation warnings.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
