### PR TITLE
Loosen criteria on flaky bond order test

### DIFF
--- a/openff/toolkit/tests/test_toolkits.py
+++ b/openff/toolkit/tests/test_toolkits.py
@@ -3768,7 +3768,7 @@ class TestAmberToolsToolkitWrapper:
         without_oe = [b.fractional_bond_order for b in mol.bonds]
         GLOBAL_TOOLKIT_REGISTRY.register_toolkit(OpenEyeToolkitWrapper)
 
-        assert with_oe == without_oe
+        assert with_oe == pytest.approx(without_oe, abs=1e-5)
 
 
 class TestBuiltInToolkitWrapper:


### PR DESCRIPTION
Fixes #1437

On tag `0.11.2`, with an unrelated patch to avoid loading MiniDrugBank when I don't need it:

```shell
python -m pytest --count=1000 -nauto openff/toolkit/tests/test_toolkits.py::TestAmberToolsToolkitWrapper::test_assign_fractional_bond_orders_openeye_installed
<SNIP>
=================================== 230 failed, 770 passed in 215.82s (0:03:35) ===================================
```

The same command run on this change passes 1000/1000 of these tests.

I'm open to feedback on what the values of the arguments should be; I'm not sure what I trust to reliably report errors less than 1e-3 so I figure 1e-5 should be tight enough.

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
