### PR TITLE
Update test environments

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,7 @@ jobs:
       PYTEST_ARGS: -r fE --tb=short -nauto --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -90,7 +90,6 @@ jobs:
           ulimit -a
 
       - name: Make oe_license.txt file from GH org secret "OE_LICENSE"
-        shell: bash
         env:
           OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
         run: |
@@ -172,7 +171,7 @@ jobs:
           pytest -v --no-cov --doctest-modules --ignore=openff/toolkit/tests/ --ignore=openff/toolkit/data/ --ignore=openff/toolkit/utils/utils.py openff/
 
       - name: Codecov
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -1,6 +1,12 @@
 name: Weekly test against upstream beta and RC builds
 
 on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:

--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -75,6 +75,10 @@ jobs:
         run: |
           pytest -r fE --tb=short openff/toolkit/tests/test_links.py
 
+      - name: Run mypy
+        run: |
+          mypy --namespace-packages -p "openff.toolkit"
+
       - name: Run unit tests
         run: |
           PYTEST_ARGS+=" --ignore=openff/toolkit/tests/test_examples.py"
@@ -85,10 +89,6 @@ jobs:
       - name: Run code snippets in docs
         run: |
           pytest -v --doctest-glob="docs/*.rst" --doctest-glob="docs/*.md" docs/
-
-      - name: Run mypy
-        run: |
-          mypy --namespace-packages -p "openff.toolkit"
 
       - name: Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -1,12 +1,6 @@
 name: Weekly test against upstream beta and RC builds
 
 on:
-  push:
-    branches:
-      - "main"
-  pull_request:
-    branches:
-      - "main"
   schedule:
     - cron: "0 0 * * 0"
   workflow_dispatch:

--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -11,6 +11,10 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   test:
     name: Test beta and RC builds on on ${{ matrix.python-version }}
@@ -29,7 +33,7 @@ jobs:
       PYTEST_ARGS: -r fE --tb=short --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -41,21 +45,18 @@ jobs:
             python=${{ matrix.python-version }}
 
       - name: Additional info about the build
-        shell: bash -l {0}
         run: |
           uname -a
           df -h
           ulimit -a
 
       - name: Make oe_license.txt file from GH org secret "OE_LICENSE"
-        shell: bash
         env:
           OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
         run: |
           echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
 
       - name: Install package
-        shell: bash -l {0}
         run: |
           conda remove --force openff-toolkit openff-toolkit-base
           python setup.py develop --no-deps
@@ -66,18 +67,15 @@ jobs:
           python setup.py develop --no-deps
 
       - name: Environment Information
-        shell: bash -l {0}
         run: |
           conda info
           conda list
 
       - name: Check links
-        shell: bash -l {0}
         run: |
           pytest -r fE --tb=short openff/toolkit/tests/test_links.py
 
       - name: Run unit tests
-        shell: bash -l {0}
         run: |
           PYTEST_ARGS+=" --ignore=openff/toolkit/tests/test_examples.py"
           PYTEST_ARGS+=" --ignore=openff/toolkit/tests/test_links.py"
@@ -85,17 +83,15 @@ jobs:
           pytest $PYTEST_ARGS openff/toolkit/tests/
 
       - name: Run code snippets in docs
-        shell: bash -l {0}
         run: |
           pytest -v --doctest-glob="docs/*.rst" --doctest-glob="docs/*.md" docs/
 
       - name: Run mypy
-        shell: bash -l {0}
         run: |
           mypy --namespace-packages -p "openff.toolkit"
 
       - name: Codecov
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -60,6 +60,11 @@ jobs:
           conda remove --force openff-toolkit openff-toolkit-base
           python setup.py develop --no-deps
 
+      - name: Install test plugins
+        run: |
+          cd utilities/test_plugins
+          python setup.py develop --no-deps
+
       - name: Environment Information
         shell: bash -l {0}
         run: |

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -15,6 +15,10 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   test:
     name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}, OpenEye=${{ matrix.openeye }}
