### PR TITLE
Fix atom serial numbers in OETKW PDB writing 

### DIFF
--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -884,6 +884,11 @@ class TestOpenEyeToolkitWrapper:
         water.to_file(sio, "pdb", toolkit_registry=toolkit)
         water_from_pdb = sio.getvalue()
         water_from_pdb_split = water_from_pdb.split("\n")
+        # Check serial number
+        assert water_from_pdb_split[0].split()[1].rstrip() == "1"
+        assert water_from_pdb_split[1].split()[1].rstrip() == "2"
+        assert water_from_pdb_split[2].split()[1].rstrip() == "3"
+        # Check atom name
         assert water_from_pdb_split[0].split()[2].rstrip() == "H"
         assert water_from_pdb_split[1].split()[2].rstrip() == "O"
         assert water_from_pdb_split[2].split()[2].rstrip() == "H"

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1444,6 +1444,14 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
                     off_atom.partial_charge.m_as(unit.elementary_charge)
                 )
             res = oechem.OEAtomGetResidue(oe_atom)
+            # If we add residue info without updating the serial number, all of the atom
+            # serial numbers in a written PDB will be 0. Note two things:
+            # 1) the "res" object is specific to this atom, so its serial number
+            #    applies only to this atom
+            # 2) we do NOT preserve
+            #    PDB serial numbers in our infrastructure, we merely set these to the
+            #    atom index in the molecule so that OpenEye-written PDBs are nonzero.
+            res.SetSerialNumber(oe_to_off_idx[oe_idx] + 1)
 
             if "residue_name" in off_atom.metadata:
                 res.SetName(off_atom.metadata["residue_name"])

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1450,7 +1450,8 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             #    applies only to this atom
             # 2) we do NOT preserve
             #    PDB serial numbers in our infrastructure, we merely set these to the
-            #    atom index in the molecule so that OpenEye-written PDBs are nonzero.
+            #    atom index in the molecule so that OpenEye-written PDBs have
+            #    nonzero atom serial numbers.
             res.SetSerialNumber(oe_to_off_idx[oe_idx] + 1)
 
             if "residue_name" in off_atom.metadata:


### PR DESCRIPTION
- [x] OpenEyeToolkitWrapper's PDB writing would set all atom serial numbers to 0. This PR sets them to the offmol's atom index number + 1 (so the first atom in the written PDB is serial number 1)
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase

What a PDB written using OETKW would look like before:

```
ATOM      0 H1   ACE     1      25.950  25.179  24.582  1.00 20.00 
ATOM      0 CH3  ACE     1      25.986  26.176  24.145  1.00 20.00 
ATOM      0 H2   ACE     1      25.332  26.843  24.703  1.00 20.00 
ATOM      0 H3   ACE     1      25.673  26.131  23.104  1.00 20.00 
ATOM      0 C    ACE     1      27.405  26.691  24.218  1.00 20.00 
ATOM      0 O    ACE     1      28.285  25.999  24.713  1.00 20.00 
ATOM      0 N    ALA     2      27.621  27.909  23.728  1.00 20.00 
ATOM      0 H    ALA     2      26.838  28.435  23.370  1.00 20.00 
ATOM      0 CA   ALA     2      28.916  28.589  23.730  1.00 20.00 
ATOM      0 HA   ALA     2      29.471  28.288  24.620  1.00 20.00 
ATOM      0 CB   ALA     2      29.710  28.153  22.489  1.00 20.00 
ATOM      0 HB1  ALA     2      29.172  28.440  21.584  1.00 20.00 
ATOM      0 HB2  ALA     2      30.691  28.627  22.488  1.00 20.00 
ATOM      0 HB3  ALA     2      29.844  27.070  22.499  1.00 20.00 
ATOM      0 C    ALA     2      28.737  30.119  23.778  1.00 20.00 
ATOM      0 O    ALA     2      27.675  30.634  23.429  1.00 20.00 
ATOM      0 N    NME     3      29.784  30.841  24.197  1.00 20.00 
ATOM      0 H    NME     3      30.622  30.348  24.461  1.00 20.00 
ATOM      0 C    NME     3      29.784  32.300  24.293  1.00 20.00 
ATOM      0 H1   NME     3      28.951  32.628  24.918  1.00 20.00 
ATOM      0 H2   NME     3      30.720  32.652  24.729  1.00 20.00 
ATOM      0 H3   NME     3      29.663  32.734  23.299  1.00 20.00 
TER       1      NME     3 
END
```

And what it looks like after this PR:

```
ATOM      1 H1   ACE     1      25.950  25.179  24.582  1.00 20.00 
ATOM      2 CH3  ACE     1      25.986  26.176  24.145  1.00 20.00 
ATOM      3 H2   ACE     1      25.332  26.843  24.703  1.00 20.00 
ATOM      4 H3   ACE     1      25.673  26.131  23.104  1.00 20.00 
ATOM      5 C    ACE     1      27.405  26.691  24.218  1.00 20.00 
ATOM      6 O    ACE     1      28.285  25.999  24.713  1.00 20.00 
ATOM      7 N    ALA     2      27.621  27.909  23.728  1.00 20.00 
ATOM      8 H    ALA     2      26.838  28.435  23.370  1.00 20.00 
ATOM      9 CA   ALA     2      28.916  28.589  23.730  1.00 20.00 
ATOM     10 HA   ALA     2      29.471  28.288  24.620  1.00 20.00 
ATOM     11 CB   ALA     2      29.710  28.153  22.489  1.00 20.00 
ATOM     12 HB1  ALA     2      29.172  28.440  21.584  1.00 20.00 
ATOM     13 HB2  ALA     2      30.691  28.627  22.488  1.00 20.00 
ATOM     14 HB3  ALA     2      29.844  27.070  22.499  1.00 20.00 
ATOM     15 C    ALA     2      28.737  30.119  23.778  1.00 20.00 
ATOM     16 O    ALA     2      27.675  30.634  23.429  1.00 20.00 
ATOM     17 N    NME     3      29.784  30.841  24.197  1.00 20.00 
ATOM     18 H    NME     3      30.622  30.348  24.461  1.00 20.00 
ATOM     19 C    NME     3      29.784  32.300  24.293  1.00 20.00 
ATOM     20 H1   NME     3      28.951  32.628  24.918  1.00 20.00 
ATOM     21 H2   NME     3      30.720  32.652  24.729  1.00 20.00 
ATOM     22 H3   NME     3      29.663  32.734  23.299  1.00 20.00 
TER      23      NME     3 
CONECT    1    2
CONECT    2    3    4    5
CONECT    5    6    7
CONECT    7    8    9
CONECT    9   10   11   15
CONECT   11   12   13   14
CONECT   15   16   17
CONECT   17   18   19
CONECT   19   20   21   22
END
```


It's a slight problem that the new output has CONECT records for atoms in standard residues, but this is less of a problem than the all-zero serial numbers, so I think this should be merged and the CONECT stuff can be fixed later. 