### PR TITLE
Fix #1435

### DIFF
--- a/openff/toolkit/utils/toolkit_registry.py
+++ b/openff/toolkit/utils/toolkit_registry.py
@@ -170,6 +170,7 @@ class ToolkitRegistry:
                     raise ToolkitUnavailableException(license_exception.msg)
                 else:
                     logger.warning(license_exception)
+                return
             except ToolkitUnavailableException:
                 msg = "Unable to load toolkit '{}'. ".format(
                     toolkit_wrapper._toolkit_name


### PR DESCRIPTION
This is not easily added to the test matrix and I'd encourage a reviewer to set their local environment up with OpenEye Toolkits **installed but not licensed** in order to reproduce the original error.

```shell
(openff-dev) [openff-toolkit] git checkout fix-weird-openeye-config        13:31:48  ☁  fix-weird-openeye-config ☀
Already on 'fix-weird-openeye-config'
(openff-dev) [openff-toolkit] conda list | grep openeye                    13:31:50  ☁  fix-weird-openeye-config ☀
openeye-toolkits          2022.1.1                py310_0    openeye
(openff-dev) [openff-toolkit] python                                       13:31:53  ☁  fix-weird-openeye-config ☀
Python 3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:43:44) [Clang 13.0.1 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from openeye import oechem
>>> oechem.OEChemIsLicensed()
LICENSE: Could not open license file specified by OE_LICENSE environment variable "/Users/mattthompson/.oe_license.txt"
LICENSE: Could not open license file "oe_license.txt" in local directory
LICENSE: N.B. OE_DIR environment variable is not set
LICENSE: No product keys!
False
>>> from openff.toolkit.utils import *
LICENSE: No product keys!
LICENSE: No product keys!
LICENSE: No product keys!
LICENSE: No product keys!
The OpenEye Toolkits are found to be installed but not licensed and therefore will not be used.
The OpenEye Toolkits require a (free for academics) license, see https://docs.eyesopen.com/toolkits/python/quickstart-python/license.html
>>> GLOBAL_TOOLKIT_REGISTRY.registered_toolkits
[ToolkitWrapper around The RDKit version 2022.03.5, ToolkitWrapper around AmberTools version 22.0, ToolkitWrapper around Built-in Toolkit version None]
>>>