@@ -34,7 +38,7 @@ jobs:
       PACKAGE: openff-toolkit
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
 
       - name: Vanilla install from conda
         uses: mamba-org/provision-with-micromamba@main
@@ -52,27 +56,23 @@ jobs:
             python=${{ matrix.python-version }}
 
       - name: Additional info about the build
-        shell: bash -l {0}
         run: |
           uname -a
           df -h
           ulimit -a
 
       - name: Make oe_license.txt file from GH org secret "OE_LICENSE"
-        shell: bash
         env:
           OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
         run: |
           echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
 
       - name: Environment Information
-        shell: bash -l {0}
         run: |
           conda info
           conda list
 
       - name: Check installed toolkits
-        shell: bash -l {0}
         run: |
           # Checkout the state of the repo as of the last release (including RCs)
           export LATEST_TAG=$(git ls-remote --tags https://github.com/openforcefield/openff-toolkit.git | cut -f2 | grep -E "([0-9]+)\.([0-9]+)\.([0-9]+)$" | sort --version-sort | tail -1 | sed 's/refs\/tags\///')
@@ -91,7 +91,6 @@ jobs:
           fi
 
       - name: Check that correct OFFTK version was installed
-        shell: bash -l {0}
         run: |
           # Go up one directory to ensure that we don't just load the OFFTK from the checked-out repo
           cd ../
@@ -112,7 +111,6 @@ jobs:
           cd openff-toolkit
 
       - name: Test the package
-        shell: bash -l {0}
         run: |
           # Install test plugins
           cd utilities/test_plugins

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,12 +1,6 @@
 name: Conda latest
 
 on:
-  push:
-    branches:
-      - "main"
-  pull_request:
-    branches:
-      - "main"
   release:
     types:
       - released

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -1,6 +1,12 @@
 name: Conda latest
 
 on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
   release:
     types:
       - released

--- a/.github/workflows/conda_010X.yml
+++ b/.github/workflows/conda_010X.yml
@@ -1,12 +1,6 @@
 name: Conda 0.10.X
 
 on:
-  push:
-    branches:
-      - "main"
-  pull_request:
-    branches:
-      - "main"
   release:
     types:
       - released

--- a/.github/workflows/conda_010X.yml
+++ b/.github/workflows/conda_010X.yml
@@ -1,6 +1,12 @@
 name: Conda 0.10.X
 
 on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
   release:
     types:
       - released

--- a/.github/workflows/conda_010X.yml
+++ b/.github/workflows/conda_010X.yml
@@ -34,7 +34,7 @@ jobs:
       PACKAGE: openff-toolkit
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
 
       - name: Vanilla install from conda
         uses: mamba-org/provision-with-micromamba@main

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -41,7 +41,7 @@ jobs:
       NB_ARGS: -v --nbval-lax --ignore=examples/deprecated --durations=20
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
@@ -73,7 +73,6 @@ jobs:
           ulimit -a
 
       - name: Make oe_license.txt file from GH org secret "OE_LICENSE"
-        shell: bash
         env:
           OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
         run: |

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -20,7 +20,7 @@ jobs:
       PYVER: ${{ matrix.python-version }}
 
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v3
 
     - name: Install conda environment
       uses: mamba-org/provision-with-micromamba@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
         with:

--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -9,22 +9,27 @@ dependencies:
   - python
   - pip
   - packaging =21
-  - openmm >=7.6
-  - openff-forcefields
-  - openff-interchange
-  - smirnoff99Frosst
   - numpy
   - networkx
-  - ambertools
-  - rdkit
-  - xmltodict
   - cachetools
   - cached-property
+  - xmltodict
+  - python-constraint
+  - openmm >=7.6
+  - openff-forcefields
+  - smirnoff99Frosst
+  - openff-units >=0.2
+  - openff-utilities >=0.1.5
+  - openff-interchange-base >=0.2
+    # Toolkit-specific
+  - ambertools
+  - rdkit
+  - openeye-toolkits
     # Test-only/optional/dev
-  - mdtraj
   - pytest
   - pytest-cov
-  - openeye-toolkits
+  - pytest-xdist
+  - pytest-rerunfailures
   - pyyaml
   - toml
   - bson
@@ -32,9 +37,10 @@ dependencies:
   - qcelemental
   - qcportal >=0.15
   - qcengine
-  # Typing
+  - mdtraj
+  - parmed
+  - nbval
   - mypy
-  - typing-extensions
   - pip:
     - types-pkg_resources
     - types-setuptools

--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -8,25 +8,23 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging
+  - packaging =0.21
   - openmm >=7.6
   - openff-forcefields
+  - openff-interchange
   - smirnoff99Frosst
   - numpy
   - networkx
   - ambertools
   - rdkit
   - xmltodict
+  - cachetools
+  - cached-property
     # Test-only/optional/dev
   - mdtraj
   - pytest
   - pytest-cov
-  - nbval
-  - codecov
-  - coverage
   - openeye-toolkits
-  - cachetools
-  - cached-property
   - pyyaml
   - toml
   - bson
@@ -34,7 +32,6 @@ dependencies:
   - qcelemental
   - qcportal >=0.15
   - qcengine
-  - openff-interchange
   # Typing
   - mypy
   - typing-extensions

--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -8,7 +8,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =0.21
+  - packaging =21
   - openmm >=7.6
   - openff-forcefields
   - openff-interchange

--- a/devtools/conda-envs/conda.yaml
+++ b/devtools/conda-envs/conda.yaml
@@ -6,8 +6,6 @@ dependencies:
     # Base depends
   - openff-toolkit-examples
 
-  - openmmforcefields >=0.11.2
   - qcportal >=0.15
   - pytest
   - pytest-rerunfailures
-  - nbval

--- a/devtools/conda-envs/conda.yaml
+++ b/devtools/conda-envs/conda.yaml
@@ -1,11 +1,9 @@
 name: latest-deployment
 channels:
   - conda-forge
-
 dependencies:
     # Base depends
   - openff-toolkit-examples
-
-  - qcportal >=0.15
+    # Tests
   - pytest
   - pytest-rerunfailures

--- a/devtools/conda-envs/conda_010X.yaml
+++ b/devtools/conda-envs/conda_010X.yaml
@@ -7,8 +7,6 @@ dependencies:
     # Base depends
   - openff-toolkit-examples =0.10
 
-  - openmmforcefields
   - qcportal >=0.15
   - pytest
   - pytest-rerunfailures
-  - nbval

--- a/devtools/conda-envs/conda_oe.yaml
+++ b/devtools/conda-envs/conda_oe.yaml
@@ -12,4 +12,3 @@ dependencies:
   - qcportal >=0.15
   - pytest
   - pytest-rerunfailures
-  - nbval

--- a/devtools/conda-envs/conda_oe.yaml
+++ b/devtools/conda-envs/conda_oe.yaml
@@ -2,13 +2,10 @@ name: latest-deployment
 channels:
   - conda-forge
   - openeye
-
 dependencies:
     # Base depends
   - openff-toolkit-examples
-
-  - openmmforcefields >=0.11.2
+    # Tests
   - openeye-toolkits
-  - qcportal >=0.15
   - pytest
   - pytest-rerunfailures

--- a/devtools/conda-envs/conda_oe_010X.yaml
+++ b/devtools/conda-envs/conda_oe_010X.yaml
@@ -7,9 +7,7 @@ dependencies:
     # Base depends
   - openff-toolkit-examples =0.10
 
-  - openmmforcefields
   - openeye-toolkits
   - qcportal >=0.15
   - pytest
   - pytest-rerunfailures
-  - nbval

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -5,24 +5,21 @@ channels:
 dependencies:
   - python
   - pip
-  - packaging
+  - packaging =0.21
   - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
   - nbval
-  - codecov
-  - coverage
   - numpy
   - networkx
   - parmed
   - openeye-toolkits
-  - packaging
   - openmm =>7.6
   - openff-forcefields
   - openff-units >=0.2
   - openff-utilities >=0.1.5
-  - openff-interchange-base >0.2.0rc6
+  - openff-interchange-base >=0.2
   - smirnoff99Frosst
   - cachetools
   - cached-property
@@ -36,5 +33,5 @@ dependencies:
   - qcportal >=0.15
   - qcengine
   - mdtraj
-  - ipywidgets >=7,<8
+  - ipywidgets =7
   - pdbfixer

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -3,36 +3,39 @@ channels:
   - openeye
   - conda-forge
 dependencies:
+    # Base depends
   - python
   - pip
   - packaging =21
+  - numpy
+  - networkx
+  - cachetools
+  - cached-property
+  - xmltodict
+  - python-constraint
+  - openmm >=7.6
+  - openff-forcefields
+  - smirnoff99Frosst
+  - openff-units >=0.2
+  - openff-utilities >=0.1.5
+  - openff-interchange-base >=0.2
+    # Toolkit-specific
+  - openeye-toolkits
+    # Test-only/optional/dev/typing
   - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
-  - nbval
-  - numpy
-  - networkx
-  - parmed
-  - openeye-toolkits
-  - openmm =>7.6
-  - openff-forcefields
-  - openff-units >=0.2
-  - openff-utilities >=0.1.5
-  - openff-interchange-base >=0.2
-  - smirnoff99Frosst
-  - cachetools
-  - cached-property
   - pyyaml
   - toml
   - bson
   - msgpack-python
-  - xmltodict
-  - python-constraint
   - qcelemental
   - qcportal >=0.15
   - qcengine
   - mdtraj
+  - parmed
+  - nbval
   - ipywidgets =7
   - pdbfixer
-  - openmmforcefields
+  - openmmforcefields >=0.11.2

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python
   - pip
-  - packaging =0.21
+  - packaging =21
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -2,7 +2,6 @@ name: test
 channels:
   - openeye
   - conda-forge
-
 dependencies:
     # Base depends
   - python
@@ -10,24 +9,23 @@ dependencies:
   - packaging =21
   - numpy
   - networkx
-  - openmm =>7.6
-  - openff-forcefields
-  - openff-units >=0.2
-  - openff-utilities >=0.1.5
-  - openff-interchange-base >=0.2
-  - smirnoff99Frosst
   - cachetools
   - cached-property
   - xmltodict
   - python-constraint
-
-    # Testing
+  - openmm >=7.6
+  - openff-forcefields
+  - smirnoff99Frosst
+  - openff-units >=0.2
+  - openff-utilities >=0.1.5
+  - openff-interchange-base >=0.2
+    # Toolkit-specific
+  - openeye-toolkits
+    # Test-only/optional/dev/typing
   - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
-  - parmed
-  - openeye-toolkits
   - pyyaml
   - toml
   - bson
@@ -36,4 +34,4 @@ dependencies:
   - qcportal >=0.15
   - qcengine
   - mdtraj
-  - ipywidgets =7
+  - parmed

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -7,38 +7,34 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging
+  - packaging =0.21
+  - numpy
+  - networkx
+  - openmm =>7.6
+  - openff-forcefields
+  - openff-units >=0.2
+  - openff-utilities >=0.1.5
+  - openff-interchange-base >=0.2
+  - smirnoff99Frosst
+  - cachetools
+  - cached-property
+  - xmltodict
+  - python-constraint
 
     # Testing
   - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
-  - nbval
-  - codecov
-  - coverage
-  - numpy
-  - networkx
   - parmed
   - openeye-toolkits
-  - packaging
   - openmmforcefields >=0.11.2
-  - openmm =>7.6
-  - openff-forcefields
-  - openff-units >=0.2
-  - openff-utilities >=0.1.5
-  - openff-interchange-base >=0.2.0rc6
-  - smirnoff99Frosst
-  - cachetools
-  - cached-property
   - pyyaml
   - toml
   - bson
   - msgpack-python
-  - xmltodict
-  - python-constraint
   - qcelemental
   - qcportal >=0.15
   - qcengine
   - mdtraj
-  - ipywidgets >=7,<8
+  - ipywidgets =7

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -7,7 +7,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =0.21
+  - packaging =21
   - numpy
   - networkx
   - openmm =>7.6

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python
   - pip
-  - packaging =0.21
+  - packaging =21
   - pytest
   - pytest-cov
   - pytest-xdist

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -1,38 +1,40 @@
 name: test
 channels:
   - conda-forge
-
 dependencies:
+    # Base depends
   - python
   - pip
   - packaging =21
+  - numpy
+  - networkx
+  - cachetools
+  - cached-property
+  - xmltodict
+  - python-constraint
+  - openmm >=7.6
+  - openff-forcefields
+  - smirnoff99Frosst
+  - openff-units >=0.2
+  - openff-utilities >=0.1.5
+  - openff-interchange-base >=0.2
+    # Toolkit-specific
+  - ambertools
+  - rdkit
+    # Test-only/optional/dev/typing
   - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
-  - nbval
-  - numpy
-  - networkx
-  - ambertools
-  - rdkit
-  - openmm >=7.6
-  - openff-forcefields
-  - openff-units >=0.2
-  - openff-utilities >=0.1.5
-  - openff-interchange-base >=0.2
-  - smirnoff99Frosst
-  - cachetools
-  - cached-property
-  - python-constraint
   - pyyaml
   - toml
   - bson
   - msgpack-python
-  - xmltodict
   - qcelemental
   - qcportal >=0.15
   - qcengine
+  - nbval
   - mdtraj
   - ipywidgets =7
   - pdbfixer
-  - openmmforcefields
+  - openmmforcefields >=0.11.2

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -5,24 +5,21 @@ channels:
 dependencies:
   - python
   - pip
-  - packaging
+  - packaging =0.21
   - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
   - nbval
-  - codecov
-  - coverage
   - numpy
   - networkx
   - ambertools
   - rdkit
-  - packaging
   - openmm >=7.6
   - openff-forcefields
   - openff-units >=0.2
   - openff-utilities >=0.1.5
-  - openff-interchange-base >0.2.0rc6
+  - openff-interchange-base >=0.2
   - smirnoff99Frosst
   - cachetools
   - cached-property
@@ -36,5 +33,5 @@ dependencies:
   - qcportal >=0.15
   - qcengine
   - mdtraj
-  - ipywidgets >=7,<8
+  - ipywidgets =7
   - pdbfixer

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python
   - pip
 
-  - packaging =0.21
+  - packaging =21
   - numpy
   - networkx
   - ambertools

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -1,7 +1,6 @@
 name: test
 channels:
   - conda-forge
-
 dependencies:
     # Base depends
   - python
@@ -9,20 +8,20 @@ dependencies:
   - packaging =21
   - numpy
   - networkx
-  - ambertools
-  - rdkit
-  - openmm >=7.6
-  - openff-forcefields
-  - openff-units >=0.2
-  - openff-utilities >=0.1.5
-  - openff-interchange-base >=0.2
-  - smirnoff99Frosst
   - cachetools
   - cached-property
   - xmltodict
   - python-constraint
-
-    # Testing
+  - openmm >=7.6
+  - openff-forcefields
+  - smirnoff99Frosst
+  - openff-units >=0.2
+  - openff-utilities >=0.1.5
+  - openff-interchange-base >=0.2
+    # Toolkit-specific
+  - ambertools
+  - rdkit
+    # Test-only/optional/dev/typing
   - pytest
   - pytest-cov
   - pytest-xdist
@@ -34,5 +33,3 @@ dependencies:
   - qcelemental
   - qcportal >=0.15
   - qcengine
-  - mdtraj
-  - ipywidgets =7

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -6,38 +6,35 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging
+
+  - packaging =0.21
+  - numpy
+  - networkx
+  - ambertools
+  - rdkit
+  - openmmforcefields >=0.11.2
+  - openmm >=7.6
+  - openff-forcefields
+  - openff-units >=0.2
+  - openff-utilities >=0.1.5
+  - openff-interchange-base >=0.2
+  - smirnoff99Frosst
+  - cachetools
+  - cached-property
+  - xmltodict
+  - python-constraint
 
     # Testing
   - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
-  - nbval
-  - codecov
-  - coverage
-  - numpy
-  - networkx
-  - ambertools
-  - rdkit
-  - packaging
-  - openmmforcefields >=0.11.2
-  - openmm >=7.6
-  - openff-forcefields
-  - openff-units >=0.2
-  - openff-utilities >=0.1.5
-  - openff-interchange-base >0.2.0rc6
-  - smirnoff99Frosst
-  - cachetools
-  - cached-property
   - pyyaml
   - toml
   - bson
   - msgpack-python
-  - xmltodict
-  - python-constraint
   - qcelemental
   - qcportal >=0.15
   - qcengine
   - mdtraj
-  - ipywidgets >=7,<8
+  - ipywidgets =7

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -7,28 +7,27 @@ dependencies:
   - python
   - pip
   - packaging =21
+  - numpy
+  - networkx
+  - cachetools
+  - cached-property
+  - xmltodict
+  - python-constraint
   - openmm >=7.6
   - openff-forcefields
+  - smirnoff99Frosst
   - openff-units >=0.2
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.2
-  - smirnoff99Frosst
-  - numpy
-  - networkx
+    # Toolkit-specific
   - ambertools
   - rdkit
-  - xmltodict
-  - python-constraint
-  - cachetools
-  - cached-property
+  - openeye-toolkits
     # Test-only/optional/dev/typing
   - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
-  - nbval
-  - openeye-toolkits
-  - mdtraj
   - pyyaml
   - toml
   - bson
@@ -37,7 +36,8 @@ dependencies:
   - qcportal >=0.15
   - qcengine
   - mdtraj
-  - ipywidgets =7
+  - parmed
+  - nbval
   - mypy
   - pip:
     - types-pkg_resources

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =0.21
+  - packaging =21
   - openmm >=7.6
   - openmmforcefields >=0.11.2
   - openff-forcefields

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -37,6 +37,7 @@ dependencies:
   - qcengine
   - mdtraj
   - ipywidgets =7
+  - mypy
   - pip:
     - types-pkg_resources
     - types-setuptools

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,13 +6,13 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging
+  - packaging =0.21
   - openmm >=7.6
   - openmmforcefields >=0.11.2
   - openff-forcefields
   - openff-units >=0.2
   - openff-utilities >=0.1.5
-  - openff-interchange-base >0.2.0rc6
+  - openff-interchange-base >=0.2
   - smirnoff99Frosst
   - numpy
   - networkx
@@ -20,18 +20,15 @@ dependencies:
   - rdkit
   - xmltodict
   - python-constraint
-    # Test-only/optional/dev
+  - cachetools
+  - cached-property
+    # Test-only/optional/dev/typing
   - pytest
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
-  - nbval
-  - codecov
-  - coverage
   - openeye-toolkits
   - mdtraj
-  - cachetools
-  - cached-property
   - pyyaml
   - toml
   - bson
@@ -40,10 +37,7 @@ dependencies:
   - qcportal >=0.15
   - qcengine
   - mdtraj
-  - ipywidgets >=7,<8
-  # Typing
-  - mypy
-  - typing-extensions
+  - ipywidgets =7
   - pip:
     - types-pkg_resources
     - types-setuptools

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -26,6 +26,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
+  - nbval
   - openeye-toolkits
   - mdtraj
   - pyyaml


### PR DESCRIPTION
~~Resolves~~ Pushes #1487 into the future

- [x] Pins `packaging =0.21` (#1489)
- [x] No longer lists `codecov` as a dependency
- [x] No longer lists `coverage` as a dependency
- [x] No longer brings in `nbval` when not running notebooks
- [x] Updates some outdated constraints
- [x] Set shell in `defaults` section
- [x] Do not set patch version of actions when not necessary
- [x] Reorganizes files to avoid confusion about base dependencies
- [x] No longer brings in examples-only dependencies when examples are not run