### PR TITLE
Sort hierarchy iterators without `packaging`

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -49,7 +49,6 @@ import numpy as np
 from openff.units import unit
 from openff.units.elements import MASSES, SYMBOLS
 from openff.utilities.exceptions import MissingOptionalDependencyError
-from packaging import version
 
 import openff.toolkit
 from openff.toolkit.utils.exceptions import (
@@ -5667,11 +5666,7 @@ class HierarchyScheme:
         Semantically sort the HierarchyElements belonging to this object, according to
         their identifiers.
         """
-        # hard-code the sort_func value here, since it's hard to serialize safely
-        def sort_func(x):
-            return version.parse(".".join([str(i) for i in x.identifier]))
-
-        self.hierarchy_elements.sort(key=sort_func)
+        self.hierarchy_elements.sort(key=lambda x: [int(y) for y in x.split(".")])
 
     def __str__(self):
         return (

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5666,7 +5666,9 @@ class HierarchyScheme:
         Semantically sort the HierarchyElements belonging to this object, according to
         their identifiers.
         """
-        self.hierarchy_elements.sort(key=lambda x: [int(y) for y in x.split(".")])
+        self.hierarchy_elements.sort(
+            key=lambda x: ".".join([str(i) for i in x.identifier])
+        )
 
     def __str__(self):
         return (


### PR DESCRIPTION
Tests using something in the OpenFF stack have been reporting a spooky deprecation warning for a few weeks now. In the spirit of spooky season, I hunted down the source of the error as the use of `packaging.version.parse` to do a semantic sort at some point during hierarchy construction. The root cause is obfuscated by ... uhh ... _reasons_. `LegacyVersion` is deprecated but its deprecation warning is only emitted at _construction_, not at import time. It turns out `version.parse` will fall back to creating a `LegacyVersion` if passed a string that it cannot squish into something compliant with PEP 440.

I tracked this behavior down to `HierarchyScheme.sort_hierarchy_elements` doing a semantic sort, which I think can be replaced without the use of `packaging`. I'm not sure what behavior this would change, if anybody, but it does not cause any tests to fail.

```shell
$ git checkout upstream/main && pytest test_pdb.py
HEAD is now at cd3b78ef Use actual good molecules in multi-molecule loading test (#1409)
=============================================== test session starts ===============================================
platform darwin -- Python 3.9.13, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/mattthompson/software/openff-toolkit
plugins: xdist-2.5.0, forked-1.4.0, rerunfailures-10.2, nbval-0.9.6, cov-3.0.0
collected 1 item

test_pdb.py .                                                                                               [100%]

================================================ warnings summary =================================================
test_pdb.py::test_load
test_pdb.py::test_load
test_pdb.py::test_load
test_pdb.py::test_load
test_pdb.py::test_load
  /Users/mattthompson/mambaforge/envs/openff-dev/lib/python3.9/site-packages/packaging/version.py:111: DeprecationWarning: Creating a LegacyVersion has been deprecated and will be removed in the next major release
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================== 1 passed, 5 warnings in 0.89s ==========================================
$ git checkout no-version-sort && pytest test_pdb.py
Previous HEAD position was cd3b78ef Use actual good molecules in multi-molecule loading test (#1409)
Switched to branch 'no-version-sort'
=============================================== test session starts ===============================================
platform darwin -- Python 3.9.13, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/mattthompson/software/openff-toolkit
plugins: xdist-2.5.0, forked-1.4.0, rerunfailures-10.2, nbval-0.9.6, cov-3.0.0
collected 1 item

test_pdb.py .                                                                                               [100%]

================================================ 1 passed in 0.91s ================================================
```

Using a minimal PDB loader in the test script:
```python3
from openff.toolkit.utils import get_data_file_path
from openff.toolkit import Molecule

def test_load():
    Molecule.from_polymer_pdb(get_data_file_path("proteins/MainChain_ALA_ALA.pdb"))
```
I've only observed this when running tests, but it might also be spat out in some Jupyter configurations.