### PR TITLE
Improved support for hierarchy schemes from OpenMM and PDBs

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,6 +15,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ## Bug fixes
 - [PR #1400](https://github.com/openforcefield/openff-toolkit/pull/1400): Fixes a bug where `Molecule.from_pdb_and_smiles` could incorrectly order coordinates.
+- [PR #1404](https://github.com/openforcefield/openff-toolkit/pull/1404): Support default hierarchy schemes in outputs of `Molecule.from_pdb_and_smiles()` and `Topology.from_openmm()`
 
 ## 0.11.0 Major release adding support for proteins and refactoring the Topology class.
 

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -2139,9 +2139,14 @@ class TestMolecule:
             # Not sure that the following are necessary given are_isomorphic,
             # but keeping them from previous test implementations
 
-            # Check that the atom properties are identical
+            # Check that the atom properties are identical (except metadata)
             for pdb_atom, sdf_atom in zip(pdb_mol.atoms, sdf_mol.atoms):
-                assert pdb_atom.to_dict() == sdf_atom.to_dict()
+                pdb_atom_dict = pdb_atom.to_dict()
+                del pdb_atom_dict["metadata"]
+
+                sdf_atom_dict = sdf_atom.to_dict()
+                del sdf_atom_dict["metadata"]
+                assert sdf_atom_dict == pdb_atom_dict
 
             # Check that the bonds match, though possibly in a different order
             sdf_bonds = {

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -2059,7 +2059,7 @@ class TestMolecule:
         def test_conformers_match_pdb(self, pdb_path, smiles, sdf_path):
             """The produced conformers should match the coordinates in the PDB
 
-            This test uses OpenMM as an alternative PDB parser to check
+            This test uses MDTraj as an alternative PDB parser to check
             coordinates."""
             import mdtraj
 

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -2036,29 +2036,30 @@ class TestMolecule:
             with pytest.raises(InvalidConformerError):
                 Molecule.from_pdb_and_smiles(pdb_path, wrong_smiles)
 
+        @requires_pkg("mdtraj")
         def test_atom_order_matches_pdb(self, pdb_path, smiles, sdf_path):
             """The produced Molecule's atom order should match the PDB
 
             This test uses MDTraj as an alternative PDB parser to check atom
-            ordering. However, it can only check that the elements are correct,
-            not connectivity."""
+            ordering. However, it can only check that the elements and atom
+            names are correct, not connectivity."""
             import mdtraj
 
             pdb_path = get_data_file_path(pdb_path)
             mol = Molecule.from_pdb_and_smiles(pdb_path, smiles)
 
-            pdb_mdtraj = mdtraj.load_pdb(pdb_path)
+            pdb_mdtraj = mdtraj.load_pdb(pdb_path, standard_names=False)
 
             assert pdb_mdtraj.n_atoms == mol.n_atoms
-            for i in range(mol.n_atoms):
-                mdtraj_element = pdb_mdtraj.top.atom(i).element.number
-                off_element = mol.atom(i).atomic_number
-                assert mdtraj_element == off_element
+            for mdtraj_atom, off_atom in zip(pdb_mdtraj.topology.atoms, mol.atoms):
+                assert mdtraj_atom.element.number == off_atom.atomic_number
+                assert mdtraj_atom.name == off_atom.name
 
+        @requires_pkg("mdtraj")
         def test_conformers_match_pdb(self, pdb_path, smiles, sdf_path):
             """The produced conformers should match the coordinates in the PDB
 
-            This test uses MDTraj as an alternative PDB parser to check
+            This test uses OpenMM as an alternative PDB parser to check
             coordinates."""
             import mdtraj
 
@@ -2074,6 +2075,29 @@ class TestMolecule:
 
             assert np.all(np.abs(mdtraj_coordinates - pdb_coordinates) < 1e-3)
 
+        @requires_pkg("openmm")
+        def test_metadata_matches_pdb(self, pdb_path, smiles, sdf_path):
+            """The produced conformers should match the coordinates in the PDB
+
+            This test uses OpenMM as an alternative PDB parser to check
+            metadata."""
+            from openmm.app import PDBFile
+
+            pdb_path = get_data_file_path(pdb_path)
+            mol = Molecule.from_pdb_and_smiles(pdb_path, smiles)
+
+            pdb_omm = PDBFile(pdb_path)
+
+            for omm_atom, off_atom in zip(pdb_omm.getTopology().atoms(), mol.atoms):
+                omm_metadata = {
+                    "residue_name": omm_atom.residue.name,
+                    "residue_number": int(omm_atom.residue.id),
+                    "insertion_code": omm_atom.residue.insertionCode,
+                    "chain_id": omm_atom.residue.chain.id,
+                }
+                assert omm_metadata == off_atom.metadata
+
+        @requires_rdkit
         def test_connectivity_matches_pdb(self, pdb_path, smiles, sdf_path):
             """
             The produced Molecule's connectivity should match RDKit's interpretation
@@ -2143,9 +2167,11 @@ class TestMolecule:
             for pdb_atom, sdf_atom in zip(pdb_mol.atoms, sdf_mol.atoms):
                 pdb_atom_dict = pdb_atom.to_dict()
                 del pdb_atom_dict["metadata"]
+                del pdb_atom_dict["name"]
 
                 sdf_atom_dict = sdf_atom.to_dict()
                 del sdf_atom_dict["metadata"]
+                del sdf_atom_dict["name"]
                 assert sdf_atom_dict == pdb_atom_dict
 
             # Check that the bonds match, though possibly in a different order

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -514,6 +514,9 @@ class TestTopology:
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         assert topology.n_molecules == 239
         assert topology.n_unique_molecules == 2
+        assert all(
+            all([molecule.residues, molecule.chains]) for molecule in topology.molecules
+        )
 
     def test_from_openmm_missing_reference(self):
         """Test creation of an OpenFF Topology object from an OpenMM Topology when missing a unique molecule"""

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -514,6 +514,7 @@ class TestTopology:
         topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
         assert topology.n_molecules == 239
         assert topology.n_unique_molecules == 2
+        # Ensure that hierarchy iterators are initialized
         assert all(
             all([molecule.residues, molecule.chains]) for molecule in topology.molecules
         )

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1228,14 +1228,14 @@ class FrozenMolecule(Serializable):
             # even if that conflicts with the current values in atom metadata.
             new_hier_scheme = HierarchyScheme(
                 self,
-                hierarchy_scheme_dict["uniqueness_criteria"],
+                tuple(hierarchy_scheme_dict["uniqueness_criteria"]),
                 iter_name,
             )
             self._hierarchy_schemes[iter_name] = new_hier_scheme
 
             for element_dict in hierarchy_scheme_dict["hierarchy_elements"]:
                 new_hier_scheme.add_hierarchy_element(
-                    element_dict["identifier"], element_dict["atom_indices"]
+                    tuple(element_dict["identifier"]), element_dict["atom_indices"]
                 )
 
     def __repr__(self):

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1448,6 +1448,7 @@ class Topology(Serializable):
                 ]
 
                 off_atom.metadata["chain_id"] = omm_mol_G.nodes[omm_atom]["chain_id"]
+            remapped_mol.add_default_hierarchy_schemes()
             topology._add_molecule_keep_cache(remapped_mol)
         topology._invalidate_cached_properties()
 

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1297,6 +1297,8 @@ class Topology(Serializable):
         This method guarantees that the order of atoms in the input OpenMM Topology will be the same as the ordering
         of atoms in the output OpenFF Topology. However it does not guarantee the order of the bonds will be the same.
 
+        Hierarchy schemes are taken from the OpenMM topology, not from `unique_molecules`.
+
         Parameters
         ----------
         openmm_topology : openmm.app.Topology

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -240,6 +240,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         # Take residue info from PDB
         for pdbatom, newatom in zip(pdbmol.atoms, new_mol.atoms):
             newatom.metadata.update(pdbatom.metadata)
+            newatom.name = pdbatom.name
         new_mol.add_default_hierarchy_schemes()
 
         return new_mol

--- a/openff/toolkit/utils/serialization.py
+++ b/openff/toolkit/utils/serialization.py
@@ -474,7 +474,7 @@ def _contains_bytes(val) -> bool:
         return True
     elif isinstance(val, (int, float, str, bool)):
         return False
-    elif isinstance(val, list):
+    elif isinstance(val, (list, tuple)):
         return any([_contains_bytes(x) for x in val])
     elif isinstance(val, dict):
         return any([_contains_bytes(x) for x in val.values()])
@@ -495,14 +495,14 @@ def _prep_numpy_data_for_json(data: Dict) -> Dict:
             data[key] = _prep_numpy_data_for_json(val)
         if isinstance(val, bytes):
             data[key] = np.frombuffer(val, dtype=big_endian_float).tolist()
-        if isinstance(val, list):
+        if isinstance(val, (list, tuple)):
             for i, element in enumerate(val):
                 if isinstance(element, bytes):
                     # Handles case of List[np.array], like Molecule.conformers
                     data[key][i] = np.frombuffer(
                         element, dtype=big_endian_float
                     ).tolist()
-                else:
+                elif isinstance(element, dict):
                     # Handles case of List[Molecule], like Topology.molecules
                     data[key][i] = _prep_numpy_data_for_json(element)
     return data


### PR DESCRIPTION
This adds residue and chain hierarchy scheme support to `Molecule.from_pdb_and_smiles` and `Topology.from_openmm`.

This is based on #1400 to avoid conflicts, so that should be merged first.

Fixes #1386.

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
