### PR TITLE
Remove use of deprecated `distutils` module

### DIFF
--- a/openff/toolkit/utils/ambertools_wrapper.py
+++ b/openff/toolkit/utils/ambertools_wrapper.py
@@ -7,7 +7,7 @@ __all__ = ("AmberToolsToolkitWrapper",)
 import subprocess
 import tempfile
 from collections import defaultdict
-from distutils.spawn import find_executable
+from shutil import which
 
 import numpy as np
 from openff.units import unit
@@ -68,8 +68,7 @@ class AmberToolsToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         """
         # TODO: Check all tools needed
-        # TODO: How should we implement find_executable?
-        ANTECHAMBER_PATH = find_executable("antechamber")
+        ANTECHAMBER_PATH = which("antechamber")
         if ANTECHAMBER_PATH is None:
             return False
         # AmberToolsToolkitWrapper needs RDKit to do basically anything, since its interface requires SDF I/O
@@ -193,9 +192,7 @@ class AmberToolsToolkitWrapper(base_wrapper.ToolkitWrapper):
                 strict_n_conformers=strict_n_conformers,
             )
 
-        # Find the path to antechamber
-        # TODO: How should we implement find_executable?
-        ANTECHAMBER_PATH = find_executable("antechamber")
+        ANTECHAMBER_PATH = which("antechamber")
         if ANTECHAMBER_PATH is None:
             raise AntechamberNotFoundError(
                 "Antechamber not found, cannot run charge_mol()"
@@ -459,9 +456,7 @@ class AmberToolsToolkitWrapper(base_wrapper.ToolkitWrapper):
         """
         from openff.toolkit.topology import Molecule
 
-        # Find the path to antechamber
-        # TODO: How should we implement find_executable?
-        ANTECHAMBER_PATH = find_executable("antechamber")
+        ANTECHAMBER_PATH = which("antechamber")
         if ANTECHAMBER_PATH is None:
             raise AntechamberNotFoundError(
                 "Antechamber not found, cannot run "


### PR DESCRIPTION
### Short description

The `distutils` module is [deprecated](https://peps.python.org/pep-0632/) in Python 3.10 and slated to be removed in 3.12. This PR removes its use with a drop-in replacement.


### More background

We use it only to find the path to the `antechamber` executable, something that the PEP conveniently recommends a stdlib alternative.

`shutil.which` is also much faster to import than `distutils.spawn.find_executable`. I was working on something else and found importing `distutils` took ~180 ms just to find the Antechamber path. `AmberToolsToolkitWrapper` is imported in virtually all use cases. Stealing @Yoshanuikabundi's slick `hyperfine` one-liners:

```shell
(openff-interchange-env) [openff-toolkit] git checkout upstream/main                        9:47:06  ☁  0f1611fe ☂
HEAD is now at 0f1611fe Faster topology atom index (#1361)
(openff-interchange-env) [openff-toolkit] hyperfine --warmup 1 'python -c "from openff.toolkit import Molecule"'
Benchmark 1: python -c "from openff.toolkit import Molecule"
  Time (mean ± σ):     920.8 ms ±  40.8 ms    [User: 736.9 ms, System: 321.3 ms]
  Range (min … max):   868.1 ms … 1003.0 ms    10 runs

(openff-interchange-env) [openff-toolkit] git checkout no-distutils                         9:47:20  ☁  0f1611fe ☂
Previous HEAD position was 0f1611fe Faster topology atom index (#1361)
Switched to branch 'no-distutils'
(openff-interchange-env) [openff-toolkit] hyperfine --warmup 1 'python -c "from openff.toolkit import Molecule"'
Benchmark 1: python -c "from openff.toolkit import Molecule"
  Time (mean ± σ):     719.1 ms ±  20.1 ms    [User: 551.0 ms, System: 282.4 ms]
  Range (min … max):   682.7 ms … 744.2 ms    10 runs
```

shows a ~200 ms speedup in import times for free.