### PR TITLE
Refactor OpenEye checks to only warn if installed and unlicesed

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -14,6 +14,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### Bug fixes
 - [PR #1417](https://github.com/openforcefield/openff-toolkit/pull/1417): Ensure the properties dict is copied when a `Molecule` is.
 
+### Improved documentation and warnings
+- [PR #1426](https://github.com/openforcefield/openff-toolkit/pull/1426): A warning about OpenEye Toolkits being unavailable is only emitted when they are installed but the license file is not found.
+
 ## 0.11.1 Minor release forbidding loading radicals
 
 ## Behavior changes

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -146,10 +146,14 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             if self._is_installed is False:
                 raise ToolkitUnavailableException(
                     "OpenEye Toolkits are not installed."
-                    "{self._toolkit_installation_instructions}"
+                    + self._toolkit_installation_instructions
                 )
             if self._is_licensed is False:
-                raise LicenseError(self._toolkit_license_instructions)
+                raise LicenseError(
+                    "The OpenEye Toolkits are found to be installed but not licensed and "
+                    + "therefore will not be used.\n"
+                    + self._toolkit_license_instructions
+                )
 
         from openeye import __version__ as openeye_version
 
@@ -158,7 +162,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
     @classmethod
     def _check_licenses(cls) -> bool:
         """Check license of all known OpenEye tools. Returns True if any are found
-        to be licensed, False if any are not."""
+        to be licensed, False if all are not."""
         for tool, license_func in cls._license_functions.items():
             try:
                 module = importlib.import_module("openeye." + tool)
@@ -199,10 +203,6 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
                     cls._is_available = True
                 else:
                     cls._is_available = False
-                    logger.warning(
-                        "The OpenEye Toolkits are found to be installed but not licensed and "
-                        "therefore will not be used."
-                    )
             cls._is_available = cls._is_installed and cls._is_licensed
         return cls._is_available
 

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -13,7 +13,7 @@ import re
 import tempfile
 from collections import defaultdict
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from cachetools import LRUCache, cached
@@ -70,16 +70,19 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
 
     _toolkit_name = "OpenEye Toolkit"
     _toolkit_installation_instructions = (
-        "The OpenEye toolkit requires a (free for academics) license, and can be "
-        "found at: "
+        "The OpenEye Toolkits can be installed via "
+        "`conda install openeye-toolkits -c openeye`"
+    )
+    _toolkit_license_instructions = (
+        "The OpenEye Toolkits require a (free for academics) license which can be found at "
         "https://docs.eyesopen.com/toolkits/python/quickstart-python/install.html"
     )
     # This could belong to ToolkitWrapper, although it seems strange
     # to carry that data for open-source toolkits
-    _is_licensed = None
+    _is_licensed: Optional[bool] = None
     # Only for OpenEye is there potentially a difference between
     # being available and installed
-    _is_installed = None
+    _is_installed: Optional[bool] = None
     _license_functions = {
         "oechem": "OEChemIsLicensed",
         "oequacpac": "OEQuacPacIsLicensed",
@@ -140,24 +143,23 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         # check if the toolkit can be loaded
         if not self.is_available():
-            msg = (
-                f"The required toolkit {self._toolkit_name} is not "
-                f"available. {self._toolkit_installation_instructions}"
-            )
             if self._is_installed is False:
-                raise ToolkitUnavailableException(msg)
+                raise ToolkitUnavailableException(
+                    "OpenEye Toolkits are not installed."
+                    "{self._toolkit_installation_instructions}"
+                )
             if self._is_licensed is False:
-                raise LicenseError(msg)
+                raise LicenseError(self._toolkit_license_instructions)
 
         from openeye import __version__ as openeye_version
 
         self._toolkit_version = openeye_version
 
     @classmethod
-    def _check_licenses(cls):
+    def _check_licenses(cls) -> bool:
         """Check license of all known OpenEye tools. Returns True if any are found
         to be licensed, False if any are not."""
-        for (tool, license_func) in cls._license_functions.items():
+        for tool, license_func in cls._license_functions.items():
             try:
                 module = importlib.import_module("openeye." + tool)
             except (ImportError, ModuleNotFoundError):
@@ -192,6 +194,15 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
                         importlib.import_module("openeye." + tool)
                     except (ImportError, ModuleNotFoundError):
                         cls._is_installed = False
+            if cls._is_installed:
+                if cls._is_licensed:
+                    cls._is_available = True
+                else:
+                    cls._is_available = False
+                    logger.warning(
+                        "The OpenEye Toolkits are found to be installed but not licensed and "
+                        "therefore will not be used."
+                    )
             cls._is_available = cls._is_installed and cls._is_licensed
         return cls._is_available
 

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -74,8 +74,8 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         "`conda install openeye-toolkits -c openeye`"
     )
     _toolkit_license_instructions = (
-        "The OpenEye Toolkits require a (free for academics) license which can be found at "
-        "https://docs.eyesopen.com/toolkits/python/quickstart-python/install.html"
+        "The OpenEye Toolkits require a (free for academics) license, see "
+        "https://docs.eyesopen.com/toolkits/python/quickstart-python/license.html"
     )
     # This could belong to ToolkitWrapper, although it seems strange
     # to carry that data for open-source toolkits

--- a/openff/toolkit/utils/toolkit_registry.py
+++ b/openff/toolkit/utils/toolkit_registry.py
@@ -164,12 +164,12 @@ class ToolkitRegistry:
             try:
                 toolkit_wrapper = toolkit_wrapper()
 
-            # This exception can only be raised by OpenEyeToolkitWrapper
-            except LicenseError as openeye_exception:
+            # This exception can be raised by OpenEyeToolkitWrapper
+            except LicenseError as license_exception:
                 if exception_if_unavailable:
-                    raise ToolkitUnavailableException(openeye_exception)
+                    raise ToolkitUnavailableException(license_exception.msg)
                 else:
-                    logger.warning(openeye_exception)
+                    logger.warning(license_exception)
             except ToolkitUnavailableException:
                 msg = "Unable to load toolkit '{}'. ".format(
                     toolkit_wrapper._toolkit_name


### PR DESCRIPTION
Closes #1425 and possibly other issues

The result of high-level imports, i.e. `from openff.toolkit import Molecule`, for the cases of OpenEye Toolkits being installed and/or licensed are as follows:

|   | Installed | Not installed |
|---|---|---|
| Licensed  | Nothing | Nothing |
| Not licensed | A versbose warning | Nothing |

Said warning, for various cases of `oechem` not finding the environment variable or file:

```python3
>>> from openff.toolkit import Molecule
LICENSE: Could not open license file "oe_license.txt" in local directory
LICENSE: N.B. OE_LICENSE environment variable is not set
LICENSE: N.B. OE_DIR environment variable is not set
LICENSE: No product keys!
LICENSE: No product keys!
LICENSE: No product keys!
LICENSE: No product keys!
The OpenEye Toolkits are found to be installed but not licensed and therefore will not be used.
The OpenEye Toolkits require a (free for academics) license which can be found at https://docs.eyesopen.com/toolkits/python/quickstart-python/install.html
```

More thoroughly, showing
* No warning when license exists and is set up properly
* Warning when `openeye-toolkits` is installed and `OE_LICENSE` is set but file does not exist
* Warning when `openeye-toolkits` is installed and `OE_LICENSE` is not set
* No warning when `openeye-toolkits` is not installed and license is not set up
* No warning when `openeye-toolkits` is not installed and license is set up properly

This covers everything I can think of.

```shell
(openff-interchange-env) [openff-toolkit] wc -l ~/.oe_license.txt && echo $OE_LICENSE
     197 /Users/mattthompson/.oe_license.txt
/Users/mattthompson/.oe_license.txt
(openff-interchange-env) [openff-toolkit] python -c "from openff.toolkit import Molecule"
(openff-interchange-env) [openff-toolkit] mv ~/.oe_license.txt ~/.foo_license.txt
(openff-interchange-env) [openff-toolkit] python -c "from openff.toolkit import Molecule"
LICENSE: Could not open license file specified by OE_LICENSE environment variable "/Users/mattthompson/.oe_license.txt"
LICENSE: Could not open license file "oe_license.txt" in local directory
LICENSE: N.B. OE_DIR environment variable is not set
LICENSE: No product keys!
LICENSE: No product keys!
LICENSE: No product keys!
LICENSE: No product keys!
The OpenEye Toolkits are found to be installed but not licensed and therefore will not be used.
The OpenEye Toolkits require a (free for academics) license which can be found at https://docs.eyesopen.com/toolkits/python/quickstart-python/install.html
(openff-interchange-env) [openff-toolkit] unset OE_LICENSE          10:42:44  ☁  quieter-openeye-warning ☂
(openff-interchange-env) [openff-toolkit] python -c "from openff.toolkit import Molecule"
LICENSE: Could not open license file "oe_license.txt" in local directory
LICENSE: N.B. OE_LICENSE environment variable is not set
LICENSE: N.B. OE_DIR environment variable is not set
LICENSE: No product keys!
LICENSE: No product keys!
LICENSE: No product keys!
LICENSE: No product keys!
The OpenEye Toolkits are found to be installed but not licensed and therefore will not be used.
The OpenEye Toolkits require a (free for academics) license which can be found at https://docs.eyesopen.com/toolkits/python/quickstart-python/install.html
(openff-interchange-env) [openff-toolkit] CONDA_SUBDIR=osx-64 mamba uninstall openeye-toolkits -yq

                  __    __    __    __
                 /  \  /  \  /  \  /  \
                /    \/    \/    \/    \
███████████████/  /██/  /██/  /██/  /████████████████████████
              /  / \   / \   / \   / \  \____
             /  /   \_/   \_/   \_/   \    o \__,
            / _/                       \_____/  `
            |/
        ███╗   ███╗ █████╗ ███╗   ███╗██████╗  █████╗
        ████╗ ████║██╔══██╗████╗ ████║██╔══██╗██╔══██╗
        ██╔████╔██║███████║██╔████╔██║██████╔╝███████║
        ██║╚██╔╝██║██╔══██║██║╚██╔╝██║██╔══██╗██╔══██║
        ██║ ╚═╝ ██║██║  ██║██║ ╚═╝ ██║██████╔╝██║  ██║
        ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚═════╝ ╚═╝  ╚═╝

        mamba (0.25.0) supported by @QuantStack

        GitHub:  https://github.com/mamba-org/mamba
        Twitter: https://twitter.com/QuantStack

█████████████████████████████████████████████████████████████

  Package              Version  Build   Channel     Size
──────────────────────────────────────────────────────────
  Remove:
──────────────────────────────────────────────────────────

  - openeye-toolkits  2022.1.1  py38_0  openeye

  Summary:

  Remove: 1 packages

  Total download: 0 B

──────────────────────────────────────────────────────────

Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
(openff-interchange-env) [openff-toolkit] python -c "from openff.toolkit import Molecule"
(openff-interchange-env) [openff-toolkit] mv ~/.foo_license.txt ~/.oe_license.txt
(openff-interchange-env) [openff-toolkit] export OE_LICENSE=/Users/mattthompson/.oe_license.txt
(openff-interchange-env) [openff-toolkit] python -c "from openff.toolkit import Molecule"
```


- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
