### PR TITLE
Fix possible import loop

### DIFF
--- a/openff/toolkit/utils/__init__.py
+++ b/openff/toolkit/utils/__init__.py
@@ -1,2 +1,2 @@
-from openff.toolkit.utils.toolkits import *
 from openff.toolkit.utils.utils import *
+from openff.toolkit.utils.toolkits import *


### PR DESCRIPTION
In #1236 a couple of imports were changed to happen in a different order. This breaks _some_ things ([_some_ `conda-build` builds ](https://github.com/conda-forge/openff-interchange-feedstock/pull/29#issuecomment-1278099222)and [_some_ `pip`-based installs](https://readthedocs.org/api/v2/build/18345132.txt)) but does not seem to break anything we have distributed - or at least we have no reports of this.