### PR TITLE
Remove SMIRKS validation checks in `ForceField` construction

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -18,7 +18,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   `attach_units`, `detach_units`, and `extract_serialized_units_from_dict` have been removed from
   `openff.toolkit.utils.utils`.
 - [PR #1472](https://github.com/openforcefield/openff-toolkit/pull/1472):
-  Removes [`ParmaeterHandler._VALENCE_TYPE`] and the same attribute of its subclasses, which were
+  Removes [`ParameterHandler._VALENCE_TYPE`] and the same attribute of its subclasses, which were
   previously not used. Also deprecates `ChemicalEnvironment` and, by extension, the
   `openff.toolkit.typing.chemistry` submodule.
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -17,6 +17,14 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   the built-in `dict`.
   `attach_units`, `detach_units`, and `extract_serialized_units_from_dict` have been removed from
   `openff.toolkit.utils.utils`.
+- [PR #1472](https://github.com/openforcefield/openff-toolkit/pull/1472):
+  Removes [`ParmaeterHandler._VALENCE_TYPE`] and the same attribute of its subclasses, which were
+  previously not used. Also deprecates `ChemicalEnvironment` and, by extension, the
+  `openff.toolkit.typing.chemistry` submodule.
+
+[`ChemicalEnvironment`]: ChemicalEnvironment
+[`ParameterHandler._VALENCE_TYPE`]: ParameterHandler._VALENCE_TYPE
+
 
 ### Bugfixes
 - [PR #1476](https://github.com/openforcefield/openff-toolkit/pull/1476): Fixes

--- a/openff/toolkit/tests/test_chemicalenvironment.py
+++ b/openff/toolkit/tests/test_chemicalenvironment.py
@@ -28,6 +28,14 @@ else:
 
 
 class TestChemicalEnvironments:
+    def test_deprecation_warning(self):
+        from openff.toolkit.typing.chemistry.environment import (
+            ChemicalEnvironmentDeprecationWarning,
+        )
+
+        with pytest.warns(ChemicalEnvironmentDeprecationWarning):
+            ChemicalEnvironment("[*:1]")
+
     def test_createEnvironments(self):
         """
         Test all types of ChemicalEnvironment objects with defined atoms and bonds

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -2870,6 +2870,13 @@ class TestMolecule:
 
         assert molecule == molecule_copy
 
+    def test_chemical_environment_old_arg(self):
+        from openff.toolkit.typing.chemistry import ChemicalEnvironment
+
+        molecule = create_ethanol()
+        with pytest.raises(ValueError, match="'query' must be a SMARTS"):
+            molecule.chemical_environment_matches(ChemicalEnvironment("[*:1]"))
+
     @requires_openeye
     def test_chemical_environment_matches_OE(self):
         """Test chemical environment matches"""

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -890,7 +890,6 @@ class TestMolecule:
 
     # TODO: Should there be an equivalent toolkit test and leave this as an integration test?
     @requires_openeye
-    @pytest.mark.slow
     def test_create_from_file(self):
         """Test standard constructor taking a filename or file-like object."""
         # TODO: Expand test to both openeye and rdkit toolkits
@@ -914,7 +913,11 @@ class TestMolecule:
         # Ensure that attempting to initialize a single Molecule from a file
         # containing multiple molecules raises a ValueError
         filename = get_data_file_path("molecules/butane_multi.sdf")
-        with pytest.raises(ValueError):
+
+        with pytest.raises(
+            ValueError,
+            match="Specified file or file-like.*exactly one molecule",
+        ):
             Molecule(filename, allow_undefined_stereo=True)
 
     def test_from_pathlib_path(self):

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -41,7 +41,6 @@ from openff.utilities import requires_package
 from openff.toolkit.topology import Molecule
 from openff.toolkit.topology._mm_molecule import _SimpleBond, _SimpleMolecule
 from openff.toolkit.topology.molecule import FrozenMolecule, HierarchyElement
-from openff.toolkit.typing.chemistry import ChemicalEnvironment
 from openff.toolkit.utils import quantity_to_string, string_to_quantity
 from openff.toolkit.utils.exceptions import (
     AtomNotInTopologyError,
@@ -991,9 +990,9 @@ class Topology(Serializable):
 
     def chemical_environment_matches(
         self,
-        query,
-        aromaticity_model="MDL",
-        unique=False,
+        query: str,
+        aromaticity_model: str = "MDL",
+        unique: bool = False,
         toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
     ):
         """
@@ -1006,9 +1005,8 @@ class Topology(Serializable):
 
         Parameters
         ----------
-        query : str or ChemicalEnvironment
-            SMARTS string (with one or more tagged atoms) or ``ChemicalEnvironment`` query
-            Query will internally be resolved to SMARTS using ``query.as_smarts()`` if it has an ``.as_smarts`` method.
+        query : str
+            SMARTS string (with one or more tagged atoms)
         aromaticity_model : str
             Override the default aromaticity model for this topology and use the specified aromaticity model instead.
             Allowed values: ['MDL']
@@ -1021,10 +1019,8 @@ class Topology(Serializable):
         """
 
         # Render the query to a SMARTS string
-        if type(query) is str:
+        if isinstance(query, str):
             smarts = query
-        elif type(query) is ChemicalEnvironment:
-            smarts = query.as_smarts()
         else:
             raise ValueError(
                 f"Don't know how to convert query '{query}' into SMARTS string"

--- a/openff/toolkit/typing/chemistry/environment.py
+++ b/openff/toolkit/typing/chemistry/environment.py
@@ -23,10 +23,15 @@ __all__ = [
     "ImproperChemicalEnvironment",
 ]
 
+import warnings
 from typing import Optional
 
 from openff.toolkit.utils.exceptions import SMIRKSMismatchError, SMIRKSParsingError
 from openff.toolkit.utils.toolkits import GLOBAL_TOOLKIT_REGISTRY, ToolkitWrapper
+
+
+class ChemicalEnvironmentDeprecationWarning(UserWarning):
+    """Warning for deprecated portions of the Molecule API."""
 
 
 class ChemicalEnvironment:
@@ -68,6 +73,13 @@ class ChemicalEnvironment:
             if smirks did not have expected connectivity between tagged atoms
             and validate_valence_type=True
         """
+        warnings.warn(
+            "ChemicalEnvironment is deprecated and will be removed in a future "
+            "release. If you rely on the functionality in this class, please "
+            "open an issue on the openff-toolkit GitHub.",
+            ChemicalEnvironmentDeprecationWarning,
+        )
+
         # Support string input for toolkit names for legacy reasons
         if toolkit_registry == "openeye":
             from openff.toolkit.utils.toolkits import OpenEyeToolkitWrapper

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -76,7 +76,6 @@ from packaging.version import Version
 
 from openff.toolkit.topology import ImproperDict, TagSortedDict, Topology, ValenceDict
 from openff.toolkit.topology.molecule import Molecule
-from openff.toolkit.typing.chemistry import ChemicalEnvironment
 from openff.toolkit.utils.collections import ValidatedDict, ValidatedList
 from openff.toolkit.utils.exceptions import (
     DuplicateParameterError,
@@ -1626,12 +1625,11 @@ class ParameterType(_ParameterAttributeHandler):
     --------
 
     This class allows to define new parameter types by just listing its
-    attributes. In the example below, ``_VALENCE_TYPE`` AND ``_ELEMENT_NAME``
-    are used for the validation of the SMIRKS pattern associated to the
-    parameter and the automatic serialization/deserialization into a ``dict``.
+    attributes. In the example below, ``_ELEMENT_NAME`` is used to
+    describe the SMIRNOFF parameter being defined, and is used during
+    automatic serialization/deserialization into a ``dict``.
 
     >>> class MyBondParameter(ParameterType):
-    ...     _VALENCE_TYPE = 'Bond'
     ...     _ELEMENT_NAME = 'Bond'
     ...     length = ParameterAttribute(unit=unit.angstrom)
     ...     k = ParameterAttribute(unit=unit.kilocalorie / unit.mole / unit.angstrom**2)
@@ -1660,7 +1658,6 @@ class ParameterType(_ParameterAttributeHandler):
     argument or through the decorator syntax.
 
     >>> class MyParameterType(ParameterType):
-    ...     _VALENCE_TYPE = 'Atom'
     ...     _ELEMENT_NAME = 'Atom'
     ...
     ...     attr_optional = ParameterAttribute(default=2)
@@ -1700,7 +1697,6 @@ class ParameterType(_ParameterAttributeHandler):
     is performed for each indexed attribute.
 
     >>> class MyTorsionType(ParameterType):
-    ...     _VALENCE_TYPE = 'ProperTorsion'
     ...     _ELEMENT_NAME = 'Proper'
     ...     periodicity = IndexedParameterAttribute(converter=int)
     ...     k = IndexedParameterAttribute(unit=unit.kilocalorie / unit.mole)
@@ -1725,8 +1721,6 @@ class ParameterType(_ParameterAttributeHandler):
 
     """
 
-    # ChemicalEnvironment valence type string expected by SMARTS string for this Handler
-    _VALENCE_TYPE: Optional[str] = None
     # The string mapping to this ParameterType in a SMIRNOFF data source
     _ELEMENT_NAME: Optional[str] = None
 
@@ -1734,17 +1728,6 @@ class ParameterType(_ParameterAttributeHandler):
     smirks = ParameterAttribute()
     id = ParameterAttribute(default=None)
     parent_id = ParameterAttribute(default=None)
-
-    @smirks.converter
-    def smirks(self, attr, smirks):
-        # Validate the SMIRKS string to ensure it matches the expected
-        # parameter type, raising an exception if it is invalid or doesn't
-        # tag a valid set of atoms.
-
-        # TODO: Add check to make sure we can't make tree non-hierarchical
-        #       This would require parameter type knows which ParameterList it belongs to
-        ChemicalEnvironment.validate_smirks(smirks, validate_valence_type=True)
-        return smirks
 
     def __init__(self, smirks, allow_cosmetic_attributes=False, **kwargs):
         """
@@ -2407,7 +2390,6 @@ class ConstraintHandler(ParameterHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        _VALENCE_TYPE = "Bond"
         _ELEMENT_NAME = "Constraint"
 
         distance = ParameterAttribute(default=None, unit=unit.angstrom)
@@ -2429,8 +2411,6 @@ class BondHandler(ParameterHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        # ChemicalEnvironment valence type string expected by SMARTS string for this Handler
-        _VALENCE_TYPE = "Bond"
         _ELEMENT_NAME = "Bond"
 
         length = ParameterAttribute(default=None, unit=unit.angstrom)
@@ -2569,7 +2549,6 @@ class AngleHandler(ParameterHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        _VALENCE_TYPE = "Angle"  # ChemicalEnvironment valence type string expected by SMARTS string for this Handler
         _ELEMENT_NAME = "Angle"
 
         angle = ParameterAttribute(unit=unit.degree)
@@ -2615,7 +2594,6 @@ class ProperTorsionHandler(ParameterHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        _VALENCE_TYPE = "ProperTorsion"
         _ELEMENT_NAME = "Proper"
 
         periodicity = IndexedParameterAttribute(converter=int)
@@ -2690,7 +2668,6 @@ class ImproperTorsionHandler(ParameterHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        _VALENCE_TYPE = "ImproperTorsion"
         _ELEMENT_NAME = "Improper"
 
         periodicity = IndexedParameterAttribute(converter=int)
@@ -2774,7 +2751,6 @@ class vdWHandler(_NonbondedHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        _VALENCE_TYPE = "Atom"  # ChemicalEnvironment valence type expected for SMARTS
         _ELEMENT_NAME = "Atom"
 
         epsilon = ParameterAttribute(unit=unit.kilocalorie / unit.mole)
@@ -3105,7 +3081,6 @@ class LibraryChargeHandler(_NonbondedHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        _VALENCE_TYPE = None  # This disables the connectivity check when parsing LibraryChargeType objects
         _ELEMENT_NAME = "LibraryCharge"
 
         name = ParameterAttribute(default=None)
@@ -3221,7 +3196,6 @@ class ChargeIncrementModelHandler(_NonbondedHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        _VALENCE_TYPE = None  # This disables the connectivity check when parsing LibraryChargeType objects
         _ELEMENT_NAME = "ChargeIncrement"
 
         charge_increment = IndexedParameterAttribute(unit=unit.elementary_charge)
@@ -3315,7 +3289,6 @@ class GBSAHandler(ParameterHandler):
         .. warning :: This API is experimental and subject to change.
         """
 
-        _VALENCE_TYPE = "Atom"
         _ELEMENT_NAME = "Atom"
 
         radius = ParameterAttribute(unit=unit.angstrom)
@@ -3391,7 +3364,6 @@ class VirtualSiteHandler(_NonbondedHandler):
 
     class VirtualSiteType(vdWHandler.vdWType):
 
-        _VALENCE_TYPE = None  # type: ignore[assignment]
         _ELEMENT_NAME = "VirtualSite"
 
         name = ParameterAttribute(default="EP", converter=str)

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -167,6 +167,7 @@ class SMIRKSMismatchError(OpenFFToolkitException):
     """
 
 
+# TODO: This should be renamed to SMARTSParsingError
 class SMIRKSParsingError(OpenFFToolkitException):
     """
     Exception for when SMIRKS are not parseable for any environment


### PR DESCRIPTION
#1473
- [x] Remove `ParameterHandler._VALENCE_TYPE` and equivalents in subclasses
- [x] Deprecates `ChemicalEnvironment`
- [x] Updates `Molecule.strip_atom_stereochemistry` to not use `AtomChemicalEnvironment`
- [x] Updates `Topology.chemical_environment_matches` to not accept a `ChemicalEnvironment`
- [x] Re-routes some exceptions that were imported from aliases
- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
