### PR TITLE
Run CI on main branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,15 +3,14 @@ name: CI
 on:
   push:
     branches:
-      - "master"
+      - "main"
       - "maintenance/.*"
   pull_request:
     branches:
-      - "master"
+      - "main"
       - "maintenance/.*"
-      - "topology-biopolymer-refactor"
   schedule:
-    # Nightly tests run on master by default:
+    # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.
     #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
     - cron: "0 0 * * *"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -3,15 +3,14 @@ name: Examples
 on:
   push:
     branches:
-      - "master"
+      - "main"
       - "maintenance/.+"
   pull_request:
     branches:
-      - "master"
+      - "main"
       - "maintenance/.+"
-      - "topology-biopolymer-refactor"
   schedule:
-    # Nightly tests run on master by default:
+    # Nightly tests run on main by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.
     #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
     - cron: "0 0 * * *"


### PR DESCRIPTION
Updates CI to run on `main` (and not `master` or `topology-biopolymer-refactor`)