### PR TITLE
Simplify RDKit stereochemistry warnings

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -24,6 +24,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 [`Atom.atomic_number`]: Atom.atomic_number
 
+### Improved documentation and warnings
+- [PR #1483](https://github.com/openforcefield/openff-toolkit/pull/1483): Simplified and clarified errors and warnings related to undefined stereochemistry with RDKit.
+
 
 ## 0.11.4 Bugfix release
 

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -2571,7 +2571,12 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         return undefined_bond_indices
 
     @classmethod
-    def _detect_undefined_stereo(cls, rdmol, err_msg_prefix="", raise_warning=False):
+    def _detect_undefined_stereo(
+        cls,
+        rdmol,
+        err_msg_prefix="",
+        raise_warning=False,
+    ):
         """Raise UndefinedStereochemistryError if the RDMol has undefined stereochemistry.
 
         Parameters
@@ -2579,7 +2584,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         rdmol : rdkit.Chem.Mol
             The RDKit molecule.
         err_msg_prefix : str, optional
-            A string to prepend to the error/warning message.
+            A string to prepend to the error message (but not the warning).
         raise_warning : bool, optional, default=False
             If True, a warning is issued instead of an exception.
 
@@ -2597,7 +2602,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         if len(undefined_atom_indices) == 0 and len(undefined_bond_indices) == 0:
             msg = None
         else:
-            msg = err_msg_prefix + "RDMol has unspecified stereochemistry. "
+            msg = "RDMol has unspecified stereochemistry. "
             # The "_Name" property is not always assigned.
             if rdmol.HasProp("_Name"):
                 msg += "RDMol name: " + rdmol.GetProp("_Name")
@@ -2630,7 +2635,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
                 msg = "Warning (not error because allow_undefined_stereo=True): " + msg
                 logger.warning(msg)
             else:
-                msg = "Unable to make OFFMol from RDMol: " + msg
+                msg = err_msg_prefix + msg
                 raise UndefinedStereochemistryError(msg)
 
     @staticmethod


### PR DESCRIPTION
This PR clarifies and simplifies errors and warnings related to undefined stereochemistry with RDKit. Closes #857.

Before: 
```python
>>> from openff.toolkit import Molecule, RDKitToolkitWrapper
>>> Molecule.from_smiles(
...     "C(F)(Cl)(Br)", 
...     allow_undefined_stereo=True, 
...     toolkit_registry=RDKitToolkitWrapper()
... )
Warning (not error because allow_undefined_stereo=True): Unable to make OFFMol from RDMol: RDMol has unspecified stereochemistry. Undefined chiral centers are:
 - Atom C (index 0)

>>> from openff.toolkit import Molecule, RDKitToolkitWrapper
>>> Molecule.from_smiles(
...     "C(F)(Cl)(Br)", 
...     allow_undefined_stereo=False, 
...     toolkit_registry=RDKitToolkitWrapper()
... )
Traceback (most recent call last)...
UndefinedStereochemistryError: Unable to make OFFMol from RDMol: Unable to make OFFMol from SMILES: RDMol has unspecified stereochemistry. Undefined chiral centers are:
 - Atom C (index 0)

>>> from rdkit.Chem import MolFromSmiles
>>> rdmol = MolFromSmiles("C(F)(Cl)(Br)")
>>>
>>> Molecule.from_rdkit(rdmol, allow_undefined_stereo=True)
Warning (not error because allow_undefined_stereo=True): Unable to make OFFMol from RDMol: RDMol has unspecified stereochemistry. Undefined chiral centers are:
 - Atom C (index 0)

>>> Molecule.from_rdkit(rdmol, allow_undefined_stereo=False)
Traceback (most recent call last)...
UndefinedStereochemistryError: Unable to make OFFMol from RDMol: Unable to make OFFMol from RDMol: RDMol has unspecified stereochemistry. Undefined chiral centers are:
 - Atom C (index 0)

```

After: 
```python
>>> from openff.toolkit import Molecule, RDKitToolkitWrapper
>>> Molecule.from_smiles(
...     "C(F)(Cl)(Br)", 
...     allow_undefined_stereo=True, 
...     toolkit_registry=RDKitToolkitWrapper()
... )
Warning (not error because allow_undefined_stereo=True): RDMol has unspecified stereochemistry. Undefined chiral centers are:
 - Atom C (index 0)

>>> from openff.toolkit import Molecule, RDKitToolkitWrapper
>>> Molecule.from_smiles(
...     "C(F)(Cl)(Br)", 
...     allow_undefined_stereo=False, 
...     toolkit_registry=RDKitToolkitWrapper()
... )
Traceback (most recent call last)...
UndefinedStereochemistryError: Unable to make OFFMol from SMILES: RDMol has unspecified stereochemistry. Undefined chiral centers are:
 - Atom C (index 0)

>>> from rdkit.Chem import MolFromSmiles
>>> rdmol = MolFromSmiles("C(F)(Cl)(Br)")
>>>
>>> Molecule.from_rdkit(rdmol, allow_undefined_stereo=True)
Warning (not error because allow_undefined_stereo=True): RDMol has unspecified stereochemistry. Undefined chiral centers are:
 - Atom C (index 0)

>>> Molecule.from_rdkit(rdmol, allow_undefined_stereo=False)
Traceback (most recent call last)...
UndefinedStereochemistryError: Unable to make OFFMol from RDMol: RDMol has unspecified stereochemistry. Undefined chiral centers are:
 - Atom C (index 0)

```

- [x] Tag issue being addressed
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
