### PR TITLE
Add `ignore_keys` argument to `convert_all_strings_to_quantity`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -24,6 +24,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
   a `ParameterHandler`'s class when calling `ForceField.register_parameter_handler`.
 - [PR #1480](https://github.com/openforcefield/openff-toolkit/pull/1480): Fixes
   [#1479](https://github.com/openforcefield/openff-toolkit/issues/1479) by requiring that `Atom.atomic_number` is a positive integer.
+- [PR #1494](https://github.com/openforcefield/openff-toolkit/pull/1494): Fixes
+  [#1493](https://github.com/openforcefield/openff-toolkit/issues/1493) in which some OFFXML file
+  contents were parsed to `unit.Quantity` objects despite not representing physical quantities.
 
 [`Atom.atomic_number`]: Atom.atomic_number
 

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -998,6 +998,26 @@ class TestForceField:
         assert len(forcefield._parameter_handlers["ImproperTorsions"]._parameters) == 2
         assert len(forcefield._parameter_handlers["vdW"]._parameters) == 2
 
+    def test_load_do_not_convert_non_quantity_strings(self):
+        """Reproduce part of #1493"""
+        sage = ForceField("openff-2.0.0.offxml")
+
+        for parameter_handler_name in sage.registered_parameter_handlers:
+
+            parameter_handler = sage.get_parameter_handler(parameter_handler_name)
+
+            for parameter in parameter_handler.parameters:
+                assert isinstance(parameter.smirks, str)
+                assert not isinstance(parameter.smirks, unit.Quantity)
+
+                # Ensure that, for example, F isn't converted to Farad
+                if (
+                    parameter_handler_name == "LibraryCharges"
+                    and getattr(parameter, "name") is not None
+                ):
+                    assert isinstance(parameter.name, str)
+                    assert not isinstance(parameter.name, unit.Quantity)
+
     def test_pickle(self):
         """
         Test pickling and unpickling a force field

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -589,7 +589,7 @@ class ForceField:
         self._parameter_io_handlers[io_format] = parameter_io_handler
 
     @property
-    def registered_parameter_handlers(self):
+    def registered_parameter_handlers(self) -> List[str]:
         """
         Return the list of registered parameter handlers by name
 
@@ -875,7 +875,10 @@ class ForceField:
             self._add_date(smirnoff_data["SMIRNOFF"]["Date"])
 
         # Go through the whole SMIRNOFF data structure, trying to convert all strings to Quantity
-        smirnoff_data = convert_all_strings_to_quantity(smirnoff_data)
+        smirnoff_data = convert_all_strings_to_quantity(
+            smirnoff_data,
+            ignore_keys=["smirks", "name"],
+        )
 
         # Go through the subsections, delegating each to the proper ParameterHandler
 

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -26,7 +26,7 @@ __all__ = [
 import contextlib
 import functools
 import logging
-from typing import List, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pint
@@ -207,7 +207,10 @@ def string_to_quantity(quantity_string) -> Union[str, int, float, unit.Quantity]
         return quantity
 
 
-def convert_all_strings_to_quantity(smirnoff_data):
+def convert_all_strings_to_quantity(
+    smirnoff_data: Dict,
+    ignore_keys: List[str] = list(),
+):
     """
     Traverses a SMIRNOFF data structure, attempting to convert all
     quantity-defining strings into openff.units.unit.Quantity objects.
@@ -230,12 +233,21 @@ def convert_all_strings_to_quantity(smirnoff_data):
 
     if isinstance(smirnoff_data, dict):
         for key, value in smirnoff_data.items():
-            smirnoff_data[key] = convert_all_strings_to_quantity(value)
+            if key in ignore_keys:
+                smirnoff_data[key] = value
+            else:
+                smirnoff_data[key] = convert_all_strings_to_quantity(
+                    value,
+                    ignore_keys=ignore_keys,
+                )
         obj_to_return = smirnoff_data
 
     elif isinstance(smirnoff_data, list):
         for index, item in enumerate(smirnoff_data):
-            smirnoff_data[index] = convert_all_strings_to_quantity(item)
+            smirnoff_data[index] = convert_all_strings_to_quantity(
+                item,
+                ignore_keys=ignore_keys,
+            )
         obj_to_return = smirnoff_data
 
     elif isinstance(smirnoff_data, int) or isinstance(smirnoff_data, float):


### PR DESCRIPTION
This PR implements @lilyminium's suggested fix to #1493 and also adds a test to catch some of the behavior she observed, which was previously not covered in tests.

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
