### PR TITLE
Allow D- and F- block radicals

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -8,6 +8,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ## Current development
 
+## Behavior changes
+- [PR #1421](https://github.com/openforcefield/openff-toolkit/pull/1421): Allow `Molecule.from_rdkit()` to load D- and F- block radicals, which cannot have implicit hydrogens.
+
 ## 0.11.1 Minor release forbidding loading radicals
 
 ## Behavior changes

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -2052,7 +2052,7 @@ class TestRDKitToolkitWrapper:
 
     def test_rdkit_from_smiles_transition_metal_radical(self):
         """Test that parsing an SMILES with a transition metal radical works."""
-        RDKitToolkitWrapper().from_smiles("[Zn2+]")
+        RDKitToolkitWrapper().from_smiles("[Zn+2]")
 
     def test_rdkit_from_smiles_hydrogens_are_explicit(self):
         """

--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -342,6 +342,10 @@ class TestOpenEyeToolkitWrapper:
         with pytest.raises(RadicalsNotSupportedError):
             OpenEyeToolkitWrapper().from_smiles("[CH3]")
 
+    def test_openeye_from_smiles_transition_metal_radical(self):
+        """Test that parsing an SMILES with a transition metal radical works."""
+        OpenEyeToolkitWrapper().from_smiles("[Zn+2]")
+
     # TODO: test_smiles_round_trip
 
     def test_smiles_add_H(self):
@@ -665,7 +669,7 @@ class TestOpenEyeToolkitWrapper:
         assert oechem.OEHasImplicitHydrogens(oe_molecule)
 
     def test_from_openeye_radical(self):
-        """Test that parsing an rdmol with a radical raises RadicalsNotSupportedError."""
+        """Test that parsing an oemol with a radical raises RadicalsNotSupportedError."""
         from openeye import oechem
 
         smiles = "[H][C]([H])[H]"
@@ -674,6 +678,16 @@ class TestOpenEyeToolkitWrapper:
 
         with pytest.raises(RadicalsNotSupportedError):
             OpenEyeToolkitWrapper().from_openeye(oemol)
+
+    def test_from_openeye_transition_metal_radical(self):
+        """Test that parsing an oemol with a transition metal radical works."""
+        from openeye import oechem
+
+        smiles = "[Zn+2]"
+        oemol = oechem.OEGraphMol()
+        oechem.OESmilesToMol(oemol, smiles)
+
+        OpenEyeToolkitWrapper().from_openeye(oemol)
 
     def test_from_openeye_implicit_hydrogen(self):
         """
@@ -2036,6 +2050,10 @@ class TestRDKitToolkitWrapper:
         with pytest.raises(RadicalsNotSupportedError):
             RDKitToolkitWrapper().from_smiles("[CH3]")
 
+    def test_rdkit_from_smiles_transition_metal_radical(self):
+        """Test that parsing an SMILES with a transition metal radical works."""
+        RDKitToolkitWrapper().from_smiles("[Zn2+]")
+
     def test_rdkit_from_smiles_hydrogens_are_explicit(self):
         """
         Test to ensure that RDKitToolkitWrapper.from_smiles has the proper behavior with
@@ -2466,6 +2484,14 @@ class TestRDKitToolkitWrapper:
 
         with pytest.raises(RadicalsNotSupportedError):
             RDKitToolkitWrapper().from_rdkit(rdmol)
+
+    def test_from_rdkit_transition_metal_radical(self):
+        """Test that parsing an rdmol with a transition metal radical works."""
+        from rdkit import Chem
+
+        rdmol = Chem.MolFromSmiles("[Zn+2]")
+
+        RDKitToolkitWrapper().from_rdkit(rdmol)
 
     @pytest.mark.parametrize(
         "smiles, expected_map", [("[Cl:1][Cl]", {0: 1}), ("[Cl:1][Cl:2]", {0: 1, 1: 2})]

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1168,6 +1168,9 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             # Carry with implicit units of elementary charge for faster route through _add_atom
             formal_charge = oeatom.GetFormalCharge()
             explicit_valence = oeatom.GetExplicitValence()
+            # Implicit hydrogens are never added to D- and F- block elements,
+            # and the MDL valence is always the explicit valence for these
+            # elements, so this does not count radical electrons in these blocks.
             mdl_valence = oechem.OEMDLGetValence(
                 atomic_number, formal_charge, explicit_valence
             )

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -1723,7 +1723,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
 
             # See issues #1075 for some discussion on radicals
             if (
-                rda.atomic_number not in d_and_f_block_elements
+                rda.GetAtomicNum() not in d_and_f_block_elements
                 and rda.GetNumRadicalElectrons() != 0
             ):
                 raise RadicalsNotSupportedError(

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -1711,12 +1711,23 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         map_bonds = {}
         # if we are loading from a mapped smiles extract the mapping
         atom_mapping = {}
+        # We need the elements of the lanthanides, actinides, and transition
+        # metals as we don't want to exclude radicals in these blocks.
+        d_and_f_block_elements = {
+            *range(21, 31),
+            *range(39, 49),
+            *range(57, 81),
+            *range(89, 113),
+        }
         for rda in rdmol.GetAtoms():
 
             # See issues #1075 for some discussion on radicals
-            if rda.GetNumRadicalElectrons() != 0:
+            if (
+                rda.atomic_number not in d_and_f_block_elements
+                and rda.GetNumRadicalElectrons() != 0
+            ):
                 raise RadicalsNotSupportedError(
-                    "The OpenFF Toolkit does not currently support parsing molecules with radicals. "
+                    "The OpenFF Toolkit does not currently support parsing molecules with S- and P-block radicals. "
                     f"Found {rda.GetNumRadicalElectrons()} radical electrons on molecule {Chem.MolToSmiles(rdmol)}."
                 )
 


### PR DESCRIPTION
Closes #1420.

OK I've dug into this issue a bit more now. The RDKit wrapper uses the `Atom.GetNumRadicalElectrons()` method, which looks at the atom's electron configuration and reports the number of unpaired electrons. If there are any unpaired electrons, we raise an error. This matches the chemical definition of radical exactly, but means that d- and f-block elements that we don't usually think about as radicals can be excluded.

The OpenEye wrapper is not equivalent, as openeye doesn't provide the equivalent  - it instead gets what RDKit calls the "standard valence", or what OpenEye calls the "MDL model valence" for the atom, and if it's different to the actual valence (including formal charge) then we call it a radical. This doesn't match the chemical definition of radical, as it's more about whether there are dangling bonds rather than unpaired electrons. However, it does pretty closely match what chemists usually mean when they say radical - I don't think I've ever heard a transition metal called a radical, even though plenty of them technically are.

I tried to think of weird radicals that would demonstrate the difference, but apart from d- and f-block elements the approach we use in the OpenEye wrapper seems to basically work. Unfortunately, the MDL valence model isn't available in RDKit. It's documented in the OE docs [here](https://docs.eyesopen.com/toolkits/python/oechemtk/valence.html#mdl-valence-model). I think we would end up matching it pretty closely just by skipping the radical check for d- and f- block elements (transition metals, lanthanides, actinides) and using the existing code for everything else.

So TL;DR:
 - RDKit's `Atom.GetNumRadicalElectrons()` is too expansive and doesn't have an equivalent in openeye
 - OpenEye's `oechem.OEMDLGetValence()` is about right and doesn't have an equivalent in RDKit
 - I think "Accept all d- and f- block elements, and other elements when they don't have unpaired electrons" will be about equivalent to the current OE implementation, so that's what I've written.

This approach is also safe with respect to #1075, as implicit hydrogens are never added to D- and F- block elements.

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
