### PR TITLE
Recommend `interchange.to_openmm_topology()` in migration guide

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -129,7 +129,22 @@ The following classes and methods have been **removed** from `openff.toolkit.typ
 - `ParameterHandler.check_partial_bond_orders_from_molecules_duplicates()`
 - `ParameterHandler.assign_partial_bond_orders_from_molecules()`
 
-In addition, the `ParameterHandler.create_force()` method has been deprecated and its functionality has been removed. It will be removed in a future release. The `return_topology` argument of `create_openmm_system` has also been deprecated, and will be removed in 0.12.0. If you need access to the modified topology, create an `Interchange` and retrieve it there:
+In addition, the `ParameterHandler.create_force()` method has been deprecated and its functionality has been removed. It will be removed in a future release. 
+
+The `return_topology` argument of `create_openmm_system` has also been deprecated, and will be removed in 0.12.0. To create an OpenMM topology, use `Interchange`:
+
+```diff
+- omm_sys, off_top = force_field.create_openmm_system(
+-     topology,
+-     return_topology=True,
+- )
+- omm_top = off_top.to_openmm()
++ interchange = force_field.create_interchange(topology)
++ omm_sys = interchange.to_openmm(combine_nonbonded_forces=True)
++ omm_top = interchange.to_openmm_topology()
+```
+
+If you need access to the modified OpenFF topology for some other reason, create an `Interchange` and retrieve it there:
 
 ```diff
 - omm_sys, off_top = force_field.create_openmm_system(


### PR DESCRIPTION
This is an important API, and the previous migration suggestion might have led to a lot of missing virtual sites in the future from people doing `interchange.topology.to_openmm()` rather than `interchange.to_openmm_topology()`

- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
