### PR TITLE
Document limitations of `Topology.to_openmm`

### DIFF
--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1428,6 +1428,8 @@ class Topology(Serializable):
         OpenFF Molecule that it came from. In other words, no chain or residue
         will span two OpenFF Molecules.
 
+        This method will **not** populate the OpenMM Topology with virtual sites.
+
         Parameters
         ----------
         ensure_unique_atom_names : bool, optional. Default=True

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1443,6 +1443,8 @@ class Topology(Serializable):
         openmm_topology : openmm.app.Topology
             An OpenMM Topology object
         """
+        # TODO: MT needs to write a virtual sites section of the Interchange user guide.
+        #       Once that exists, the last note in this docstring should link to that.
         from openmm import app
 
         from openff.toolkit.topology.molecule import Bond


### PR DESCRIPTION
At some point I need to write docs in Interchange that focus on details of virtual site implementations. Right now there's a soft gotcha in that `Topology.to_openmm` does not include virtual sites whereas `Interchange.to_openmm_topology` does.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/master/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/master/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/master/docs/releasehistory.rst)
