### PR TITLE
Remove explicit `py` dependency from test environments

### DIFF
--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -19,7 +19,6 @@ dependencies:
   - xmltodict
     # Test-only/optional/dev
   - mdtraj
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-cov
   - nbval

--- a/devtools/conda-envs/conda.yaml
+++ b/devtools/conda-envs/conda.yaml
@@ -8,7 +8,6 @@ dependencies:
 
   - openmmforcefields >=0.11.2
   - qcportal >=0.15
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-rerunfailures
   - nbval

--- a/devtools/conda-envs/conda_010X.yaml
+++ b/devtools/conda-envs/conda_010X.yaml
@@ -9,7 +9,6 @@ dependencies:
 
   - openmmforcefields
   - qcportal >=0.15
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-rerunfailures
   - nbval

--- a/devtools/conda-envs/conda_oe.yaml
+++ b/devtools/conda-envs/conda_oe.yaml
@@ -10,7 +10,6 @@ dependencies:
   - openmmforcefields >=0.11.2
   - openeye-toolkits
   - qcportal >=0.15
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-rerunfailures
   - nbval

--- a/devtools/conda-envs/conda_oe_010X.yaml
+++ b/devtools/conda-envs/conda_oe_010X.yaml
@@ -10,7 +10,6 @@ dependencies:
   - openmmforcefields
   - openeye-toolkits
   - qcportal >=0.15
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-rerunfailures
   - nbval

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -5,7 +5,6 @@ channels:
 dependencies:
   - python
   - pip
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -9,7 +9,6 @@ dependencies:
   - pip
 
     # Testing
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -5,7 +5,6 @@ channels:
 dependencies:
   - python
   - pip
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -8,7 +8,6 @@ dependencies:
   - pip
 
     # Testing
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,7 +21,6 @@ dependencies:
   - xmltodict
   - python-constraint
     # Test-only/optional/dev
-  - py  # Remove after pytest 7.2 dust settles
   - pytest
   - pytest-cov
   - pytest-xdist


### PR DESCRIPTION
Reverts a temporary band-aid https://github.com/openforcefield/openff-toolkit/pull/1413/commits/6cbd50d7390db99d11926a8d7e5bf203855f6e2f