### PR TITLE
Refactor atom naming logic outside of `Topology.to_openmm`

### DIFF
--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1460,6 +1460,18 @@ class Topology(Serializable):
         # TODO: How can we preserve metadata from the openMM topology when creating the OFF topology?
         return topology
 
+    def _ensure_unique_atom_names(self, ensure_unique_atom_names: Union[str, bool]):
+        """See `Topology.to_openmm`"""
+        for molecule in self._molecules:
+            if isinstance(ensure_unique_atom_names, str) and hasattr(
+                molecule, ensure_unique_atom_names
+            ):
+                for hier_elem in getattr(molecule, ensure_unique_atom_names):
+                    if not hier_elem.has_unique_atom_names:
+                        hier_elem.generate_unique_atom_names()
+            elif not molecule.has_unique_atom_names:
+                molecule.generate_unique_atom_names()
+
     @requires_package("openmm")
     def to_openmm(self, ensure_unique_atom_names: Union[str, bool] = "residues"):
         """
@@ -1511,15 +1523,7 @@ class Topology(Serializable):
 
         # Create unique atom names
         if ensure_unique_atom_names:
-            for molecule in off_topology._molecules:
-                if isinstance(ensure_unique_atom_names, str) and hasattr(
-                    molecule, ensure_unique_atom_names
-                ):
-                    for hier_elem in getattr(molecule, ensure_unique_atom_names):
-                        if not hier_elem.has_unique_atom_names:
-                            hier_elem.generate_unique_atom_names()
-                elif not molecule.has_unique_atom_names:
-                    molecule.generate_unique_atom_names()
+            off_topology._ensure_unique_atom_names(ensure_unique_atom_names)
 
         # Go through atoms in OpenFF to preserve the order.
         omm_atoms = []

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1462,6 +1462,8 @@ class Topology(Serializable):
 
     def _ensure_unique_atom_names(self, ensure_unique_atom_names: Union[str, bool]):
         """See `Topology.to_openmm`"""
+        if not ensure_unique_atom_names:
+            return
         for molecule in self._molecules:
             if isinstance(ensure_unique_atom_names, str) and hasattr(
                 molecule, ensure_unique_atom_names
@@ -1521,9 +1523,7 @@ class Topology(Serializable):
         off_topology = Topology(self)
         omm_topology = app.Topology()
 
-        # Create unique atom names
-        if ensure_unique_atom_names:
-            off_topology._ensure_unique_atom_names(ensure_unique_atom_names)
+        off_topology._ensure_unique_atom_names(ensure_unique_atom_names)
 
         # Go through atoms in OpenFF to preserve the order.
         omm_atoms = []


### PR DESCRIPTION
I'd like to be able to use the logic of the `ensure_unique_atom_names` argument of `Topology.to_openmm` without invoking anything related to OpenMM - which I should be able to do without copying source code as these lines don't interact with OpenMM at all.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
