### PR TITLE
Update units pin

### DIFF
--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -27,7 +27,7 @@ dependencies:
 # - openmmforcefields
   - openmm =>7.6
   - openff-forcefields
-  - openff-units =>0.1.7
+  - openff-units >=0.1.7
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.2.0rc4
   - smirnoff99Frosst

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -27,7 +27,7 @@ dependencies:
 # - openmmforcefields
   - openmm =>7.6
   - openff-forcefields
-  - openff-units >=0.1.6
+  - openff-units ==0.1.6
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.2.0rc4
   - smirnoff99Frosst

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -27,7 +27,7 @@ dependencies:
 # - openmmforcefields
   - openmm =>7.6
   - openff-forcefields
-  - openff-units ==0.1.6
+  - openff-units =>0.1.7
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.2.0rc4
   - smirnoff99Frosst

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -26,7 +26,7 @@ dependencies:
 # - openmmforcefields
   - openmm >=7.6
   - openff-forcefields
-  - openff-units =>0.1.7
+  - openff-units >=0.1.7
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.2.0rc4
   - smirnoff99Frosst

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -26,7 +26,7 @@ dependencies:
 # - openmmforcefields
   - openmm >=7.6
   - openff-forcefields
-  - openff-units >=0.1.6
+  - openff-units ==0.1.6
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.2.0rc4
   - smirnoff99Frosst

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -26,7 +26,7 @@ dependencies:
 # - openmmforcefields
   - openmm >=7.6
   - openff-forcefields
-  - openff-units ==0.1.6
+  - openff-units =>0.1.7
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.2.0rc4
   - smirnoff99Frosst

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -13,7 +13,7 @@ dependencies:
     # Removed until a compatible release is made
 # - openmmforcefields
   - openff-forcefields
-  - openff-units ==0.1.6
+  - openff-units >=0.1.7
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.2.0rc4
   - smirnoff99Frosst

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -13,7 +13,7 @@ dependencies:
     # Removed until a compatible release is made
 # - openmmforcefields
   - openff-forcefields
-  - openff-units >=0.1.6
+  - openff-units ==0.1.6
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.2.0rc4
   - smirnoff99Frosst

--- a/examples/environment.yaml
+++ b/examples/environment.yaml
@@ -36,7 +36,7 @@ dependencies:
   - cachetools
   # Some others that will be pulled down by an Interchange conda package
   - openff-utilities
-  - openff-units >=0.1.6
+  - openff-units >=0.1.7
   - panedr
   - pip:
     # Replace with conda package when 0.2.0 is released


### PR DESCRIPTION
I was working in an old environment and one of my imports failed:


```shell
(openff-dev) [openff-toolkit] conda list | grep units                                                                  9:25:08  ☁  units-constraint ☂
openff-units              0.1.6              pyh6c4a22f_0    conda-forge
(openff-dev) [openff-toolkit] python -c "from openff.toolkit import *"                                                 9:25:13  ☁  units-constraint ☂
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/__init__.py", line 74, in __getattr__
    mod = importlib.import_module(obj_mod)
  File "/Users/mattthompson/miniconda3/envs/openff-dev/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/topology/__init__.py", line 10, in <module>
    from openff.toolkit.topology.topology import (
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/topology/topology.py", line 36, in <module>
    from openff.units import Quantity, unit
ImportError: cannot import name 'Quantity' from 'openff.units' (/Users/mattthompson/miniconda3/envs/openff-dev/lib/python3.9/site-packages/openff/units/__init__.py)
```

Similar failures are in the [logs](https://github.com/openforcefield/openff-toolkit/actions/runs/2927295608) of commit f728fc9. This shortcut was added in 0.1.7; in older versions you'd have to `from openff.units import unit; unit.Quantity(...) ...`. Currently some code in the toolkit uses `from openff.units import Quantity; Quantity(...) ...`, which is fine, but it requires updating this constraint.

There is currently no reason to assume the older version would be pulled down, so I wouldn't have noticed this if not for my local environment falling out of date (though still using an allowed solution).