### PR TITLE
Use `flake8-bugbear` to safeguard against default mutable args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     additional_dependencies: [
         'flake8-absolute-import',
         'flake8-no-pep420',
+        'flake8-bugbear',
     ]
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.6.1

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -123,7 +123,7 @@ class _TransformedDict(MutableMapping):
         return key
 
     @classmethod
-    def _return_possible_index_of(cls, key, possible=[], permutations={}):
+    def _return_possible_index_of(cls, key, possible, permutations):
         """
         Returns canonical ordering of ``key``, given a dictionary of ordered
         ``permutations`` and a list of allowed orders ``possible``.

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -26,7 +26,7 @@ __all__ = [
 import contextlib
 import functools
 import logging
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Iterable, List, Tuple, Union
 
 import numpy as np
 import pint
@@ -209,7 +209,7 @@ def string_to_quantity(quantity_string) -> Union[str, int, float, unit.Quantity]
 
 def convert_all_strings_to_quantity(
     smirnoff_data: Dict,
-    ignore_keys: List[str] = list(),
+    ignore_keys: Iterable[str] = tuple(),
 ):
     """
     Traverses a SMIRNOFF data structure, attempting to convert all
@@ -222,6 +222,8 @@ def convert_all_strings_to_quantity(
     ----------
     smirnoff_data : dict
         A hierarchical dict structured in compliance with the SMIRNOFF spec
+    ignore_keys : iterable of str, optional, default=tuple()
+        A list of keys to skip when converting strings to quantities
 
     Returns
     -------

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ exclude_lines =
 [flake8]
 # Flake8, PyFlakes, etc
 max-line-length = 119
-ignore = E203,W605,W503
+ignore = E203,W605,W503,B007,B009,B011,B014,B017
 exclude =
     openff/toolkit/tests/_stale_tests.py
 per-file-ignores =
@@ -177,3 +177,4 @@ doctest_optionflags =
     ELLIPSIS
     DONT_ACCEPT_TRUE_FOR_1
     NORMALIZE_WHITESPACE
+


### PR DESCRIPTION
Closes #780 and prevents this code smell from being introduced in the future (as I did in #1494).

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
