### PR TITLE
Track which `ParameterHandler`s are loaded as plugins

### DIFF
--- a/openff/toolkit/tests/test_parameter_plugins.py
+++ b/openff/toolkit/tests/test_parameter_plugins.py
@@ -38,6 +38,8 @@ def test_force_field_custom_handler():
     assert parameter_handler is not None
     assert parameter_handler.__class__.__name__ == "CustomHandler"
 
+    assert parameter_handler.__class__ in force_field._plugin_parameter_handler_classes
+
 
 def test_load_handler_plugins():
     """Tests that parameter handlers can be registered as plugins."""

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -287,14 +287,12 @@ class ForceField:
             parameter_handler_classes = all_subclasses(ParameterHandler)
         if load_plugins:
 
-            registered_handlers = load_handler_plugins()
+            plugin_classes = load_handler_plugins()
 
-            # Make sure the same handlers aren't added twice.
-            parameter_handler_classes += [
-                handler
-                for handler in registered_handlers
-                if handler not in parameter_handler_classes
-            ]
+            for handler in plugin_classes:
+                if handler not in parameter_handler_classes:
+                    parameter_handler_classes.append(handler)
+                    self._plugin_parameter_handler_classes.append(handler)
 
         self._register_parameter_handler_classes(parameter_handler_classes)
 
@@ -323,6 +321,8 @@ class ForceField:
         self._parameter_handlers = (
             OrderedDict()
         )  # ParameterHandler classes to be instantiated for each parameter type
+        # ParameterHandlers that were registered via the plugin interface
+        self._plugin_parameter_handler_classes = list()
         self._parameter_io_handler_classes = (
             OrderedDict()
         )  # ParameterIOHandler classes that _can_ be initialiazed if needed


### PR DESCRIPTION
Closes #1467 

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
