### PR TITLE
Improve reporting of `ForceField` parsing failures

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -14,11 +14,11 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Behavior changes
 - [PR #1498](https://github.com/openforcefield/openff-toolkit/pull/1498): New, more complete, and more descriptive errors for `Molecule.remap()`.
+- [PR #1525](https://github.com/openforcefield/openff-toolkit/pull/1525): Some unrelesed force fields previously accesible from `"openff/toolkit/data/test_forcefields/"` are no longer implicitly available to the `ForceField` constructor.
 
 ### Improved documentation and warnings
 - [PR #1498](https://github.com/openforcefield/openff-toolkit/pull/1498): Improved documentation for `Molecule.remap()`, `Molecule.from_smiles()`, and `Molecule.from_mapped_smiles()`, emphasizing the relationships between these methods. In particular, the documentation now clearly states that `from_smiles()` will not reorder atoms based on SMILES atom mapping.
-
-### Improved documentation and warnings
+- [PR #1525](https://github.com/openforcefield/openff-toolkit/pull/1525): Improves reporting failures when loading force fields.
 - [PR #1513](https://github.com/openforcefield/openff-toolkit/pull/1513): Improves error messages and documentation around supported aromaticity models (currently only "OEAroModel_MDL").
 
 

--- a/openff/toolkit/data/test_forcefields/mangled.offxml
+++ b/openff/toolkit/data/test_forcefields/mangled.offxml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MANGLED
+<SMIRNOFF version="0.3" aromaticity_model="OEAroModel_MDL">
+	<vdW version="0.3" potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1.0" switch_width="1.0 * angstrom" cutoff="9.0 * angstrom" method="cutoff">
+		<Atom smirks="[#1:1]" epsilon="0.0157 * mole**-1 * kilocalorie" id="n1" rmin_half="0.6 * angstrom"></Atom>
+	</vdW>
+	<Electrostatics version="0.4" periodic_potential="Ewald3D-ConductingBoundary" nonperiodic_potential="Coulomb" exception_potential="Coulomb" scale12="0.0" scale13="0.0" scale14="0.833333" scale15="1.0" switch_width="0.0 * angstrom" cutoff="9.0 * angstrom"></Electrostatics>
+	<ToolkitAM1BCC version="0.3"></ToolkitAM1BCC>
+</SMIRNOFF>

--- a/openff/toolkit/tests/test_utils.py
+++ b/openff/toolkit/tests/test_utils.py
@@ -84,9 +84,11 @@ def test_sort_smirnoff_dict():
     from collections import OrderedDict
 
     from openff.toolkit.typing.engines.smirnoff import ForceField
-    from openff.toolkit.utils.utils import sort_smirnoff_dict
+    from openff.toolkit.utils.utils import get_data_file_path, sort_smirnoff_dict
 
-    forcefield = ForceField("test_forcefields/test_forcefield.offxml")
+    forcefield = ForceField(
+        get_data_file_path("test_forcefields/test_forcefield.offxml")
+    )
     smirnoff_dict = forcefield._to_smirnoff_data()
 
     # Ensure data is not created or destroyed


### PR DESCRIPTION
This PR improves a handful of failure cases of parsing OFFXML files that I think are confusing. It also closes #1168

In particular, the current error message reported when trying to load a file that does not exist is confusing - the issue is _not_ that there is a syntax error in the first column of the first line - and obfuscated which file paths were searched by the plugin architecture:

```python3
>>> from openff.toolkit import ForceField
>>> ForceField("file-does-not-exist.offml")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/forcefield.py", line 308, in __init__
    self.parse_sources(sources, allow_cosmetic_attributes=allow_cosmetic_attributes)
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/forcefield.py", line 770, in parse_sources
    smirnoff_data = self.parse_smirnoff_from_source(source)
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/forcefield.py", line 1013, in parse_smirnoff_from_source
    raise IOError(msg)
OSError: Source file-does-not-exist.offml could not be read. If this is a file, ensure that the path is correct.
If the file is present, ensure it is in a known SMIRNOFF encoding.
Valid formats are: ['XML']
Parsing failed with the following error:
syntax error: line 1, column 0

>>>
```

becomes
```python3
>>> from openff.toolkit import ForceField
>>> ForceField("file-does-not-exist.offml")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/forcefield.py", line 308, in __init__
    self.parse_sources(sources, allow_cosmetic_attributes=allow_cosmetic_attributes)
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/forcefield.py", line 770, in parse_sources
    smirnoff_data = self.parse_smirnoff_from_source(source)
  File "/Users/mattthompson/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/forcefield.py", line 1029, in parse_smirnoff_from_source
    raise IOError(msg)
OSError: Source 'file-does-not-exist.offml' could not be read. If this is a file, ensure that the path is correct.
Looked in the following paths and found no files named 'file-does-not-exist.offml':
    /Users/mattthompson/software/openff-toolkit
    /Users/mattthompson/mambaforge/envs/test/lib/python3.9/site-packages/smirnoff99frosst/offxml
    /Users/mattthompson/mambaforge/envs/test/lib/python3.9/site-packages/openff/amber_ff_ports/offxml
    /Users/mattthompson/mambaforge/envs/test/lib/python3.9/site-packages/openforcefields/offxml
If 'file-does-not-exist.offml' is present as a file, ensure it is in a known SMIRNOFF encoding.
Valid formats are: ['XML']
Parsing failed while trying to parse source as a file with the following exception and message:
<class 'openff.toolkit.utils.exceptions.SMIRNOFFParseError'>
syntax error: line 1, column 0

>>>
```

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
