### PR TITLE
Warn when using AM1-BCC or similar methods on large molecules

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -2444,6 +2444,26 @@ class FrozenMolecule(Serializable):
         openff.toolkit.utils.toolkits.AmberToolsToolkitWrapper.assign_partial_charges
         openff.toolkit.utils.toolkits.BuiltInToolkitWrapper.assign_partial_charges
         """
+
+        # Raise a warning when users try to apply these charge methods to "large" molecules
+        WARN_LARGE_MOLECULES: Set[str] = {
+            "am1bcc",
+            "am1bccelf10",
+            "am1-mulliken",
+            "am1bccnosymspt",
+            "am1elf10",
+        }
+
+        if partial_charge_method in WARN_LARGE_MOLECULES:
+            if self.n_atoms > 150:
+                warnings.warn(
+                    f"Warning! Partial charge method '{partial_charge_method}' is not designed "
+                    "for use on large (i.e. > 150 atoms) molecule and may crash or take hours to "
+                    f"run on this molecule (found {self.n_atoms} atoms). For more, see "
+                    "https://docs.openforcefield.org/projects/toolkit/en/topology-biopolymer-refactor/faq.html"
+                    "#parameterizing-my-system-which-contains-a-large-molecule-is-taking-forever-whats-wrong",
+                )
+
         if isinstance(toolkit_registry, ToolkitRegistry):
             # We may need to try several toolkitwrappers to find one
             # that supports the desired partial charge method, so we

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -2458,7 +2458,7 @@ class FrozenMolecule(Serializable):
             if self.n_atoms > 150:
                 warnings.warn(
                     f"Warning! Partial charge method '{partial_charge_method}' is not designed "
-                    "for use on large (i.e. > 150 atoms) molecule and may crash or take hours to "
+                    "for use on large (i.e. > 150 atoms) molecules and may crash or take hours to "
                     f"run on this molecule (found {self.n_atoms} atoms). For more, see "
                     "https://docs.openforcefield.org/projects/toolkit/en/topology-biopolymer-refactor/faq.html"
                     "#parameterizing-my-system-which-contains-a-large-molecule-is-taking-forever-whats-wrong",

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -2460,7 +2460,7 @@ class FrozenMolecule(Serializable):
                     f"Warning! Partial charge method '{partial_charge_method}' is not designed "
                     "for use on large (i.e. > 150 atoms) molecules and may crash or take hours to "
                     f"run on this molecule (found {self.n_atoms} atoms). For more, see "
-                    "https://docs.openforcefield.org/projects/toolkit/en/topology-biopolymer-refactor/faq.html"
+                    "https://docs.openforcefield.org/projects/toolkit/en/stable/faq.html"
                     "#parameterizing-my-system-which-contains-a-large-molecule-is-taking-forever-whats-wrong",
                 )
 


### PR DESCRIPTION
There is no linked issue for this, but it's a common pain point for which emitting a warning is better than beefing up the FAQ (#1272).



I decided to put this in `Molecule.assign_partial_charges` directly since that will delegate out to the underlying calls and it's how `Interchange` [currently calls them](https://github.com/openforcefield/openff-interchange/blob/d4aaec28f036a3361f90b7deb0610bfee7cfb306/openff/interchange/components/smirnoff.py#L1183-L1190). The other approach would be to add it to each `ToolkitWrapper.assign_partial_charges` but I think that's unnecessarily specific (a user calling a wrapper directly is more likely to know about this limitation, as distinct from the typical user that sees `ForceField.create_openmm_system` hang) and more likely to fall out of sync with increasing toolkit functionality.

I didn't write a test for this, since it would require a little bit of kludging  - this warning is only hit when entering a dubious state, and getting there without causing other issues like a hanging unit test is tricky. But I have an idea how to do it, if that is desired.


I tested locally like so:

```python3

In [1]: SMILES = 10 * "C(CCCC)CCC"

In [2]: from openff.toolkit import Molecule

In [3]: molecule = Molecule.from_smiles(SMILES, allow_undefined_stereo=True)
Warning (not error because allow_undefined_stereo=True): OEMol has unspecified stereochemistry. oemol.GetTitle():
Problematic atoms are:
<SNIP>

In [4]: molecule.assign_partial_charges(partial_charge_method='am1bccelf10')
/Users/mattthompson/software/openff-toolkit/openff/toolkit/topology/molecule.py:2459: UserWarning: Warning! Partial charge method 'am1bccelf10' is not designed for use on large (i.e. > 150 atoms) molecule and may crash or take hours to run on this molecule (found 242 atoms). For more, see https://docs.openforcefield.org/projects/toolkit/en/topology-biopolymer-refactor/faq.html#parameterizing-my-system-which-contains-a-large-molecule-is-taking-forever-whats-wrong
  warnings.warn(
Warning: : Failed due to unspecified stereochemistry
^C^C^C[1]    20109 terminated  ipython
```

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
