### PR TITLE
Disallow non-integers passed to `Bond.bond_order`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -8,6 +8,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ## Current development
 
+## Behavior changes
+- [PR #1398](https://github.com/openforcefield/openff-toolkit/pull/1398): Updates the [`Bond.bond_order`] setter to only accept int values.
+
 ## 0.11.0 Major release adding support for proteins and refactoring the Topology class.
 
 ## Migration guide

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -11,6 +11,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ## Behavior changes
 - [PR #1398](https://github.com/openforcefield/openff-toolkit/pull/1398): Updates the [`Bond.bond_order`] setter to only accept int values.
 
+[`Bond.bond_order`]: Bond.bond_order
+
 ## 0.11.0 Major release adding support for proteins and refactoring the Topology class.
 
 ## Migration guide

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -38,7 +38,6 @@ from openff.toolkit.tests.utils import (
     requires_pkg,
     requires_rdkit,
 )
-from openff.toolkit.topology import NotBondedError
 from openff.toolkit.topology.molecule import (
     Atom,
     FrozenMolecule,
@@ -54,8 +53,10 @@ from openff.toolkit.utils import get_data_file_path
 from openff.toolkit.utils.exceptions import (
     ConformerGenerationError,
     IncompatibleUnitError,
+    InvalidBondOrderError,
     InvalidConformerError,
     MultipleMoleculesInPDBError,
+    NotBondedError,
     UnassignedChemistryInPDBError,
     UnsupportedFileTypeError,
 )
@@ -353,6 +354,14 @@ class TestAtom:
         atom.molecule = mol
         with pytest.raises(AssertionError, match="already has an associated molecule"):
             atom.molecule = mol
+
+
+class TestBond:
+    def test_float_bond_order(self):
+        molecule = create_ethanol()
+
+        with pytest.raises(InvalidBondOrderError):
+            molecule.bond(0).bond_order = 1.2
 
 
 class TestMolecule:

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -57,6 +57,7 @@ from openff.toolkit.utils.exceptions import (
     HierarchySchemeWithIteratorNameAlreadyRegisteredException,
     IncompatibleUnitError,
     InvalidAtomMetadataError,
+    InvalidBondOrderError,
     InvalidConformerError,
     MultipleMoleculesInPDBError,
     SmilesParsingError,
@@ -695,7 +696,13 @@ class Bond(Serializable):
 
     @bond_order.setter
     def bond_order(self, value):
-        self._bond_order = value
+        if isinstance(value, int):
+            self._bond_order = value
+        else:
+            raise InvalidBondOrderError(
+                "Non-integer bond order passed to `Bond.bond_order` setter.  Consider using "
+                "`Bond.fractional_bond_order` for fractional/partial bond orders."
+            )
 
     @property
     def fractional_bond_order(self):

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -700,8 +700,11 @@ class Bond(Serializable):
             self._bond_order = value
         else:
             raise InvalidBondOrderError(
-                "Non-integer bond order passed to `Bond.bond_order` setter.  Consider using "
-                "`Bond.fractional_bond_order` for fractional/partial bond orders."
+                "Only integer bond orders may be passed to `Bond.bond_order` setter. "
+                "For aromatic bonds, instead kekulize the input structure and use "
+                "the resulting integer bond orders. If performing partial bond "
+                "order-based parameter interpolation, consider using "
+                "`Bond.fractional_bond_order`."
             )
 
     @property

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -132,6 +132,12 @@ class NotBondedError(OpenFFToolkitException):
     """
 
 
+class InvalidBondOrderError(OpenFFToolkitException):
+    """
+    Exception for passing a non-int to `Molecule.bond_order`
+    """
+
+
 class InvalidBoxVectorsError(OpenFFToolkitException):
     """
     Exception for setting invalid box vectors


### PR DESCRIPTION
This does produce a couple of test failures. I haven't looked into them yet to see if they're valid or not. #1399 

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
