### PR TITLE
Turn off toolkit showcase

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -136,6 +136,9 @@ jobs:
           # openmmforcefields incompatible with new toolkit
           NB_ARGS+=" --ignore=examples/external/swap_amber_parameters/swap_existing_ligand_parameters_with_openmmforcefields.ipynb"
 
+          # See https://github.com/openforcefield/openff-toolkit/issues/1392
+          NB_ARGS+=" --ignore=examples/toolkit_showcase"
+
           python -m pytest $NB_ARGS examples
 
       - name: Codecov


### PR DESCRIPTION
Until #1392 is resolved, this skips the showcase from running in CI so CI can serve its purpose.