### PR TITLE
Fix incorrect usage of `Quantity.magnitude_as` #1406

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -98,7 +98,7 @@ print(converted)
 
 Report the value in compatible units:
 ```
-print(value.magnitude_as(unit.angstrom))  $ or .m_as()
+print(value.m_as(unit.angstrom))  # Note that value.magnitude_as() does not exist
 # 10.0 <Unit('angstrom')>
 ```
 


### PR DESCRIPTION
From
```shell
grep -r "magnitude_as" ~/software/openff-toolkit/
./docs/releasehistory.md:print(value.magnitude_as(unit.angstrom))  $ or .m_as()
```
to
```shell
grep -r "magnitude_as" ~/software/openff-toolkit/
./docs/releasehistory.md:print(value.m_as(unit.angstrom))  # Note that value.magnitude_as() does not exist
```