### PR TITLE
Corrected tolerance to have the unit of force as defined in the OpenMM doc

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -9,6 +9,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ## Current development
 
+### Examples updates
+- [PR #1447](https://github.com/openforcefield/openff-toolkit/pull/1447): Fixed units of tolerance used in OpenMM minimization in Toolkit Showcase example notebook (from @ziyuanzhao2000)
+
 ### Miscellaneous
 - [PR #1413](https://github.com/openforcefield/openff-toolkit/pull/1413): Remove some large and unused data files from the test suite.
 

--- a/examples/toolkit_showcase/toolkit_showcase.ipynb
+++ b/examples/toolkit_showcase/toolkit_showcase.ipynb
@@ -603,7 +603,9 @@
    "outputs": [],
    "source": [
     "simulation.minimizeEnergy(\n",
-    "    tolerance=openmm_unit.Quantity(value=50.0, unit=openmm_unit.kilojoule_per_mole / openmm_unit.nanometer)\n",
+    "    tolerance=openmm_unit.Quantity(\n",
+    "        value=50.0, unit=openmm_unit.kilojoule_per_mole / openmm_unit.nanometer\n",
+    "    )\n",
     ")\n",
     "minimized_state = simulation.context.getState(\n",
     "    getPositions=True, getEnergy=True, getForces=True\n",

--- a/examples/toolkit_showcase/toolkit_showcase.ipynb
+++ b/examples/toolkit_showcase/toolkit_showcase.ipynb
@@ -603,7 +603,7 @@
    "outputs": [],
    "source": [
     "simulation.minimizeEnergy(\n",
-    "    tolerance=openmm_unit.Quantity(value=50.0, unit=openmm_unit.kilojoule_per_mole)\n",
+    "    tolerance=openmm_unit.Quantity(value=50.0, unit=openmm_unit.kilojoule_per_mole / openmm_unit.nanometer)\n",
     ")\n",
     "minimized_state = simulation.context.getState(\n",
     "    getPositions=True, getEnergy=True, getForces=True\n",


### PR DESCRIPTION
This is just to fix the issue mentioned here #1446 in the showcase notebook.