### PR TITLE
Re-introduce compatible openmmforcefields

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -72,10 +72,8 @@ jobs:
           mamba env update --file examples/environment.yaml --name test
 
           # If openmmforcefields is included in examples/environment.yaml,
-          # remove RDKit and AmberTools brought in by it. Currently it's not included,
-          # so don't remove it.
-          # if [[ ${{ matrix.rdkit }} == false ]]; then
-          if [[ true == false ]]; then
+          # remove RDKit and AmberTools brought in by it.
+          if [[ ${{ matrix.rdkit }} == false ]]; then
             conda remove --force rdkit ambertools
           fi
 
@@ -125,9 +123,6 @@ jobs:
 
           # Working on in #1325
           NB_ARGS+=" --ignore=examples/virtual_sites/vsite_showcase.ipynb"
-
-          # openmmforcefields incompatible with new toolkit
-          NB_ARGS+=" --ignore=examples/external/swap_amber_parameters/swap_existing_ligand_parameters_with_openmmforcefields.ipynb"
 
           # JM will do some smithing on this before 0.11.0 release
           NB_ARGS+=" --ignore=examples/toolkit_showcase/toolkit_showcase.ipynb"

--- a/devtools/conda-envs/conda.yaml
+++ b/devtools/conda-envs/conda.yaml
@@ -8,7 +8,7 @@ dependencies:
     # Base depends
   - openff-toolkit-examples
 
-  - openmmforcefields
+  - openmmforcefields >=0.11.1
   - qcportal >=0.15
   - pytest
   - pytest-rerunfailures

--- a/devtools/conda-envs/conda_oe.yaml
+++ b/devtools/conda-envs/conda_oe.yaml
@@ -9,7 +9,7 @@ dependencies:
     # Base depends
   - openff-toolkit-examples
 
-  - openmmforcefields
+  - openmmforcefields >=0.11.1
   - openeye-toolkits
   - qcportal >=0.15
   - pytest

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -23,8 +23,7 @@ dependencies:
   - parmed
   - openeye-toolkits
   - packaging
-    # Removed until a compatible release is made
-# - openmmforcefields
+  - openmmforcefields >=0.11.1
   - openmm =>7.6
   - openff-forcefields
   - openff-units >=0.1.6

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -22,8 +22,7 @@ dependencies:
   - ambertools
   - rdkit
   - packaging
-    # Removed until a compatible release is made
-# - openmmforcefields
+  - openmmforcefields >=0.11.1
   - openmm >=7.6
   - openff-forcefields
   - openff-units >=0.1.6

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,8 +10,7 @@ dependencies:
   - pip
   - packaging
   - openmm >=7.6
-    # Removed until a compatible release is made
-# - openmmforcefields
+  - openmmforcefields >=0.11.1
   - openff-forcefields
   - openff-units >=0.1.6
   - openff-utilities >=0.1.5


### PR DESCRIPTION
Release 0.11.1 of `openmmforcefields` introduces a **backwards-compatible** fix for the new toolkit APIs.

This PR attempts to re-introduce the examples that depend on it.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
