### PR TITLE
Migrate `python setup.py` to `pip install`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,8 @@ jobs:
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       PACKAGE: openff
-      PYTEST_ARGS: -r fE --tb=short -nauto --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
+      PYTEST_ARGS: -r fE --tb=short -nauto
+      COV: --cov=openff/toolkit --cov-config=setup.cfg --cov-append --cov-report=xml
 
     steps:
       - uses: actions/checkout@v3
@@ -103,12 +104,11 @@ jobs:
           # against a conda build of Interchange. (It may also be pulled down
           # by `openmmforcefields` and should be removed in that case a well.)
           conda remove --force openff-toolkit openff-toolkit-base
-          python setup.py develop --no-deps
+          python -m pip install .
 
       - name: Install test plugins
         run: |
-          cd utilities/test_plugins
-          python setup.py develop --no-deps
+          python -m pip install utilities/test_plugins
 
       - name: Remove undesired toolkits
         run: |
@@ -153,7 +153,7 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
             PYTEST_ARGS+=" --runslow"
           fi
-          pytest $PYTEST_ARGS openff/toolkit/tests/
+          python -m pytest $PYTEST_ARGS $COV openff/toolkit/
 
       - name: Run code snippets in docs
         if: ${{ matrix.rdkit == true && matrix.openeye == true }}

--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -24,7 +24,8 @@ jobs:
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
-      PYTEST_ARGS: -r fE --tb=short --cov=openff --cov-config=setup.cfg --cov-append --cov-report=xml
+      PYTEST_ARGS: -r fE --tb=short -nauto
+      COV: --cov=openff/toolkit --cov-config=setup.cfg --cov-append --cov-report=xml
 
     steps:
       - uses: actions/checkout@v3
@@ -53,12 +54,11 @@ jobs:
       - name: Install package
         run: |
           conda remove --force openff-toolkit openff-toolkit-base
-          python setup.py develop --no-deps
+          python -m pip install .
 
       - name: Install test plugins
         run: |
-          cd utilities/test_plugins
-          python setup.py develop --no-deps
+          python -m pip install utilities/test_plugins
 
       - name: Environment Information
         run: |
@@ -78,7 +78,7 @@ jobs:
           PYTEST_ARGS+=" --ignore=openff/toolkit/tests/test_examples.py"
           PYTEST_ARGS+=" --ignore=openff/toolkit/tests/test_links.py"
           PYTEST_ARGS+=" --runslow"
-          pytest $PYTEST_ARGS openff/toolkit/tests/
+          pytest $PYTEST_ARGS $COV openff/toolkit/tests/
 
       - name: Run code snippets in docs
         run: |

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -106,10 +106,7 @@ jobs:
 
       - name: Test the package
         run: |
-          # Install test plugins
-          cd utilities/test_plugins
-          python setup.py develop --no-deps
-          cd -
+          python -m pip install utilities/test_plugins
 
           pwd
           ls

--- a/.github/workflows/conda_010X.yml
+++ b/.github/workflows/conda_010X.yml
@@ -109,10 +109,7 @@ jobs:
         shell: bash -l {0}
         run: |
 
-          # Install test plugins
-          cd utilities/test_plugins
-          python setup.py develop --no-deps
-          cd -
+          python -m pip install utilities/test_plugins
 
           pwd
           ls

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -83,7 +83,7 @@ jobs:
           # Maybe remove the packaged openff-toolkit, installed as a dependency of openmmforcefields
           # and/or Interchange
           conda remove --force openff-toolkit-base
-          python setup.py develop --no-deps
+          python -m pip install .
 
       - name: Remove undesired toolkits
         run: |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,11 +106,11 @@ Note that this may update other packages or install new packages if the most rec
 
 ## Installing from source
 
-The OpenFF Toolkit has a lot of dependencies, so we strongly encourage installation with a package manager. The [developer's guide](install_dev) describes setting up a development environment. If you're sure you want to install from source, check the [`conda-forge` recipe](https://github.com/conda-forge/openff-toolkit-feedstock/blob/main/recipe/meta.yaml) for current dependencies, install them, download and extract the source distribution from [GitHub](https://github.com/openforcefield/openff-toolkit/releases), and then run `setup.py`:
+The OpenFF Toolkit has a lot of dependencies, so we strongly encourage installation with a package manager. The [developer's guide](install_dev) describes setting up a development environment. If you're sure you want to install from source, check the [`conda-forge` recipe](https://github.com/conda-forge/openff-toolkit-feedstock/blob/main/recipe/meta.yaml) for current dependencies, install them, download and extract the source distribution from [GitHub](https://github.com/openforcefield/openff-toolkit/releases), and then run `pip`:
 
 ```shell-session
 $ cd openff-toolkit
-$ python setup.py install
+$ python -m pip install .
 ```
 
 ## Single-file installer


### PR DESCRIPTION
`setup.py` is dead, long live `setup.py`!

https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

This should not affect deployment since `python setup.py` calls only happen in our automation. There was a single mention in docs, which I've updated. I couldn't find anything else in the public sections.

* `--no-deps` should not be needed since we don't (and can't and should not) define our requirements via `install_requires` in `setup.py`
* `--develop` is unneeded since we're not patching the toolkit inside of workflows
* `pip` can take a path, which is handy for installing the test plugins