### PR TITLE
VS handler fix for 0.10.6

### DIFF
--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -31,8 +31,8 @@ dependencies:
   - msgpack-python
   - xmltodict
   - qcelemental
-  - qcportal
+  - qcportal >= 0.15
   - qcengine
   - mdtraj
-  - openff-interchange
+  - openff-interchange < 0.2
   - python-constraint

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -30,8 +30,8 @@ dependencies:
   - msgpack-python
   - xmltodict
   - qcelemental
-  - qcportal
+  - qcportal >= 0.15
   - qcengine
   - mdtraj
-  - openff-interchange
+  - openff-interchange < 0.2
   - python-constraint

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -32,9 +32,9 @@ dependencies:
   - bson
   - msgpack-python
   - qcelemental
-  - qcportal
+  - qcportal >= 0.15
   - qcengine
-  - openff-interchange
+  - openff-interchange < 0.2
   # Typing
   - mypy
   - typing-extensions

--- a/examples/environment.yaml
+++ b/examples/environment.yaml
@@ -9,15 +9,16 @@ dependencies:
   - notebook
   - gromacs
   - qcelemental
-  - qcportal
+  - qcportal >= 0.15
   - qcengine
   - openmmforcefields
   # Below are dependencies of the toolkit; they are listed here as a reference
   - mdtraj
   - numpy
   - openmm
-  - openff-forcefields >=2.0.0
-  - openff-interchange >=0.1.3
+  - openff-forcefields >= 2
+  - openff-interchange < 0.2
   - gromacs
   - lammps
   - ambertools
+  - ipywidgets =7

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -2224,6 +2224,27 @@ class TestForceField:
         )
         force_field.label_molecules(Molecule.from_smiles("CF").to_topology())
 
+    def test_issue_1422(self):
+        """ Inherited plugin VirtualSite handlers should be detected
+        and treated like VirtualSites
+
+        https://github.com/openforcefield/openff-toolkit/issues/1422
+        """
+        class PluginVirtualSites(VirtualSiteHandler):
+            _TAGNAME = "InheritedTestVirtualSites"
+
+            def _find_matches(
+                    self,
+                    entity: Topology,
+                    transformed_dict_cls=dict,
+                    unique=False,
+            ) -> Dict[Tuple[int], List[ParameterHandler._Match]]:
+                return {(0,): [ParameterHandler._Match(None, None), ParameterHandler._Match(None, None)]}
+
+        force_field = ForceField()
+        force_field.get_parameter_handler("InheritedTestVirtualSites")
+        force_field.label_molecules(Molecule.from_smiles("CO").to_topology())
+
 
 def generate_monatomic_ions():
     return (

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -2225,21 +2225,27 @@ class TestForceField:
         force_field.label_molecules(Molecule.from_smiles("CF").to_topology())
 
     def test_issue_1422(self):
-        """ Inherited plugin VirtualSite handlers should be detected
+        """Inherited plugin VirtualSite handlers should be detected
         and treated like VirtualSites
 
         https://github.com/openforcefield/openff-toolkit/issues/1422
         """
+
         class PluginVirtualSites(VirtualSiteHandler):
             _TAGNAME = "InheritedTestVirtualSites"
 
             def _find_matches(
-                    self,
-                    entity: Topology,
-                    transformed_dict_cls=dict,
-                    unique=False,
+                self,
+                entity: Topology,
+                transformed_dict_cls=dict,
+                unique=False,
             ) -> Dict[Tuple[int], List[ParameterHandler._Match]]:
-                return {(0,): [ParameterHandler._Match(None, None), ParameterHandler._Match(None, None)]}
+                return {
+                    (0,): [
+                        ParameterHandler._Match(None, None),
+                        ParameterHandler._Match(None, None),
+                    ]
+                }
 
         force_field = ForceField()
         force_field.get_parameter_handler("InheritedTestVirtualSites")

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -1489,9 +1489,6 @@ class ForceField:
             for tag, parameter_handler in self._parameter_handlers.items():
                 param_is_list = False
 
-                if type(parameter_handler) == VirtualSiteHandler:
-                    param_is_list = True
-
                 matches = parameter_handler.find_matches(top_mol)
                 # Remove the chemical environment matches from the
                 # matched results.
@@ -1505,6 +1502,8 @@ class ForceField:
 
                 # Now make parameter_matches into a dict mapping
                 # match objects to ParameterTypes
+
+                param_is_list = isinstance(parameter_handler, VirtualSiteHandler)
 
                 if param_is_list:
                     for match in matches:


### PR DESCRIPTION
This removes a bug which is the dependence on the order of the list. Ie when param_is_list is set to true, it stays true for each next handler. 

Is one way to addresses #1422 with minimal changes

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
