### PR TITLE
Constrain `ipywidgets`

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -37,6 +37,7 @@ dependencies:
   - qcengine
   - mdtraj
   - parmed
+  - ipywidgets =7
   - nbval
   - mypy
   - pip:


### PR DESCRIPTION
At some point over the weekend, [nightly CI](https://github.com/openforcefield/openff-toolkit/actions/workflows/CI.yml?query=event%3Aschedule) started failing at the step of running through docs in the vanilla test environment, which was not constrained in a way that resolves the `ipywidgets`/NGLview situation.

I'm not immediately sure what caused it to go from regularly passing to failing, but here's the closest [before](https://github.com/openforcefield/openff-toolkit/actions/runs/3915866280) and [after](https://github.com/openforcefield/openff-toolkit/actions/runs/3920879965) I could find. So I'm not sure if this needs to be fixed in deployment as well.