### PR TITLE
Require `Atom.atomic_numbers` is a positive integer

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -10,8 +10,12 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Bugfixes
 - [PR #1476](https://github.com/openforcefield/openff-toolkit/pull/1476): Fixes
-  [#1475](https://github.com/openforcefield/openff-toolkit/issues/1475), by also registering
+  [#1475](https://github.com/openforcefield/openff-toolkit/issues/1475) by also registering
   a `ParameterHandler`'s class when calling `ForceField.register_parameter_handler`.
+- [PR #1480](https://github.com/openforcefield/openff-toolkit/pull/1480): Fixes
+  [#1479](https://github.com/openforcefield/openff-toolkit/issues/1479) by requiring that `Atom.atomic_number` is a positive integer.
+
+[`Atom.atomic_number`]: Atom.atomic_number
 
 
 ## 0.11.4 Bugfix release

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -286,6 +286,19 @@ class TestAtom:
         atom1 = Atom(6, 1 * unit.elementary_charge, False)
         assert atom1.formal_charge == 1 * unit.elementary_charge
 
+    def test_init_invalid_atoms(self):
+        with pytest.raises(ValueError, match="must be int"):
+            Atom(0.5, 0, False)
+
+        with pytest.raises(ValueError, match="must be int"):
+            Atom(1 / 2, 0, False)
+
+        with pytest.raises(ValueError, match="must be positive"):
+            Atom(0, 0, False)
+
+        with pytest.raises(ValueError, match="must be positive"):
+            Atom(-1, 0, False)
+
     @pytest.mark.parametrize("atomic_number", range(1, 117))
     def test_atom_properties(self, atomic_number):
         """Test that atom properties are correctly populated and gettable"""

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -208,7 +208,7 @@ class Atom(Particle):
         Parameters
         ----------
         atomic_number : int
-            Atomic number of the atom, assumed to be non-zero
+            Atomic number of the atom. Must be non-negative and non-zero.
         formal_charge : int or openff.units.unit.Quantity-wrapped int with dimension "charge"
             Formal charge of the atom
         is_aromatic : bool

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -215,7 +215,7 @@ class Atom(Particle):
         Parameters
         ----------
         atomic_number : int
-            Atomic number of the atom
+            Atomic number of the atom, assumed to be non-zero
         formal_charge : int or openff.units.unit.Quantity-wrapped int with dimension "charge"
             Formal charge of the atom
         is_aromatic : bool

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -182,13 +182,10 @@ class Atom(Particle):
 
     .. todo::
 
-       * Should ``Atom`` objects be immutable or mutable?
        * Do we want to support the addition of arbitrary additional properties,
          such as floating point quantities (e.g. ``charge``), integral
          quantities (such as ``id`` or ``serial`` index in a PDB file),
          or string labels (such as Lennard-Jones types)?
-
-    .. todo :: Allow atoms to have associated properties.
 
     .. warning :: This API is experimental and subject to change.
     """
@@ -207,10 +204,6 @@ class Atom(Particle):
         Create an immutable Atom object.
 
         Object is serializable and immutable.
-
-        .. todo :: Use attrs to validate?
-
-        .. todo :: We can add setters if we need to.
 
         Parameters
         ----------
@@ -274,6 +267,7 @@ class Atom(Particle):
     # TODO: Should stereochemistry be reset/cleared/recomputed upon addition of a bond?
     def add_bond(self, bond):
         """Adds a bond that this atom is involved in
+
         .. todo :: Is this how we want to keep records?
 
         Parameters
@@ -286,13 +280,11 @@ class Atom(Particle):
 
     def to_dict(self):
         """Return a dict representation of the atom."""
-        # TODO
         atom_dict = OrderedDict()
         atom_dict["atomic_number"] = self._atomic_number
         atom_dict["formal_charge"] = self._formal_charge.m_as(unit.elementary_charge)
         atom_dict["is_aromatic"] = self._is_aromatic
         atom_dict["stereochemistry"] = self._stereochemistry
-        # TODO: Should we let atoms have names?
         atom_dict["name"] = self._name
         atom_dict["metadata"] = dict(self._metadata)
         # TODO: Should this be implicit in the atom ordering when saved?
@@ -452,8 +444,6 @@ class Atom(Particle):
             )
         self._name = other
 
-    # TODO: How are we keeping track of bonds, angles, etc?
-
     @property
     def bonds(self):
         """
@@ -461,11 +451,8 @@ class Atom(Particle):
 
         """
         return self._bonds
-        # for bond in self._bonds:
-        #    yield bond
 
     @property
-    # def bonded_to(self):
     def bonded_atoms(self):
         """
         The list of ``Atom`` objects this atom is involved in bonds with

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -241,7 +241,13 @@ class Atom(Particle):
         >>> atom = Atom(6, 0, False, stereochemistry='R', name='CT')
 
         """
+        if not isinstance(atomic_number, int):
+            raise ValueError(f"atomic number must be int, found {type(atomic_number)}")
+        if atomic_number <= 0:
+            raise ValueError(f"atomic number must be positive, given {atomic_number}.")
+
         self._atomic_number = atomic_number
+
         # Use the setter here, since it will handle either ints or Quantities
         if hasattr(formal_charge, "units"):
             # Faster check than ` == unit.dimensionless`


### PR DESCRIPTION
#1479 

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
