### PR TITLE
More `flake8-bugbear`: fix B014, B017

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -41,6 +41,7 @@ from openff.toolkit.tests.utils import (
 )
 from openff.toolkit.topology.molecule import (
     Atom,
+    BondExistsError,
     FrozenMolecule,
     HierarchyElement,
     HierarchySchemeNotFoundException,
@@ -3098,7 +3099,7 @@ class TestMolecule:
                 fractional_bond_order=bond.fractional_bond_order,
             )
         # Try to add the final bond twice, which should raise an Exception
-        with pytest.raises(Exception):
+        with pytest.raises(BondExistsError):
             molecule_copy.add_bond(
                 bond.atom1_index,
                 bond.atom2_index,

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -51,6 +51,7 @@ from openff.toolkit.utils import (
 )
 from openff.toolkit.utils.exceptions import (
     AtomNotInTopologyError,
+    BondNotInTopologyError,
     DuplicateUniqueMoleculeError,
     IncompatibleUnitError,
     InvalidBoxVectorsError,
@@ -271,8 +272,6 @@ class TestTopology:
         """Test Topology.atom function (atom lookup from index)"""
         topology = Topology()
         topology.add_molecule(ethane_from_smiles())
-        with pytest.raises(Exception):
-            topology.atom(-1)
 
         # Make sure we get 2 carbons and 8 hydrogens
         n_carbons = 0
@@ -285,7 +284,13 @@ class TestTopology:
         assert n_carbons == 2
         assert n_hydrogens == 6
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="must be an int.*'str'"):
+            topology.atom("one")
+
+        with pytest.raises(AtomNotInTopologyError):
+            topology.atom(-1)
+
+        with pytest.raises(AtomNotInTopologyError):
             topology.atom(8)
 
     def test_atom_index(self):
@@ -336,8 +341,6 @@ class TestTopology:
         topology = Topology()
         topology.add_molecule(ethane_from_smiles())
         topology.add_molecule(ethene_from_smiles())
-        with pytest.raises(Exception):
-            topology.bond(-1)
 
         n_single_bonds = 0
         n_double_bonds = 0
@@ -366,7 +369,13 @@ class TestTopology:
         assert n_cc_bonds == 2
         assert n_ch_bonds == 10
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError, match="must be an int.*'str'"):
+            topology_bond = topology.bond("one")
+
+        with pytest.raises(BondNotInTopologyError, match="No bond with index -1"):
+            topology.bond(-1)
+
+        with pytest.raises(BondNotInTopologyError, match="No bond with index 12"):
             topology_bond = topology.bond(12)
 
     def test_angles(self):

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -54,6 +54,7 @@ from typing_extensions import TypeAlias
 
 from openff.toolkit.utils.constants import DEFAULT_AROMATICITY_MODEL
 from openff.toolkit.utils.exceptions import (
+    BondExistsError,
     HierarchySchemeNotFoundException,
     HierarchySchemeWithIteratorNameAlreadyRegisteredException,
     IncompatibleUnitError,
@@ -2866,7 +2867,7 @@ class FrozenMolecule(Serializable):
             )
         # TODO: Check to make sure bond does not already exist
         if atom1_atom.is_bonded_to(atom2_atom):
