### PR TITLE
Remove unused `aromaticity_model` argument from `Topology.chemical_environment_matches`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -12,6 +12,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### New features
 - [PR #1502](https://github.com/openforcefield/openff-toolkit/pull/1502): Adds Gasteiger charge computation using the RDKit backend.
 
+### Bug fixes
+- [PR #1515](https://github.com/openforcefield/openff-toolkit/pull/1515): Removes unused `aromaticity_model` argument from `Topology.chemical_environment_matches`
+
 ### Improved documentation and warnings
 - [PR #1513](https://github.com/openforcefield/openff-toolkit/pull/1513): Improves error messages and documentation around supported aromaticity models (currently only "OEAroModel_MDL").
 

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -989,7 +989,6 @@ class Topology(Serializable):
     def chemical_environment_matches(
         self,
         query: str,
-        aromaticity_model: str = "MDL",
         unique: bool = False,
         toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
     ):
@@ -1005,9 +1004,6 @@ class Topology(Serializable):
         ----------
         query : str
             SMARTS string (with one or more tagged atoms)
-        aromaticity_model : str
-            Override the default aromaticity model for this topology and use the specified aromaticity model instead.
-            Allowed values: ['MDL']
 
         Returns
         -------


### PR DESCRIPTION
Resolves #453 - arguably an API break since it changes a function signature.

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
