### PR TITLE
Support mapped SMILES in `from_smiles` with minimal guarantees

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -14,6 +14,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   the built-in `dict`.
   `attach_units`, `detach_units`, and `extract_serialized_units_from_dict` have been removed from
   `openff.toolkit.utils.utils`.
+- [PR #1482](https://github.com/openforcefield/openff-toolkit/pull/1482): `Molecule.from_smiles()` now attempts to order atoms according to the provided mapping. If atom order is important, we continue to recommend `from_mapped_smiles`, which will raise an exception if the map is incomplete or invalid.
 
 ### Bugfixes
 - [PR #1476](https://github.com/openforcefield/openff-toolkit/pull/1476): Fixes

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -2494,7 +2494,7 @@ class TestMolecule:
             pytest.skip(f"Required toolkit {toolkit_class} is unavailable")
         with pytest.raises(
             SmilesParsingError,
-            match="The mapped smiles does not contain enough indexes",
+            match="The mapped SMILES has missing, duplicate, or out-of-range indices.",
         ):
             Molecule.from_mapped_smiles("[Cl:1][Cl]", toolkit_registry=toolkit_class())
 

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -3613,6 +3613,8 @@ class TestMoleculeAttemptRemap:
         """
         molecule = Molecule.from_mapped_smiles("[C@:1]([F:2])([Cl:3])([Br:4])[I:5]")
 
+        mapping = {k: v + 1 for k, v in mapping.items()}
+
         molecule.properties["atom_map"] = mapping
 
         remapped = molecule._attempt_remap_from_properties()
@@ -3653,6 +3655,8 @@ class TestMoleculeAttemptRemap:
         """
         molecule = Molecule.from_mapped_smiles("[C@:1]([F:2])([Cl:3])([Br:4])[I:5]")
 
+        mapping = {k: v + 1 for k, v in mapping.items()}
+
         molecule.properties["atom_map"] = mapping
 
         remapped = molecule._attempt_remap_from_properties()
@@ -3685,6 +3689,8 @@ class TestMoleculeAttemptRemap:
         original atom map with keys updated to their new positions."
         """
         molecule = Molecule.from_mapped_smiles("[C@:1]([F:2])([Cl:3])([Br:4])[I:5]")
+
+        mapping = {k: v + 1 for k, v in mapping.items()}
 
         molecule.properties["atom_map"] = mapping
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1731,7 +1731,13 @@ class FrozenMolecule(Serializable):
         allow_undefined_stereo=False,
     ):
         """
-        Construct a Molecule from a SMILES representation
+        Construct a Molecule from a SMILES representation.
+
+        This method will attempt to order the atoms in the created molecule
+        according to the SMILES' atom mapping, but will not raise an exception
+        if it fails. If atom order is important, use
+        the :py:meth:`from_mapped_smiles` method instead, which ensures that the
+        atom mapping assigns every atom exactly one index.
 
         Parameters
         ----------
@@ -1751,10 +1757,19 @@ class FrozenMolecule(Serializable):
         -------
         molecule : openff.toolkit.topology.Molecule
 
+        Raises
+        ------
+        RadicalsNotSupportedError
+            If any atoms in the RDKit molecule contain radical electrons.
+
         Examples
         --------
 
         >>> molecule = Molecule.from_smiles('Cc1ccccc1')
+
+        See also
+        --------
+        Molecule.from_mapped_smiles
 
         """
         if isinstance(toolkit_registry, ToolkitRegistry):
@@ -4666,11 +4681,10 @@ class FrozenMolecule(Serializable):
         pairs that reside entirely within the molecule. The new molecule's atom
         map is the original atom map with keys updated to their new positions.
 
-        .. warning :: Garbage in, garbage out
-
-            This method may not do what you expect if the atom map is malformed.
-            If you want to raise an exception in case of a malformed atom map,
-            use :py:meth`Molecule.remap` instead.
+        .. warning :: This method  may not provide the ordering you expect if
+           the atom map is malformed (garbage in, garbage out). If you want to
+           raise an exception in case of a malformed atom map,
+           use :py:meth:`Molecule.remap` instead.
 
         """
         # Set up the source and destination maps

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -4415,17 +4415,19 @@ class FrozenMolecule(Serializable):
                 "mapped SMILES using cmiles."
             )
 
-        if len(mapping) != offmol.n_atoms:
+        # If the mapping is anything other than every atom mapped to itself, the
+        # remapping was invalid (because it means from_smiles failed to reorder
+        # the atoms according to the atom map). If the mapping is every atom
+        # mapped to itself, the map was valid (because there are no duplicate
+        # destination indices, no missing indices, and no out-of-range indices).
+        # Therefore, the mapping is every atom mapped to itself if and only if
+        # the mapping was valid.
+        if mapping != {i: i for i in range(offmol.n_atoms)}:
             raise SmilesParsingError(
-                "The mapped smiles does not contain enough indexes to remap the molecule."
+                "The mapped SMILES has missing, duplicate, or out-of-range indices."
             )
 
-        # remap the molecule using the atom map found in the smiles
-        # the order is mapping = Dict[current_index: new_index]
-        # first renumber the mapping dict indexed from 0, currently from 1 as 0 indicates no mapping in toolkits
-        adjusted_mapping = dict((current, new - 1) for current, new in mapping.items())
-
-        return offmol.remap(adjusted_mapping, current_to_new=True)
+        return offmol
 
     @classmethod
     @requires_package("qcelemental")

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -4421,8 +4421,9 @@ class FrozenMolecule(Serializable):
         # mapped to itself, the map was valid (because there are no duplicate
         # destination indices, no missing indices, and no out-of-range indices).
         # Therefore, the mapping is every atom mapped to itself if and only if
-        # the mapping was valid.
-        if mapping != {i: i for i in range(offmol.n_atoms)}:
+        # the mapping was valid. Source indices are 0-indexed, but destination
+        # indices are 1-indexed.
+        if mapping != {i: i + 1 for i in range(offmol.n_atoms)}:
             raise SmilesParsingError(
                 "The mapped SMILES has missing, duplicate, or out-of-range indices."
             )
@@ -4695,6 +4696,8 @@ class FrozenMolecule(Serializable):
 
         # Place the first valid mapping for each atom into the new mapping
         for k, v in atom_map.items():
+            # SMILES maps are 1-indexed, but remap must be 0-indexed
+            v = v - 1
             if (
                 k < self.n_atoms
                 and v < self.n_atoms

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1760,7 +1760,7 @@ class FrozenMolecule(Serializable):
         Raises
         ------
         RadicalsNotSupportedError
-            If any atoms in the RDKit molecule contain radical electrons.
+            If any atoms in the input molecule contain radical electrons.
 
         Examples
         --------

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1916,6 +1916,14 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         """
         Create a Molecule from a SMILES string using the OpenEye toolkit.
 
+        This method will attempt to order the atoms in the created molecule
+        according to the SMILES' atom mapping, but will not raise an exception
+        if it fails. If atom order is important, use the
+        :py:meth:`Molecule.from_mapped_smiles()
+        <openff.toolkit.topology.Molecule.from_mapped_smiles>` method instead,
+        which ensures that the atom mapping assigns every atom exactly one
+        index.
+
         .. warning :: This API is experimental and subject to change.
 
         Parameters
@@ -1938,7 +1946,12 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         Raises
         ------
-        RadicalsNotSupportedError : If any atoms in the OpenEye molecule contain radical electrons.
+        RadicalsNotSupportedError
+            If any atoms in the OpenEye molecule contain radical electrons.
+
+        See also
+        --------
+        Molecule.from_mapped_smiles
         """
         from openeye import oechem
 

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1966,7 +1966,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         molecule = self.from_openeye(
             oemol, _cls=_cls, allow_undefined_stereo=allow_undefined_stereo
-        )
+        )._attempt_remap_from_properties()
         return molecule
 
     def from_inchi(self, inchi, allow_undefined_stereo=False, _cls=None):

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -932,6 +932,14 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         """
         Create a Molecule from a SMILES string using the RDKit toolkit.
 
+        This method will attempt to order the atoms in the created molecule
+        according to the SMILES' atom mapping, but will not raise an exception
+        if it fails. If atom order is important, use the
+        :py:meth:`Molecule.from_mapped_smiles()
+        <openff.toolkit.topology.Molecule.from_mapped_smiles>` method instead,
+        which ensures that the atom mapping assigns every atom exactly one
+        index.
+
         .. warning :: This API is experimental and subject to change.
 
         Parameters
@@ -954,7 +962,12 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         Raises
         ------
-        RadicalsNotSupportedError : If any atoms in the RDKit molecule contain radical electrons.
+        RadicalsNotSupportedError
+            If any atoms in the RDKit molecule contain radical electrons.
+
+        See also
+        --------
+        Molecule.from_mapped_smiles
         """
         from rdkit import Chem
 

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -1009,7 +1009,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
             _cls=_cls,
             allow_undefined_stereo=allow_undefined_stereo,
             hydrogens_are_explicit=hydrogens_are_explicit,
-        )
+        )._attempt_remap_from_properties()
 
         return molecule
 


### PR DESCRIPTION
This PR adds a best-effort approach to supporting mapped SMILES in the `from_smiles` method. This hopefully reduces the common "oops, I forgot `from_mapped_smiles` exists" mistake. It also adds documentation to `from_smiles` recommending the use of `from_mapped_smiles` when atom ordering is important. It carefully makes no guarantees (except in the private implementing method) about this behavior and suggests that users not rely on it. Obviously users probably will rely on it and we won't be able to change it later, but at least offering exceptions for broken maps gives people an incentive to use `from_mapped_smiles` (which is also now more discoverable). The atom map property is kept and updated for the new atom ordering.

This is not a breaking change, as the changed behavior was not previously specified.

Commits 7c2914e and 437bf38 are optional. They simplify `from_mapped_smiles` to avoid a second call to `remap`. This modifies the exceptions raised when an invalid mapping is provided to `from_mapped_smiles` to be less specific, which may not be desirable.

This change incidentally simplifies the use of partial maps:

```diff
mol = Molecule.from_smiles("[H][O:1][H]")
- mol = mol.remap(mol.properties["atom_map"])
- del mol.properties["atom_map"]

```

Closes #1439, closes #1186.

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
