### PR TITLE
`Topology.from_openmm` fixes

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -8,6 +8,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ## Current development
 
+### New features
+- [PR #1484](https://github.com/openforcefield/openff-toolkit/pull/1484): A `positions` argument has been added to `Topology.from_openmm()` and `Topology.from_mdtraj()`, which allows the topology's positions to be set more conveniently.
+
 ### Behavior changes
 - [PR #1466](https://github.com/openforcefield/openff-toolkit/pull/1466):
   Replaces the use of `collections.OrderedDict` throughout the toolkit with
@@ -24,6 +27,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 [`Atom.atomic_number`]: Atom.atomic_number
 
+### Improved documentation and warnings
+- [PR #1484](https://github.com/openforcefield/openff-toolkit/pull/1484): The docstrings for `Topology.from_openmm()` and `Topology.from_mdtraj()` have been improved
 
 ## 0.11.4 Bugfix release
 

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 import numpy as np
 import pytest
 from openff.units import unit
+from openff.units.openmm import from_openmm
 from openff.units.units import Quantity
 from openmm import app
 
@@ -511,9 +512,14 @@ class TestTopology:
 
         molecules = [create_ethanol(), create_cyclohexane()]
 
-        topology = Topology.from_openmm(pdbfile.topology, unique_molecules=molecules)
+        topology = Topology.from_openmm(
+            pdbfile.topology,
+            unique_molecules=molecules,
+            positions=pdbfile.positions,
+        )
         assert topology.n_molecules == 239
         assert topology.n_unique_molecules == 2
+        assert np.all(topology.get_positions() == from_openmm(pdbfile.positions))
         # Ensure that hierarchy iterators are initialized
         assert all(
             all([molecule.residues, molecule.chains]) for molecule in topology.molecules

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1865,13 +1865,13 @@ class Topology(Serializable):
         Topology. However it does not guarantee the order of the bonds will be
         the same.
 
-        Hierarchy schemes are taken from the OpenMM topology, not from
+        Hierarchy schemes are taken from the MDTraj topology, not from
         ``unique_molecules``.
 
         Parameters
         ----------
-        openmm_topology
-            The OpenMM Topology object to convert
+        mdtraj_topology
+            The MDTraj Topology object to convert
         unique_molecules
             An iterable containing all the unique molecules in the topology.
             This is used to identify the molecules in the MDTraj topology and

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1304,25 +1304,44 @@ class Topology(Serializable):
         """
         Construct an OpenFF Topology object from an OpenMM Topology object.
 
-        This method guarantees that the order of atoms in the input OpenMM Topology will be the same as the ordering
-        of atoms in the output OpenFF Topology. However it does not guarantee the order of the bonds will be the same.
+        This method guarantees that the order of atoms in the input OpenMM
+        Topology will be the same as the ordering of atoms in the output OpenFF
+        Topology. However it does not guarantee the order of the bonds will be
+        the same.
 
-        Hierarchy schemes are taken from the OpenMM topology, not from `unique_molecules`.
+        Hierarchy schemes are taken from the OpenMM topology, not from
+        ``unique_molecules``.
 
         Parameters
         ----------
-        openmm_topology : openmm.app.Topology
-            An OpenMM Topology object
-        unique_molecules : iterable of objects that can be used to construct unique Molecule objects
-            All unique molecules must be provided, in any order, though multiple copies of each molecule are allowed.
-            The atomic elements and bond connectivity will be used to match the reference molecules
-            to molecule graphs appearing in the OpenMM ``Topology``. If bond orders are present in the
-            OpenMM ``Topology``, these will be used in matching as well.
+        openmm_topology
+            The OpenMM Topology object to convert
+        unique_molecules
+            An iterable containing all the unique molecules in the topology.
+            This is used to identify the molecules in the OpenMM topology and
+            provide any missing chemical information. Each chemical species in
+            the topology must be specified exactly once, though the topology
+            may have any number of copies, including zero. The chemical
+            elements of atoms and their bond connectivity will be used to match
+            these reference molecules to the molecules appearing in the
+            topology. If bond orders are specified in the topology, these will
+            be used in matching as well.
 
         Returns
         -------
-        topology : openff.toolkit.topology.Topology
-            An OpenFF Topology object
+        topology
+            An OpenFF Topology object, constructed from the molecules in
+            ``unique_molecules``, with the same atom order as the input topology.
+
+        Raises
+        ------
+        MissingUniqueMoleculesError
+            If ``unique_molecules`` is ``None``
+        DuplicateUniqueMoleculeError
+            If the same connectivity graph is represented by two different
+            molecules in ``unique_molecules``
+        ValueError
+            If a chemically impossible molecule is detected in the topology
         """
         import networkx as nx
         from openff.units.openmm import from_openmm

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1301,7 +1301,7 @@ class Topology(Serializable):
         cls,
         openmm_topology: "openmm.app.Topology",
         unique_molecules: Optional[Iterable[FrozenMolecule]] = None,
-        positions: Union[None, Quantity, OMMQuantity] = None,
+        positions: Union[None, Quantity, "OMMQuantity"] = None,
     ) -> "Topology":
         """
         Construct an OpenFF Topology object from an OpenMM Topology object.
@@ -1854,7 +1854,7 @@ class Topology(Serializable):
         cls,
         mdtraj_topology: "mdtraj.Topology",
         unique_molecules: Optional[Iterable[FrozenMolecule]] = None,
-        positions: Union[None, OMMQuantity, Quantity] = None,
+        positions: Union[None, "OMMQuantity", Quantity] = None,
     ):
         """
         Construct an OpenFF ``Topology`` from an MDTraj ``Topology``

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -22,6 +22,7 @@ from typing import (
     TYPE_CHECKING,
     Dict,
     Generator,
+    Iterable,
     Iterator,
     List,
     Literal,
@@ -61,6 +62,7 @@ from openff.toolkit.utils.toolkits import (
 )
 
 if TYPE_CHECKING:
+    from openmm.app import Topology as OMMTopology
     from openmm.unit import Quantity as OMMQuantity
 
     from openff.toolkit.topology.molecule import Atom
@@ -1294,7 +1296,11 @@ class Topology(Serializable):
 
     @classmethod
     @requires_package("openmm")
-    def from_openmm(cls, openmm_topology, unique_molecules=None):
+    def from_openmm(
+        cls,
+        openmm_topology: "OMMTopology",
+        unique_molecules: Optional[Iterable[FrozenMolecule]] = None,
+    ) -> "Topology":
         """
         Construct an OpenFF Topology object from an OpenMM Topology object.
 

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -33,6 +33,7 @@ from typing import (
 )
 
 import numpy as np
+from networkx import Graph
 from numpy.typing import NDArray
 from openff.units import Quantity, ensure_quantity, unit
 from openff.utilities import requires_package
@@ -1366,7 +1367,7 @@ class Topology(Serializable):
 
         # Convert all unique mols to graphs
         topology = cls()
-        graph_to_unq_mol = {}
+        graph_to_unq_mol: Dict[Graph, FrozenMolecule] = {}
         for unq_mol in unique_molecules:
             unq_mol_graph = unq_mol.to_networkx()
             for existing_graph in graph_to_unq_mol.keys():

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -62,7 +62,7 @@ from openff.toolkit.utils.toolkits import (
 )
 
 if TYPE_CHECKING:
-    from openmm.app import Topology as OMMTopology
+    import openmm.app
     from openmm.unit import Quantity as OMMQuantity
 
     from openff.toolkit.topology.molecule import Atom
@@ -1298,7 +1298,7 @@ class Topology(Serializable):
     @requires_package("openmm")
     def from_openmm(
         cls,
-        openmm_topology: "OMMTopology",
+        openmm_topology: "openmm.app.Topology",
         unique_molecules: Optional[Iterable[FrozenMolecule]] = None,
     ) -> "Topology":
         """


### PR DESCRIPTION
Numerous changes to `Topology.from_openmm` and `Topology.from_mdtraj` (which is a thin wrapper around the former):
- Type annotations added to function signatures
- Docstrings expanded and corrected/clarified (closes #1248)
- `positions` argument added (closes #1478)

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
