### PR TITLE
Clarify aromaticity model support

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -12,6 +12,10 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### New features
 - [PR #1502](https://github.com/openforcefield/openff-toolkit/pull/1502): Adds Gasteiger charge computation using the RDKit backend.
 
+### Improved documentation and warnings
+- [PR #1513](https://github.com/openforcefield/openff-toolkit/pull/1513): Improves error messages and documentation around supported aromaticity models (currently only "OEAroModel_MDL").
+
+
 ## 0.12.0
 
 ### New features

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -51,6 +51,7 @@ from openff.units.elements import MASSES, SYMBOLS
 from openff.utilities.exceptions import MissingOptionalDependencyError
 from packaging import version
 
+from openff.toolkit.utils.constants import DEFAULT_AROMATICITY_MODEL
 from openff.toolkit.utils.exceptions import (
     HierarchySchemeNotFoundException,
     HierarchySchemeWithIteratorNameAlreadyRegisteredException,
@@ -64,7 +65,6 @@ from openff.toolkit.utils.exceptions import (
 )
 from openff.toolkit.utils.serialization import Serializable
 from openff.toolkit.utils.toolkits import (
-    DEFAULT_AROMATICITY_MODEL,
     GLOBAL_TOOLKIT_REGISTRY,
     InvalidToolkitRegistryError,
     OpenEyeToolkitWrapper,
@@ -4140,8 +4140,8 @@ class FrozenMolecule(Serializable):
 
         Parameters
         ----------
-        aromaticity_model : str, optional, default=DEFAULT_AROMATICITY_MODEL
-            The aromaticity model to use
+        aromaticity_model : str, optional, default="OEAroModel_MDL"
+            The aromaticity model to use. Only OEAroModel_MDL is supported.
 
         Returns
         -------
@@ -4700,8 +4700,8 @@ class FrozenMolecule(Serializable):
 
         Parameters
         ----------
-        aromaticity_model : str, optional, default=DEFAULT_AROMATICITY_MODEL
-            The aromaticity model to use
+        aromaticity_model : str, optional, default="OEAroModel_MDL"
+            The aromaticity model to use. Only OEAroModel_MDL is supported.
 
         Returns
         -------

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -42,6 +42,10 @@ from openff.toolkit.topology import Molecule
 from openff.toolkit.topology._mm_molecule import _SimpleBond, _SimpleMolecule
 from openff.toolkit.topology.molecule import FrozenMolecule, HierarchyElement
 from openff.toolkit.utils import quantity_to_string, string_to_quantity
+from openff.toolkit.utils.constants import (
+    ALLOWED_AROMATICITY_MODELS,
+    DEFAULT_AROMATICITY_MODEL,
+)
 from openff.toolkit.utils.exceptions import (
     AtomNotInTopologyError,
     DuplicateUniqueMoleculeError,
@@ -55,11 +59,7 @@ from openff.toolkit.utils.exceptions import (
     WrongShapeError,
 )
 from openff.toolkit.utils.serialization import Serializable
-from openff.toolkit.utils.toolkits import (
-    ALLOWED_AROMATICITY_MODELS,
-    DEFAULT_AROMATICITY_MODEL,
-    GLOBAL_TOOLKIT_REGISTRY,
-)
+from openff.toolkit.utils.toolkits import GLOBAL_TOOLKIT_REGISTRY
 
 if TYPE_CHECKING:
     import mdtraj
@@ -419,8 +419,7 @@ class Topology(Serializable):
         from openff.toolkit.topology.molecule import FrozenMolecule
 
         # Assign cheminformatics models
-        model = DEFAULT_AROMATICITY_MODEL
-        self._aromaticity_model = model
+        self._aromaticity_model = DEFAULT_AROMATICITY_MODEL
 
         # Initialize storage
         self._initialize()
@@ -437,7 +436,6 @@ class Topology(Serializable):
         """
         Initializes a blank Topology.
         """
-        self._aromaticity_model = DEFAULT_AROMATICITY_MODEL
         self._constrained_atom_pairs = dict()
         self._box_vectors = None
         self._molecules = list()
@@ -568,12 +566,12 @@ class Topology(Serializable):
         aromaticity_model : str
             Aromaticity model to use. One of: ['OEAroModel_MDL']
         """
-
         if aromaticity_model not in ALLOWED_AROMATICITY_MODELS:
-            msg = "Aromaticity model must be one of {}; specified '{}'".format(
-                ALLOWED_AROMATICITY_MODELS, aromaticity_model
+            raise InvalidAromaticityModelError(
+                f"Read aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
+                f"{ALLOWED_AROMATICITY_MODELS}."
             )
-            raise InvalidAromaticityModelError(msg)
+
         self._aromaticity_model = aromaticity_model
 
     @property
@@ -2132,6 +2130,8 @@ class Topology(Serializable):
             An OpenEye molecule
         positions : unit-wrapped array with shape [nparticles,3], optional, default=None
             Positions to use in constructing OEMol.
+        aromaticity_model : str, optional, default="OEAroModel_MDL"
+            The aromaticity model to use. Only OEAroModel_MDL is supported.
 
         NOTE: This comes from https://github.com/oess/oeommtools/blob/master/oeommtools/utils.py
 

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -31,10 +31,13 @@ from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 from packaging.version import Version
 
-from openff.toolkit.topology.molecule import DEFAULT_AROMATICITY_MODEL
 from openff.toolkit.typing.engines.smirnoff.io import ParameterIOHandler
 from openff.toolkit.typing.engines.smirnoff.parameters import ParameterHandler
 from openff.toolkit.typing.engines.smirnoff.plugins import load_handler_plugins
+from openff.toolkit.utils.constants import (
+    ALLOWED_AROMATICITY_MODELS,
+    DEFAULT_AROMATICITY_MODEL,
+)
 from openff.toolkit.utils.exceptions import (
     ParameterHandlerRegistrationError,
     PartialChargeVirtualSitesError,
@@ -235,8 +238,8 @@ class ForceField:
             specified, any top-level tags that are repeated will be merged if they are compatible, with files appearing
             later in the sequence resulting in parameters that have higher precedence.  Support for multiple files is
             primarily intended to allow solvent parameters to be specified by listing them last in the sequence.
-        aromaticity_model : string, default='OEAroModel_MDL'
-            The aromaticity model used by the force field. Currently, only 'OEAroModel_MDL' is supported
+        aromaticity_model : str, optional, default="OEAroModel_MDL"
+            The aromaticity model to use. Only OEAroModel_MDL is supported.
         parameter_handler_classes : iterable of ParameterHandler classes, optional, default=None
             If not None, the specified set of ParameterHandler classes will be instantiated to create the parameter
             object model.  By default, all imported subclasses of ParameterHandler are automatically registered.
@@ -313,7 +316,7 @@ class ForceField:
         self._disable_version_check = (
             False  # if True, will disable checking compatibility version
         )
-        self._aromaticity_model = None
+        self._aromaticity_model = DEFAULT_AROMATICITY_MODEL
         # Parameter handler classes that _can_ be initialized if needed
         self._parameter_handler_classes = dict()
         # ParameterHandler classes to be instantiated for each parameter type
@@ -395,9 +398,10 @@ class ForceField:
 
         """
         # Implement better logic here if we ever support another aromaticity model
-        if aromaticity_model != "OEAroModel_MDL":
+        if aromaticity_model not in ALLOWED_AROMATICITY_MODELS:
             raise SMIRNOFFAromaticityError(
-                f"Read aromaticity model {aromaticity_model}. Currently only OEAroModel_MDL is supported."
+                f"Read aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
+                f"{ALLOWED_AROMATICITY_MODELS}."
             )
 
         self._aromaticity_model = aromaticity_model

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -400,8 +400,8 @@ class ForceField:
         # Implement better logic here if we ever support another aromaticity model
         if aromaticity_model not in ALLOWED_AROMATICITY_MODELS:
             raise SMIRNOFFAromaticityError(
-                f"Read aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
-                f"{ALLOWED_AROMATICITY_MODELS}."
+                f"Read aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models: "
+                f"{ALLOWED_AROMATICITY_MODELS}"
             )
 
         self._aromaticity_model = aromaticity_model

--- a/openff/toolkit/utils/__init__.py
+++ b/openff/toolkit/utils/__init__.py
@@ -17,15 +17,17 @@ from openff.toolkit.utils.utils import (
     temporary_cd,
     unit_to_string,
 )
-from openff.toolkit.utils.toolkits import (
+from openff.toolkit.utils.constants import (
+    DEFAULT_AROMATICITY_MODEL,
     ALLOWED_AROMATICITY_MODELS,
-    ALLOWED_CHARGE_MODELS,
+    DEFAULT_FRACTIONAL_BOND_ORDER_MODEL,
     ALLOWED_FRACTIONAL_BOND_ORDER_MODELS,
+    DEFAULT_CHARGE_MODEL,
+    ALLOWED_CHARGE_MODELS,
+)
+from openff.toolkit.utils.toolkits import (
     AMBERTOOLS_AVAILABLE,
     BASIC_CHEMINFORMATICS_TOOLKITS,
-    DEFAULT_AROMATICITY_MODEL,
-    DEFAULT_CHARGE_MODEL,
-    DEFAULT_FRACTIONAL_BOND_ORDER_MODEL,
     GLOBAL_TOOLKIT_REGISTRY,
     OPENEYE_AVAILABLE,
     RDKIT_AVAILABLE,

--- a/openff/toolkit/utils/constants.py
+++ b/openff/toolkit/utils/constants.py
@@ -8,15 +8,11 @@ __all__ = (
 )
 
 
-# TODO: Is there a more specific name and reference for the aromaticity model?
-DEFAULT_AROMATICITY_MODEL = "OEAroModel_MDL"
 ALLOWED_AROMATICITY_MODELS = ["OEAroModel_MDL"]
+DEFAULT_AROMATICITY_MODEL = ALLOWED_AROMATICITY_MODELS[0]
 
-# TODO: Is there a more specific name and reference for the fractional bond order models?
-DEFAULT_FRACTIONAL_BOND_ORDER_MODEL = "Wiberg"
 ALLOWED_FRACTIONAL_BOND_ORDER_MODELS = ["Wiberg"]
+DEFAULT_FRACTIONAL_BOND_ORDER_MODEL = ALLOWED_FRACTIONAL_BOND_ORDER_MODELS[0]
 
-# TODO: Should this be `AM1-BCC`, or should we encode BCCs explicitly via AM1-CM2 preprocessing?
-DEFAULT_CHARGE_MODEL = "AM1-BCC"
-# TODO: Which models do we want to support?
 ALLOWED_CHARGE_MODELS = ["AM1-BCC"]
+DEFAULT_CHARGE_MODEL = ALLOWED_CHARGE_MODELS[0]

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1326,8 +1326,8 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         if aromaticity_model not in ALLOWED_AROMATICITY_MODELS:
             raise InvalidAromaticityModelError(
-                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
-                f"{ALLOWED_AROMATICITY_MODELS}."
+                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models: "
+                f"{ALLOWED_AROMATICITY_MODELS}"
             )
 
         oemol = oechem.OEMol()
@@ -1356,8 +1356,9 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         if aromaticity_model == "OEAroModel_MDL":
             oechem.OEAssignAromaticFlags(oemol, oechem.OEAroModelMDL)
         else:
-            raise NotImplementedError(
-                "The aromaticity model is assumed to be OEAroModel_MDL"
+            raise InvalidAromaticityModelError(
+                "Aromaticity model {aromaticity_model} is not in the set of allowed aromaticity models:  "
+                f"{ALLOWED_AROMATICITY_MODELS}"
             )
 
         # Set atom stereochemistry now that all connectivity is in place
@@ -2683,8 +2684,9 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         if aromaticity_model == "OEAroModel_MDL":
             oechem.OEAssignAromaticFlags(qmol, oechem.OEAroModel_MDL)
         else:
-            raise NotImplementedError(
-                "The aromaticity model is assumed to be OEAroModel_MDL"
+            raise InvalidAromaticityModelError(
+                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
+                f"{ALLOWED_AROMATICITY_MODELS}"
             )
 
         # oechem.OEAssignHybridization(mol)

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -25,13 +25,17 @@ if TYPE_CHECKING:
 from openff.units.elements import SYMBOLS
 
 from openff.toolkit.utils import base_wrapper
-from openff.toolkit.utils.constants import DEFAULT_AROMATICITY_MODEL
+from openff.toolkit.utils.constants import (
+    ALLOWED_AROMATICITY_MODELS,
+    DEFAULT_AROMATICITY_MODEL,
+)
 from openff.toolkit.utils.exceptions import (
     ChargeCalculationError,
     ChargeMethodUnavailableError,
     ConformerGenerationError,
     GAFFAtomTypeWarning,
     InconsistentStereochemistryError,
+    InvalidAromaticityModelError,
     InvalidIUPACNameError,
     LicenseError,
     NotAttachedToMoleculeError,
@@ -1320,11 +1324,10 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
     ):
         from openeye import oechem
 
-        if hasattr(oechem, aromaticity_model):
-            oe_aro_model = getattr(oechem, aromaticity_model)
-        else:
-            raise ValueError(
-                "Error: provided aromaticity model not recognized by oechem."
+        if aromaticity_model not in ALLOWED_AROMATICITY_MODELS:
+            raise InvalidAromaticityModelError(
+                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
+                f"{ALLOWED_AROMATICITY_MODELS}."
             )
 
         oemol = oechem.OEMol()
@@ -1350,7 +1353,12 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             # oebond.SetAromatic(bond.is_aromatic)
             oemol_bonds.append(oebond)
 
-        oechem.OEAssignAromaticFlags(oemol, oe_aro_model)
+        if aromaticity_model == "OEAroModel_MDL":
+            oechem.OEAssignAromaticFlags(oemol, oechem.OEAroModelMDL)
+        else:
+            raise NotImplementedError(
+                "The aromaticity model is assumed to be OEAroModel_MDL"
+            )
 
         # Set atom stereochemistry now that all connectivity is in place
         for atom, oeatom in zip(molecule.atoms, oemol_atoms):
@@ -2634,8 +2642,8 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             SMARTS string with any number of sequentially tagged atoms.
             If there are N tagged atoms numbered 1..N, the resulting matches will be N-tuples of
             atoms that match the corresponding tagged atoms.
-        aromaticity_model : str, optional, default=None
-            OpenEye aromaticity model designation as a string, such as ``OEAroModel_MDL``.
+        aromaticity_model : str, optional, default="OEAroModel_MDL"
+            The aromaticity model to use. Only OEAroModel_MDL is supported.
             Molecule is prepared with this aromaticity model prior to querying.
         unique : bool, default=False
             If True, only return unique matches. If False, return all matches. This is passed to
@@ -2667,27 +2675,18 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         if not oechem.OEParseSmarts(qmol, smarts):
             raise ValueError(f"Error parsing SMARTS '{smarts}'")
 
-        # Apply aromaticity model
-        if type(aromaticity_model) == str:
-            # Check if the user has provided a manually-specified aromaticity_model
-            if hasattr(oechem, aromaticity_model):
-                oearomodel = getattr(oechem, aromaticity_model)
-            else:
-                raise ValueError(
-                    "Error: provided aromaticity model not recognized by oechem."
-                )
-        else:
-            raise ValueError("Error: provided aromaticity model must be a string.")
-
         # OEPrepareSearch will clobber our desired aromaticity model if we don't sync up mol
         # and qmol ahead of time.
-        # Prepare molecule
-        # oechem.OEClearAromaticFlags(mol)
-        # oechem.OEAssignAromaticFlags(mol, oearomodel)
 
-        # If aromaticity model was provided, prepare query molecule
         oechem.OEClearAromaticFlags(qmol)
-        oechem.OEAssignAromaticFlags(qmol, oearomodel)
+
+        if aromaticity_model == "OEAroModel_MDL":
+            oechem.OEAssignAromaticFlags(qmol, oechem.OEAroModel_MDL)
+        else:
+            raise NotImplementedError(
+                "The aromaticity model is assumed to be OEAroModel_MDL"
+            )
+
         # oechem.OEAssignHybridization(mol)
         oechem.OEAssignHybridization(qmol)
 
@@ -2720,7 +2719,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         self,
         molecule: "Molecule",
         smarts: str,
-        aromaticity_model="OEAroModel_MDL",
+        aromaticity_model=DEFAULT_AROMATICITY_MODEL,
         unique=False,
     ) -> List[Tuple[int, ...]]:
         """
@@ -2734,8 +2733,8 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             The molecule for which all specified SMARTS matches are to be located
         smarts : str
             SMARTS string with optional SMIRKS-style atom tagging
-        aromaticity_model : str, optional, default='OEAroModel_MDL'
-            Molecule is prepared with this aromaticity model prior to querying.
+        aromaticity_model : str, optional, default="OEAroModel_MDL"
+            The aromaticity model to use. Only OEAroModel_MDL is supported.
         unique : bool, default=False
             If True, only return unique matches. If False, return all matches.
 

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -1905,8 +1905,8 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         if aromaticity_model not in ALLOWED_AROMATICITY_MODELS:
             raise InvalidAromaticityModelError(
-                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
-                f"{ALLOWED_AROMATICITY_MODELS}."
+                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models: "
+                f"{ALLOWED_AROMATICITY_MODELS}"
             )
 
         # Create an editable RDKit molecule
@@ -1967,8 +1967,9 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         if aromaticity_model == "OEAroModel_MDL":
             Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
         else:
-            raise NotImplementedError(
-                "The aromaticity model is assumed to be OEAroModel_MDL"
+            raise InvalidAromaticityModelError(
+                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:"
+                f"{ALLOWED_AROMATICITY_MODELS}"
             )
 
         # Assign atom stereochemsitry and collect atoms for which RDKit
@@ -2067,7 +2068,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         if aromaticity_model not in ALLOWED_AROMATICITY_MODELS:
             raise InvalidAromaticityModelError(
-                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
+                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models: "
                 f"{ALLOWED_AROMATICITY_MODELS}."
             )
 

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -20,10 +20,14 @@ from openff.units import unit
 from openff.units.elements import SYMBOLS
 
 from openff.toolkit.utils import base_wrapper
-from openff.toolkit.utils.constants import DEFAULT_AROMATICITY_MODEL
+from openff.toolkit.utils.constants import (
+    ALLOWED_AROMATICITY_MODELS,
+    DEFAULT_AROMATICITY_MODEL,
+)
 from openff.toolkit.utils.exceptions import (
     ChargeMethodUnavailableError,
     ConformerGenerationError,
+    InvalidAromaticityModelError,
     NotAttachedToMoleculeError,
     RadicalsNotSupportedError,
     SMILESParseError,
@@ -1899,6 +1903,12 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
     ):
         from rdkit import Chem
 
+        if aromaticity_model not in ALLOWED_AROMATICITY_MODELS:
+            raise InvalidAromaticityModelError(
+                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
+                f"{ALLOWED_AROMATICITY_MODELS}."
+            )
+
         # Create an editable RDKit molecule
         rdmol = Chem.RWMol()
 
@@ -1954,11 +1964,12 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
             Chem.SANITIZE_ALL ^ Chem.SANITIZE_ADJUSTHS ^ Chem.SANITIZE_SETAROMATICITY,
         )
 
-        # Fix for aromaticity being lost
         if aromaticity_model == "OEAroModel_MDL":
             Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
         else:
-            raise ValueError(f"Aromaticity model {aromaticity_model} not recognized")
+            raise NotImplementedError(
+                "The aromaticity model is assumed to be OEAroModel_MDL"
+            )
 
         # Assign atom stereochemsitry and collect atoms for which RDKit
         # can't figure out chirality. The _CIPCode property of these atoms
@@ -2035,8 +2046,8 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         Parameters
         ----------
 
-        aromaticity_model : str, optional, default=DEFAULT_AROMATICITY_MODEL
-            The aromaticity model to use
+        aromaticity_model : str, optional, default="OEAroModel_MDL"
+            The aromaticity model to use. Only OEAroModel_MDL is supported.
 
         Returns
         -------
@@ -2053,6 +2064,12 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         >>> rdmol = ethanol.to_rdkit()
         """
         from rdkit import Chem, Geometry
+
+        if aromaticity_model not in ALLOWED_AROMATICITY_MODELS:
+            raise InvalidAromaticityModelError(
+                f"Given aromaticity model {aromaticity_model} which is not in the set of allowed aromaticity models:  "
+                f"{ALLOWED_AROMATICITY_MODELS}."
+            )
 
         # Convert the OFF molecule's connectivity table to RDKit, returning a cached rdmol if possible
         rdmol = self._connection_table_to_rdkit(
@@ -2334,16 +2351,6 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
                 full_matches |= set(h_matches)
 
             return full_matches
-
-        # Make a copy of the molecule
-        # rdmol = Chem.Mol(rdmol)
-        # Use designated aromaticity model
-        # if aromaticity_model == "OEAroModel_MDL":
-        #    Chem.SanitizeMol(rdmol, Chem.SANITIZE_ALL ^ Chem.SANITIZE_SETAROMATICITY)
-        #    Chem.SetAromaticity(rdmol, Chem.AromaticityModel.AROMATICITY_MDL)
-        # else:
-        #    # Only the OEAroModel_MDL is supported for now
-        #    raise ValueError("Unknown aromaticity model: {}".aromaticity_models)
 
         # Set up query.
         qmol = Chem.MolFromSmarts(smarts)  # cannot catch the error


### PR DESCRIPTION
Our infrastructure only supports one aromaticity model, but our documentation is not always clear about this and the internal logic around checking it is not unified.
 - [x] Make docstrings consistent and clear that `OEAroModel_MDL` is the only supported mode
 - [x] Raise `InvalidAromaticityModelError` where currently some `ValueError`s are raised
 - [x] Leave in place the distinction bewteen `SMIRNOFFAromaticityError` and `InvalidAromaticityModelError`
 - [x] Make internal checks somewhat amenable to expanding the list of supported models in the future (however unlikely)
 - [x] Update some import paths to be more direct

This does not break the API, it extends it very slightly. `InvalidAromaticityModelError` already inherits from `ValueError` so no code should be broken by this. This doesn't close any issues but it touches on #697 #771 #664 #453 (the last of which could be fixed here)

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
