### PR TITLE
Allow `Molecule.from_file` to parse `pathlib.Path` objects.

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -58,6 +58,9 @@ print(value_roundtrip)
 
 ## Current Development
 
+- [PR #1348](https://github.com/openforcefield/openff-toolkit/pull/1348): Allows
+  `pathlib.Path` objects to be passed to
+  [`Molecule.from_file`](openff.toolkit.topology.molecule.Molecule.from_file).
 - [PR #1276](https://github.com/openforcefield/openff-toolkit/pull/1276): Removes the
   `use_interchange` argument to
   [`create_openmm_system`](openff.toolkit.typing.engines.smirnoff.ForceField.create_openmm_system).

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -14,8 +14,8 @@ TODO:
 """
 import copy
 import os
+import pathlib
 import pickle
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import numpy as np
@@ -881,7 +881,7 @@ class TestMolecule:
         ethanol = create_ethanol()
         ethanol.to_file("ethanol.sdf", file_format="sdf")
 
-        Molecule.from_file(Path("ethanol.sdf"))
+        Molecule.from_file(pathlib.Path("ethanol.sdf"))
 
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_create_from_serialized(self, molecule):

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -876,6 +876,14 @@ class TestMolecule:
         with pytest.raises(ValueError):
             Molecule(filename, allow_undefined_stereo=True)
 
+    def test_from_file_pathlib(self):
+        from pathlib import Path
+
+        ethanol = create_ethanol()
+        ethanol.to_file("ethanol.sdf", file_format="sdf")
+
+        Molecule.from_file(Path("ethanol.sdf"))
+
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_create_from_serialized(self, molecule):
         """Test standard constructor taking the output of Molecule.to_dict()."""

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -15,6 +15,7 @@ TODO:
 import copy
 import os
 import pickle
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import numpy as np
@@ -876,9 +877,7 @@ class TestMolecule:
         with pytest.raises(ValueError):
             Molecule(filename, allow_undefined_stereo=True)
 
-    def test_from_file_pathlib(self):
-        from pathlib import Path
-
+    def test_from_pathlib_path(self):
         ethanol = create_ethanol()
         ethanol.to_file("ethanol.sdf", file_format="sdf")
 

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -5,6 +5,7 @@ Tests for cheminformatics toolkit wrappers
 
 import logging
 import os
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Dict
 
@@ -830,6 +831,13 @@ class TestOpenEyeToolkitWrapper:
         # Compare atom names
         for oeatom, atom2 in zip(oemol.GetAtoms(), molecule2.atoms):
             assert oeatom.GetName() == atom2.name
+
+    def test_from_pathlib_path(self):
+        ethanol = create_ethanol()
+        ethanol.to_file("ethanol.sdf", file_format="sdf")
+
+        toolkit = OpenEyeToolkitWrapper()
+        toolkit.from_file(Path("ethanol.sdf"), file_format="sdf")
 
     def test_write_multiconformer_pdb(self):
         """
@@ -2375,6 +2383,13 @@ class TestRDKitToolkitWrapper:
 
         off_molecule = Molecule.from_rdkit(Chem.MolFromSmiles(smiles))
         assert off_molecule.properties["atom_map"] == expected_map
+
+    def test_from_pathlib_path(self):
+        ethanol = create_ethanol()
+        ethanol.to_file("ethanol.sdf", file_format="sdf")
+
+        toolkit = RDKitToolkitWrapper()
+        toolkit.from_file(Path("ethanol.sdf"), file_format="sdf")
 
     def test_file_extension_case(self):
         """

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -5,7 +5,7 @@ Tests for cheminformatics toolkit wrappers
 
 import logging
 import os
-from pathlib import Path
+import pathlib
 from tempfile import NamedTemporaryFile
 from typing import Dict
 
@@ -837,7 +837,7 @@ class TestOpenEyeToolkitWrapper:
         ethanol.to_file("ethanol.sdf", file_format="sdf")
 
         toolkit = OpenEyeToolkitWrapper()
-        toolkit.from_file(Path("ethanol.sdf"), file_format="sdf")
+        toolkit.from_file(pathlib.Path("ethanol.sdf"), file_format="sdf")
 
     def test_write_multiconformer_pdb(self):
         """
@@ -2389,7 +2389,7 @@ class TestRDKitToolkitWrapper:
         ethanol.to_file("ethanol.sdf", file_format="sdf")
 
         toolkit = RDKitToolkitWrapper()
-        toolkit.from_file(Path("ethanol.sdf"), file_format="sdf")
+        toolkit.from_file(pathlib.Path("ethanol.sdf"), file_format="sdf")
 
     def test_file_extension_case(self):
         """

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -26,6 +26,7 @@ Molecular chemical entity representation and routines to interface with cheminfo
 """
 import json
 import operator
+import pathlib
 import warnings
 from collections import OrderedDict, UserDict
 from copy import deepcopy
@@ -3630,6 +3631,8 @@ class FrozenMolecule(Serializable):
         """
 
         if file_format is None:
+            if isinstance(file_path, pathlib.Path):
+                file_path: str = file_path.as_posix()
             if not isinstance(file_path, str):
                 raise Exception(
                     "If providing a file-like object for reading molecules, the format must be specified"

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -407,6 +407,9 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         """
         from openeye import oechem
 
+        if isinstance(file_path, pathlib.Path):
+            file_path: str = file_path.as_posix()
+
         oeformat = get_oeformat(file_format)
         ifs = oechem.oemolistream(file_path)
         if not ifs.IsValid():

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -9,6 +9,7 @@ import functools
 import importlib
 import itertools
 import logging
+import pathlib
 import tempfile
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
@@ -484,6 +485,9 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         """
         from rdkit import Chem
+
+        if isinstance(file_path, pathlib.Path):
+            file_path: str = file_path.as_posix()
 
         file_format = normalize_file_format(file_format)
 


### PR DESCRIPTION
Resolves #1347 

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