-            raise Exception(
+            raise BondExistsError(
                 f"Bond already exists between {atom1_atom} and {atom2_atom})"
             )
         bond = Bond(

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -49,6 +49,7 @@ from openff.toolkit.utils.constants import (
 )
 from openff.toolkit.utils.exceptions import (
     AtomNotInTopologyError,
+    BondNotInTopologyError,
     DuplicateUniqueMoleculeError,
     IncompatibleUnitError,
     InvalidAromaticityModelError,
@@ -2289,8 +2290,18 @@ class Topology(Serializable):
         -------
         An openff.toolkit.topology.TopologyAtom
         """
-        assert type(atom_topology_index) is int
-        assert 0 <= atom_topology_index < self.n_atoms
+        if not isinstance(atom_topology_index, int):
+            raise ValueError(
+                "Argument passed to `Topology.atom` must be an int. "
+                f"Given argument of type {type(atom_topology_index)}."
+            )
+
+        if not (0 <= atom_topology_index < self.n_atoms):
+            raise AtomNotInTopologyError(
+                f"No atom with index {atom_topology_index} exists in this topology, "
+                f"which contains {self.n_atoms} atoms."
+            )
+
         this_molecule_start_index = 0
         next_molecule_start_index = 0
         for molecule in self.molecules:
@@ -2324,9 +2335,24 @@ class Topology(Serializable):
         Returns
         -------
         An openff.toolkit.topology.TopologyBond
+
+        Raises
+        ------
+        ValueError if bond_topology_index is not an int
+        BondNotInTopologyError if bond_topology_index is not in the range [0, self.n_bonds)
         """
-        assert type(bond_topology_index) is int
-        assert 0 <= bond_topology_index < self.n_bonds
+        if not isinstance(bond_topology_index, int):
+            raise ValueError(
+                "Argument passed to `Topology.bond` must be an int. "
+                f"Given argument of type {type(bond_topology_index)}."
+            )
+
+        if not (0 <= bond_topology_index < self.n_bonds):
+            raise BondNotInTopologyError(
+                f"No bond with index {bond_topology_index} exists in this topology, "
+                f"which contains {self.n_bonds} bonds."
+            )
+
         this_molecule_start_index = 0
         next_molecule_start_index = 0
         for molecule in self._molecules:

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -994,7 +994,7 @@ class ForceField:
                 exception_type = type(e)
                 exception_context = "while trying to parse source as an object"
                 exception_msg = e.msg
-            except (FileNotFoundError, OSError):
+            except OSError:
                 # If this is not a file path or a file handle, attempt parsing as a string.
                 # TODO: Do we actually support parsing bytes?
                 try:

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -120,12 +120,20 @@ class AtomNotInTopologyError(NotInTopologyError):
     """An atom was not found in a topology."""
 
 
+class BondNotInTopologyError(NotInTopologyError):
+    """An bond was not found in a topology."""
+
+
 class MoleculeNotInTopologyError(NotInTopologyError):
     """A molecule was not found in a topology."""
 
 
 class InvalidAtomMetadataError(OpenFFToolkitException):
     """The program attempted to set atom metadata to an invalid type"""
+
+
+class BondExistsError(OpenFFToolkitException):
+    """The program attempted to add a bond that already exists"""
 
 
 class DuplicateUniqueMoleculeError(OpenFFToolkitException):

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -173,7 +173,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         for tool, license_func in cls._license_functions.items():
             try:
                 module = importlib.import_module("openeye." + tool)
-            except (ImportError, ModuleNotFoundError):
+            except ImportError:
                 continue
             else:
                 if getattr(module, license_func)():
@@ -203,7 +203,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
                     cls._is_installed = True
                     try:
                         importlib.import_module("openeye." + tool)
-                    except (ImportError, ModuleNotFoundError):
+                    except ImportError:
                         cls._is_installed = False
             if cls._is_installed:
                 if cls._is_licensed:
@@ -2788,7 +2788,7 @@ def requires_openeye_module(module_name):
         def wrapper(*args, **kwargs):
             try:
                 module = importlib.import_module("openeye." + module_name)
-            except (ImportError, ModuleNotFoundError):
+            except ImportError:
                 # TODO: Custom exception
                 raise Exception("openeye." + module_name)
             try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ exclude_lines =
 [flake8]
 # Flake8, PyFlakes, etc
 max-line-length = 119
-ignore = E203,W605,W503,B007,B009,B011,B014,B017
+ignore = E203,W605,W503,B007,B009,B011
 exclude =
     openff/toolkit/tests/_stale_tests.py
 per-file-ignores =


### PR DESCRIPTION
Another  follow-on to https://github.com/openforcefield/openff-toolkit/pull/1539; in this case `pytest.raises(Exception)` was masking some (in my opinion) subpar error handling, so I implemented some more discrete cases.

A couple of the other smaller changes would have been caught by https://github.com/asottile/pyupgrade, a tool I've used for a long time and think does a good job of keeping old (i.e. Python 2 and <3.8) constructs out.  It's easy to add - don't need to do that now.
