### PR TITLE
Do not use `typing_extensions` for features supported by `typing`

### DIFF
--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -57,12 +57,11 @@ import inspect
 import logging
 import re
 from collections import OrderedDict, defaultdict
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast, get_args
 
 import numpy as np
 from openff.units import unit
 from packaging.version import Version
-from typing_extensions import Literal, get_args
 
 from openff.toolkit.topology import ImproperDict, TagSortedDict, Topology, ValenceDict
 from openff.toolkit.topology.molecule import Molecule


### PR DESCRIPTION
This is minor but has some features of a future issue. `typing_extensions` is a third-party package that backports features of the (standard library) `typing` module to older versions of Python. For example, `typing.Literal` is only in Python 3.8 but `typing_extensions` allows it to be brought it on 3.7. After dropping Python 3.7 we are no longer use it for anything not support by the standard library.