### PR TITLE
Use non-radical molecules in multi-molecule loading test

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -900,7 +900,7 @@ class TestMolecule:
 
         # Ensure that attempting to initialize a single Molecule from a file
         # containing multiple molecules raises a ValueError
-        filename = get_data_file_path("molecules/zinc-subset-tripos.mol2.gz")
+        filename = get_data_file_path("molecules/butane_multi.sdf")
         with pytest.raises(ValueError):
             Molecule(filename, allow_undefined_stereo=True)
 


### PR DESCRIPTION
- [x] One slow-running test is failing in 0.11.1 because it relied on a file with mis-formatted chemistry (it was testing for a different error)