### PR TITLE
Faster topology atom index

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -724,6 +724,24 @@ class TestMolecule:
                 f"The required toolkit ({toolkit_class.toolkit_name}) is not available."
             )
 
+    def test_atom_index_cache(self):
+        """Test that the atom index cache is invalidated when a molecule is modified"""
+        # First make OH-
+        mol = Molecule()
+        mol.add_atom(8, -1, False, None)
+        mol.add_atom(1, 0, False, None)
+        mol.add_bond(0, 1, 1, False)
+        assert mol.atom(0).molecule_atom_index == 0
+        assert mol.atom(1).molecule_atom_index == 1
+
+        # Now convert it to H2O and ask for atom indices again
+        mol.add_atom(1, 0, False, None)
+        mol.add_bond(1, 2, 1, False)
+        mol.atom(0).formal_charge = 0
+        assert mol.atom(0).molecule_atom_index == 0
+        assert mol.atom(1).molecule_atom_index == 1
+        assert mol.atom(2).molecule_atom_index == 2
+
     mapped_types = [
         {"atom_map": None},
         {"atom_map": {0: 0}},

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -1156,10 +1156,17 @@ class TestAddTopology:
 
         assert topology1.constrained_atom_pairs[(0, 1)] == 1.01 * unit.angstrom
         assert len(topology2._cached_chemically_identical_molecules) == 1
+        # Do a basic test of topology.atom_index which forces topology2
+        # to build its atom index cache
+        assert topology2.atom_index(topology2.atom(2)) == 2
 
         topology3 = topology1 + topology2
 
         assert topology3._cached_chemically_identical_molecules is None
+        # Query the same atom as above, but in topology 3. If the cache isn't invalidated
+        # then this will still have the old atom index (2), but if it's correctly
+        # invalidated and rebuilt, it will have an index of 5.
+        assert topology3.atom_index(topology3.atom(5)) == 5
 
         # Constrained atom pairs are intentionally not removed
         assert topology3.constrained_atom_pairs[(0, 1)] == 1.01 * unit.angstrom

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -2584,8 +2584,8 @@ class FrozenMolecule(Serializable):
         # TODO: Clear fractional bond orders
         self._ordered_connection_table_hash = None
         for atom in self.atoms:
-            if "molecule_atom_index" in atom.__dict__:
-                del atom.__dict__["molecule_atom_index"]
+            if "_molecule_atom_index" in atom.__dict__:
+                del atom.__dict__["_molecule_atom_index"]
 
     def to_networkx(self):
         """Generate a NetworkX undirected graph from the molecule.

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -718,8 +718,11 @@ class Topology(Serializable):
         if "_topology_atom_index" not in atom.__dict__:
             topology_molecule_atom_start_index = 0
             for molecule in self.molecules:
-                for atom in molecule.atoms:
-                    atom._topology_atom_index = topology_molecule_atom_start_index + atom.molecule_atom_index
+                for at in molecule.atoms:
+                    at._topology_atom_index = (
+                        topology_molecule_atom_start_index + at.molecule_atom_index
+                    )
+                topology_molecule_atom_start_index += molecule.n_atoms
         if "_topology_atom_index" not in atom.__dict__:
             raise AtomNotInTopologyError("Atom not found in this Topology")
 

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -715,13 +715,15 @@ class Topology(Serializable):
         ------
         AtomNotInTopologyError : If the given atom is not in this topology
         """
-        topology_molecule_atom_start_index = 0
-        for molecule in self.molecules:
-            if molecule is atom.molecule:
-                return molecule.atom_index(atom) + topology_molecule_atom_start_index
-            else:
-                topology_molecule_atom_start_index += molecule.n_atoms
-        raise AtomNotInTopologyError("Atom not found in this Topology")
+        if "_topology_atom_index" not in atom.__dict__:
+            topology_molecule_atom_start_index = 0
+            for molecule in self.molecules:
+                for atom in molecule.atoms:
+                    atom._topology_atom_index = topology_molecule_atom_start_index + atom.molecule_atom_index
+        if "_topology_atom_index" not in atom.__dict__:
+            raise AtomNotInTopologyError("Atom not found in this Topology")
+
+        return atom._topology_atom_index
 
     def molecule_index(self, molecule):
         """


### PR DESCRIPTION
`Topology.atom_index` calls were a major contributor to openmm topology creation runtime. This PR caches topology atom indices in a parallel way to molecule atom indices.

- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase


Example:

```python
%load_ext snakeviz
from openff.toolkit import Topology, Molecule
water_top = Topology.from_molecules([Molecule.from_smiles('O')] * 5000)
```

```python
%%snakeviz 
water_top.to_openmm()
```

Before this change: 
<img width="960" alt="Screen Shot 2022-08-04 at 4 31 22 PM" src="https://user-images.githubusercontent.com/16329175/182972414-bc5b9f5d-7f14-448c-93ad-e5ce6eb63ba6.png">

After this change:
<img width="930" alt="Screen Shot 2022-08-04 at 4 33 47 PM" src="https://user-images.githubusercontent.com/16329175/182972513-13018de4-f541-4546-ad29-613965b61325.png">

