### PR TITLE
Deepcopy `properties` dict when initializing from dict

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -8,6 +8,10 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ## Current development
 
+## Bug fixes
+
+- [PR #1417](https://github.com/openforcefield/openff-toolkit/pull/1417): Ensure the properties dict is copied when a `Molecule` is.
+
 ## 0.11.1 Minor release forbidding loading radicals
 
 ## Behavior changes

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -3287,6 +3287,40 @@ class TestMolecule:
             with pytest.warns(UserWarning, match="compute_.*_am1bcc.*0.12"):
                 toolkit.compute_partial_charges_am1bcc(molecule)
 
+    def test_deepcopy_not_shallow(self):
+        """
+        Check that deep copies don't re-use any mutable data structures
+
+        Mutable attributes set in ``Molecule._initialize_from_dict()`` and their
+        mutable values should be tested here. Other attributes are either not
+        copied by ``deepcopy``, or else are immutable, so copies may be the same
+        object (eg, ``deepcopy(None)``).
+        """
+        mol_source = create_ethanol()
+        mol_source.generate_conformers()
+
+        mol_copy = copy.deepcopy(mol_source)
+
+        assert mol_source._conformers is not mol_copy._conformers
+        assert all(
+            a is not b for a, b in zip(mol_source._conformers, mol_copy._conformers)
+        )
+
+        assert mol_source._atoms is not mol_copy._atoms
+        assert all(a is not b for a, b in zip(mol_source._atoms, mol_copy._atoms))
+
+        assert mol_source._bonds is not mol_copy._bonds
+        assert all(a is not b for a, b in zip(mol_source._bonds, mol_copy._bonds))
+
+        assert mol_source._hierarchy_schemes is not mol_copy._hierarchy_schemes
+        assert all(
+            a is not b
+            for a, b in zip(mol_source._hierarchy_schemes, mol_copy._hierarchy_schemes)
+        )
+
+        assert mol_source._properties is not mol_copy._properties
+        assert mol_source._partial_charges is not mol_copy._partial_charges
+
 
 class TestMoleculeVisualization:
     @requires_pkg("IPython")

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1096,9 +1096,9 @@ class FrozenMolecule(Serializable):
         # Or not allow user-defined properties at all (just use our internal _cached_properties)
         # molecule_dict['properties'] = dict([(key, value._to_dict()) for key.value in self._properties])
         # TODO: Assuming "simple stuff" properties right now, figure out a better standard
-        molecule_dict["properties"] = self._properties
+        molecule_dict["properties"] = deepcopy(self._properties)
         if hasattr(self, "_cached_properties"):
-            molecule_dict["cached_properties"] = self._cached_properties
+            molecule_dict["cached_properties"] = deepcopy(self._cached_properties)
         # TODO: Conformers
         if self._conformers is None:
             molecule_dict["conformers"] = None
@@ -4734,7 +4734,7 @@ class FrozenMolecule(Serializable):
                 new_molecule._add_conformer(new_conformer * unit.angstrom)
 
         # move any properties across
-        new_molecule._properties = self._properties
+        new_molecule._properties = deepcopy(self._properties)
 
         return new_molecule
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1218,7 +1218,7 @@ class FrozenMolecule(Serializable):
                 conformer = unit.Quantity(conformer_unitless, c_unit)
                 self._conformers.append(conformer)
 
-        self._properties = molecule_dict["properties"]
+        self._properties = deepcopy(molecule_dict["properties"])
 
         for iter_name, hierarchy_scheme_dict in molecule_dict[
             "hierarchy_schemes"


### PR DESCRIPTION
Fixes #1416 

The change on line 1221 is not strictly necessary to fix this issue given the change on line 1099, but it seems like best practice for consistency with the rest of the method. The change on line 4737 fixes a related issue I found while writing the other fixes.

I can write tests if desired!

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
