### PR TITLE
Use `pytest.approx` to safeguard against WBO flakiness in test

### DIFF
--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -3910,9 +3910,9 @@ class TestForceFieldParameterAssignment:
         ][0]
 
         for idx in range(default_bond_force.getNumBonds()):
-            assert default_bond_force.getBondParameters(
-                idx
-            ) == mod_bond_force.getBondParameters(idx)
+            assert default_bond_force.getBondParameters(idx) == pytest.approx(
+                mod_bond_force.getBondParameters(idx)
+            )
 
         for bond1, bond2 in zip(omm_sys_top.bonds, mod_omm_sys_top.bonds):
             # 'approx()' because https://github.com/openforcefield/openff-toolkit/issues/994

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -3909,9 +3909,17 @@ class TestForceFieldParameterAssignment:
             if isinstance(f, openmm.HarmonicBondForce)
         ][0]
 
+        kj_mol_nm2 = openmm_unit.kilojoule_per_mole / openmm_unit.nanometer**2
+
         for idx in range(default_bond_force.getNumBonds()):
-            assert default_bond_force.getBondParameters(idx) == pytest.approx(
-                mod_bond_force.getBondParameters(idx)
+            # atom1_index, atom2_index, length (nm), k (kj/mol/nm2)
+            default = default_bond_force.getBondParameters(idx)
+            modified = mod_bond_force.getBondParameters(idx)
+            assert default[2].value_in_unit(openmm_unit.nanometer) == pytest.approx(
+                modified[2].value_in_unit(openmm_unit.nanometer)
+            )
+            assert default[3].value_in_unit(kj_mol_nm2) == pytest.approx(
+                modified[3].value_in_unit(kj_mol_nm2)
             )
 
         for bond1, bond2 in zip(omm_sys_top.bonds, mod_omm_sys_top.bonds):


### PR DESCRIPTION
This PR improves the reliability of a single test and does not change any source code, so I will merge without review.

A common source of annoyance (failing on maybe ~1% of runs, but ~30% of status checks) for us is a particular flaky test that relies on precise, reproducible WBO calculations. One such from a log this morning:

```
=================================== FAILURES ===================================
_________ TestForceFieldParameterAssignment.test_overwrite_bond_orders _________
[gw1] linux -- Python 3.10.5 /usr/share/miniconda3/envs/test/bin/python
openff/toolkit/tests/test_forcefield.py:3913: in test_overwrite_bond_orders
    assert default_bond_force.getBondParameters(
E   assert [1, 2, Quanti...ter**2*mole))] == [1, 2, Quanti...ter**2*mole))]
E     At index 2 diff: Quantity(value=0.13999069479999998, unit=nanometer) != Quantity(value=0.13999069569999997, unit=nanometer)
E     Full diff:
E       [
E        1,
E        2,
E     -  Quantity(value=0.13999069569999997, unit=nanometer),
E     ?                           ^^      ^
E     +  Quantity(value=0.13999069479999998, unit=nanometer),
E     ?                           ^^      ^
E     -  Quantity(value=42266.96442[206](https://github.com/openforcefield/openff-toolkit/runs/7026996481?check_suite_focus=true#step:15:207)401, unit=kilojoule/(nanometer**2*mole)),
E     ?                          ^^^^ -
E     +  Quantity(value=42266.96525049601, unit=kilojoule/(nanometer**2*mole)),
E     ?                         ++++ ^
E       ]
```

The failure is in the first of the two blocks [here](https://github.com/openforcefield/openff-toolkit/blob/349d3fa46d62202a72cd72f458f76481e778436d/openff/toolkit/tests/test_forcefield.py#L3912-L3921). Notice that the first is a hard `assert x == y` and the second uses `pytest.approx`. This PR changes the first one to use it as well. Its [default (relative) tolerance](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-approx) is 1e-6, which I'd argue is plenty for this test case. The failure above is at the ninth (!) significant digit, a level of precision for which I do not trust these tools anyway.

There are probably a few dozen other places that could use `pytest.approx`; I'm only changing it at one point that regularly causes false negatives in our CI.