### PR TITLE
Fix RDKit PDB writing

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -3348,6 +3348,16 @@ class TestMoleculeFromPDB:
             expected_mol, atom_stereochemistry_matching=False
         )
 
+        with NamedTemporaryFile(suffix="pdb") as iofile:
+            offmol.to_file(iofile.name, file_format="pdb")
+            offmol2 = Molecule.from_polymer_pdb(iofile.name)
+        assert offmol.is_isomorphic_with(offmol2)
+        assert np.allclose(
+            offmol2.conformers[0].m_as(unit.angstrom),
+            offmol2.conformers[0].m_as(unit.angstrom),
+            atol=0.01,
+        )
+
     def test_molecule_from_pdb_mainchain_ala_tripeptide(self):
         offmol = Molecule.from_polymer_pdb(
             get_data_file_path("proteins/MainChain_ALA_ALA.pdb")

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -2027,7 +2027,9 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
                 res = rdatom.GetPDBResidueInfo()
 
             atom_has_any_metadata = False
-
+            # RDKit is very naive about PDB atom names - Needs them to be exactly
+            # 4 characters or the columns won't comply with PDB specification
+            res.SetName(atom.name.center(4)[:4])
             if "residue_name" in atom.metadata:
                 atom_has_any_metadata = True
                 res.SetResidueName(atom.metadata["residue_name"])


### PR DESCRIPTION
- [x] Fixes an issue where atom names weren't previously being set in the rdatom's PDBAtomResidueInfo in `to_rdkit`, which made the columns misaligned in written PDBs.
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
