### PR TITLE
Switch CI runners to `macos-12`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
         python-version: ["3.8", "3.9", "3.10"]
         rdkit: [true, false]
         openeye: [true, false]
@@ -41,7 +41,7 @@ jobs:
           # As of 7/6/22, this cannot solve due to a missing OpenMM build.
           # Revisit when OpenMM 7.8+ is released and new builds are up.
           - python-version: "3.10"
-            os: macos-latest
+            os: macos-12
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt


### PR DESCRIPTION
I got this email:

> Thank you for being a GitHub Actions customer and using our GitHub-hosted macOS runners. Jobs using the macos-latest runner image will soon run on macos-12. This change will be rolled out to GitHub Actions over a period of several weeks beginning in October 2022. You can determine whether a job ran with macos-11 or macos-12 by viewing its log file. If you see any issues with your workflows when they are transitioned to macOS-12:

> File an issue in the [runner images](https://app.github.media/e/er?s=88570519&lid=3539&elqTrackId=309fe3b9cf4a41d2acee5df63cbc6f23&elq=11aabafe73b14af5a9b726c855f3cb77&elqaid=2756&elqat=1) repository.
> Switch back to macos-11 by changing runs-on: macos-latest to the runs-on: macos-11 workflow label.

I doubt there are differences but this change should indicate any. If this passes I will close this PR and let the update happen.