### PR TITLE
Test on Python 3.11

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         rdkit: [true, false]
         openeye: [true, false]
         exclude:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8"]
+        python-version: ["3.8", "3.11"]
         rdkit: [true, false]
         openeye: [true, false]
         exclude:


### PR DESCRIPTION
The new OpenMM builds include Python 3.11 (released October 2022) so let's see what else is missing.

https://anaconda.org/conda-forge/openmm/files

Related #1534