### PR TITLE
Docs and simplified kwarg handling for `create_openmm_system`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -118,6 +118,9 @@ Code for applying parameters to topologies has been removed from the Toolkit. Th
 
 The [`ForceField.create_interchange()`] method has been added, and the [`ForceField.create_openmm_system()`] method now uses Interchange under the hood.
 
+As part of this change, the `UnsupportedKeywordArgumentsError` has been removed;
+passing unknown arguments to `create_openmm_system` now raises a `TypeError`, as is normal in Python.
+
 The following classes and methods have been **removed** from `openff.toolkit.typing.engines.smirnoff.parameters`:
 - `NonintegralMoleculeChargeException`
 - `NonbondedMethod`

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -126,7 +126,17 @@ The following classes and methods have been **removed** from `openff.toolkit.typ
 - `ParameterHandler.check_partial_bond_orders_from_molecules_duplicates()`
 - `ParameterHandler.assign_partial_bond_orders_from_molecules()`
 
-In addition, the `ParameterHandler.create_force()` method has been deprecated and its functionality has been removed. It will be removed in a future release.
+In addition, the `ParameterHandler.create_force()` method has been deprecated and its functionality has been removed. It will be removed in a future release. The `return_topology` argument of `create_openmm_system` has also been deprecated, and will be removed in 0.12.0. If you need access to the modified topology, create an `Interchange` and retrieve it there:
+
+```diff
+- omm_sys, off_top = force_field.create_openmm_system(
+-     topology,
+-     return_topology=True,
+- )
++ interchange = force_field.create_interchange(topology)
++ off_top = interchange.topology
++ omm_sys = interchange.to_openmm(combine_nonbonded_forces=True)
+```
 
 [`Interchange`]: openff.interchange.Interchange
 [`ForceField.create_interchange()`]: openff.toolkit.typing.engines.smirnoff.forcefield.ForceField.create_interchange

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -1531,7 +1531,7 @@ class TestForceField:
 
         with pytest.raises(
             TypeError,
-            match="Unsupported.* Found: {'invalid_kwarg': 'aaa",
+            match="got an unexpected keyword argument .*invalid_kwarg.*",
         ):
             # TODO: specify desired toolkit_registry behavior in Interchange
             forcefield.create_openmm_system(

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -1530,7 +1530,7 @@ class TestForceField:
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
 
         with pytest.raises(
-            ValueError,
+            TypeError,
             match="Unsupported.* Found: {'invalid_kwarg': 'aaa",
         ):
             # TODO: specify desired toolkit_registry behavior in Interchange

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -1084,9 +1084,32 @@ class ForceField:
 
         Parameters
         ----------
-        topology : openforcefield.topology.Topology
-            The ``Topology`` which is to be parameterized with this ``ForceField``.
+        topology
+            The ``Topology`` which is to be parameterized with this
+            ``ForceField``.
+        toolkit_registry
+            The toolkit registry to use for parametrization (eg, for calculating
+            partial charges and partial bond orders)
+        charge_from_molecules
+            Take partial charges from the input topology rather than calculating
+            them. This may be useful for avoiding recalculating charges, but
+            take care to ensure that your charges are appropriate for the force
+            field.
+        partial_bond_orders_from_molecules
+            Take partial bond orders from the input topology rather than
+            calculating them. This may be useful for avoiding recalculating
+            PBOs, but take to ensure that they are appropriate for the
+            force field.
+        allow_nonintegral_charges
+            Allow charges that do not sum to an integer.
+        return_topology
+            .. deprecated:: 0.11.0
+                The ``return_topology`` argument has been deprecated and will be
+                removed in v0.12.0. Call :meth:`ForceField.create_interchange`
+                and take the topology from `interchange.topology` instead.
 
+            Return the Topology with any modifications needed to parametrize it
+            in a tuple along with the OpenMM system.
         """
         return_topology = kwargs.pop("return_topology", False)
         toolkit_registry = kwargs.pop("toolkit_registry", None)
@@ -1148,9 +1171,20 @@ class ForceField:
         ----------
         topology : openff.toolkit.topology.Topology
             The topology to create this `Interchange` object from.
-        toolkit_registry :  ToolkitRegistry, optional
-            A `ToolkitRegistry` containing the toolkit wrappers to be used during parametriation,
-            i.e. for assigning partial charges and fractional bond orders.
+        toolkit_registry
+            The toolkit registry to use for parametrization (eg, for calculating
+            partial charges and partial bond orders)
+        charge_from_molecules
+            Take charges from the input topology rather than calculating them.
+            This may be useful for avoiding recalculating charges, but take care
+            to ensure that your charges are appropriate for the force field.
+        partial_bond_orders_from_molecules
+            Take partial bond orders from the input topology rather than
+            calculating them. This may be useful for avoiding recalculating
+            PBOs, but take to ensure that they are appropriate for the
+            force field.
+        allow_nonintegral_charges
+            Allow charges that do not sum to an integer.
 
         Returns
         -------

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -1078,7 +1078,12 @@ class ForceField:
     def create_openmm_system(
         self,
         topology: "Topology",
-        **kwargs,
+        *,
+        return_topology: bool = False,
+        toolkit_registry: Optional[Union["ToolkitRegistry", "ToolkitWrapper"]] = None,
+        charge_from_molecules: Optional[List["Molecule"]] = None,
+        partial_bond_orders_from_molecules: Optional[List["Molecule"]] = None,
+        allow_nonintegral_charges: bool = False,
     ) -> Union["openmm.System", Tuple["openmm.System", "Topology"]]:
         """Create an OpenMM System from this ForceField and a Topology.
 
@@ -1111,25 +1116,6 @@ class ForceField:
             Return the Topology with any modifications needed to parametrize it
             in a tuple along with the OpenMM system.
         """
-        return_topology = kwargs.pop("return_topology", False)
-        toolkit_registry = kwargs.pop("toolkit_registry", None)
-        charge_from_molecules = kwargs.pop("charge_from_molecules", None)
-        partial_bond_orders_from_molecules = kwargs.pop(
-            "partial_bond_orders_from_molecules", None
-        )
-        allow_nonintegral_charges = kwargs.pop("allow_nonintegral_charges", False)
-
-        if len(kwargs) > 0:
-            from openff.toolkit.utils.exceptions import UnsupportedKeywordArgumentsError
-
-            msg = (
-                "Unsupported keyword arguments found passed to `ForceField.create_openmm_system`. Supported "
-                "keyword arguments are `return_topology`, `toolkit_registry`, `charge_from_molecules`, "
-                f"`partial_bond_orders_from_molecules`, and `allow_nonintegral_charges`. Found: {kwargs}"
-            )
-
-            raise UnsupportedKeywordArgumentsError(msg)
-
         interchange = self.create_interchange(
             topology,
             toolkit_registry,

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -302,10 +302,6 @@ class UnsupportedFileTypeError(OpenFFToolkitException):
     """Error raised when attempting to parse an unsupported file type."""
 
 
-class UnsupportedKeywordArgumentsError(OpenFFToolkitException, ValueError):
-    """Error raised when an unexpected keyword argument is passed to `ForceField.create_openmm_system`."""
-
-
 class MultipleMoleculesInPDBError(OpenFFToolkitException):
     """Error raised when a multiple molecules are found when one was expected"""
 


### PR DESCRIPTION
The `create_openmm_system` method does not document its keyword arguments, including that one is deprecated. This PR adds this documentation and updates the `create_interchange` docstring to match. I've also added the deprecation notice to the migration guide.

I also can't think of any reason to keep the bespoke keyword handling logic, except to avoid breaking users who rely on the exception for some reason? So I've refactored that. I've maintained the prevention of passing keyword arguments by position and documented the change of exception in the migration guide. I've kept this change all together and separate from the others in commit 962de55; in the likely case that we don't want it for some reason I haven't thought of, that single commit can be reverted and this PR will just have the documentation changes.

I think I'm done for the night - if release happens tomorrow, feel free to merge this without me!

- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
