### PR TITLE
Do not rely on removed `packaging.version.LegacyVersion` for sorting hierarchy elements

### DIFF
--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -8,7 +8,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =21
+  - packaging =23
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -8,7 +8,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packging
+  - packaging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -8,7 +8,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =23
+  - packging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =23
+  - packging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =21
+  - packaging =23
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packging
+  - packaging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =23
+  - packging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =21
+  - packaging =23
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packging
+  - packaging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -5,7 +5,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =21
+  - packaging =23
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -5,7 +5,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =23
+  - packging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -5,7 +5,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packging
+  - packaging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -5,7 +5,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =21
+  - packaging =23
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -5,7 +5,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =23
+  - packging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -5,7 +5,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packging
+  - packaging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =23
+  - packging
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packaging =21
+  - packaging =23
   - numpy
   - networkx
   - cachetools

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - python
   - pip
-  - packging
+  - packaging
   - numpy
   - networkx
   - cachetools

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -16,6 +16,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### Behavior changes
 - [PR #1498](https://github.com/openforcefield/openff-toolkit/pull/1498): New, more complete, and more descriptive errors for `Molecule.remap()`.
 - [PR #1525](https://github.com/openforcefield/openff-toolkit/pull/1525): Some unrelesed force fields previously accesible from `"openff/toolkit/data/test_forcefields/"` are no longer implicitly available to the `ForceField` constructor.
+- [PR #1545](https://github.com/openforcefield/openff-toolkit/pull/1545): Replaced the logic that sorts `HierarchyElements` with dedicated code in the OpenFF Toolkit instead of relying on deprecated features in the `packaging` module.
+
 
 ### Improved documentation and warnings
 - [PR #1498](https://github.com/openforcefield/openff-toolkit/pull/1498): Improved documentation for `Molecule.remap()`, `Molecule.from_smiles()`, and `Molecule.from_mapped_smiles()`, emphasizing the relationships between these methods. In particular, the documentation now clearly states that `from_smiles()` will not reorder atoms based on SMILES atom mapping.

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -43,6 +43,7 @@ from openff.toolkit.topology.molecule import (
     Atom,
     FrozenMolecule,
     HierarchyElement,
+    HierarchyScheme,
     HierarchySchemeNotFoundException,
     HierarchySchemeWithIteratorNameAlreadyRegisteredException,
     InvalidAtomMetadataError,
@@ -4498,20 +4499,72 @@ class TestHierarchies:
             0
         ].identifier
 
+    def test_hierarchy_element_generation(self):
+        """Ensure that hierarchy elements are generated correctly from atom metadata"""
+        from openff.toolkit.tests.create_molecules import create_ethanol
+
+        ethanol = create_ethanol()
+
+        for atom in ethanol.atoms:
+            atom.metadata["residue_name"] = "AAA"
+            atom.metadata["residue_number"] = 1
+            atom.metadata["chain_id"] = "A"
+
+        ethanol.atoms[1].metadata["chain_id"] = "Z"
+        del ethanol.atoms[2].metadata["chain_id"]
+        ethanol.atoms[3].metadata["chain_id"] = 1
+        ethanol.atoms[4].metadata["residue_number"] = "1"
+        ethanol.atoms[5].metadata["residue_name"] = "ZZZ"
+        del ethanol.atoms[6].metadata["residue_name"]
+        ethanol.atoms[7].metadata["residue_number"] = 2
+        ethanol.add_default_hierarchy_schemes()
+
+        expected_chains = [(("A",), 6), (("None",), 1), (("Z",), 1), ((1,), 1)]
+
+        assert len(ethanol.chains) == len(expected_chains)
+        for chain, exp_chain in zip(ethanol.chains, expected_chains):
+            assert chain.identifier == exp_chain[0]
+            assert len(chain.atom_indices) == exp_chain[1]
+
+        expected_residues = [
+            (("A", 1, "None", "AAA"), 2),
+            (("A", "1", "None", "AAA"), 1),
+            (("A", 1, "None", "None"), 1),
+            (("A", 1, "None", "ZZZ"), 1),
+            (("A", 2, "None", "AAA"), 1),
+            (("None", 1, "None", "AAA"), 1),
+            (("Z", 1, "None", "AAA"), 1),
+            ((1, 1, "None", "AAA"), 1),
+        ]
+
+        assert len(ethanol.residues) == len(expected_residues)
+        for residue, exp_residue in zip(ethanol.residues, expected_residues):
+            assert residue.identifier == exp_residue[0]
+            assert len(residue.atom_indices) == exp_residue[1]
+
     def test_hierarchy_element_sorting(self):
         """Ensure that hierarchy elements are sorted correctly"""
-        from openff.toolkit.tests.create_molecules import (
-            dipeptide_hierarchy_added as create_dipeptide,
-        )
+        hs = HierarchyScheme(None, ("foo", "bar"), "foobar")
+        # Atom lists are used here to indicate the positions
+        # that this element may have in the "proper" sorting.
+        hs.add_hierarchy_element(("Z", 10), [13])
+        hs.add_hierarchy_element(("Z", 5), [12])
+        # Switch two values so the list isn't just reversed from the correct sorting
+        hs.add_hierarchy_element(("None", "10"), [10])
+        hs.add_hierarchy_element(("Y", 10), [11])
+        hs.add_hierarchy_element(("A", 10), [8, 9])
+        hs.add_hierarchy_element(("A", "10"), [8, 9])
+        hs.add_hierarchy_element(("A", 1), [5, 6, 7])
+        hs.add_hierarchy_element(("A", "1"), [5, 6, 7])
+        hs.add_hierarchy_element(("A", "  1"), [5, 6, 7])
+        hs.add_hierarchy_element(("A", "None"), [4])
+        hs.add_hierarchy_element(("A", " "), [2, 3])
+        hs.add_hierarchy_element(("A", ""), [2, 3])
+        hs.add_hierarchy_element((" ", "10"), [0, 1])
+        hs.add_hierarchy_element(("", "10"), [0, 1])
+        hs.sort_hierarchy_elements()
 
-        dipeptide_hierarchy_perceived = create_dipeptide()
-
-        # Add one atom to chain "Z", force an update of the hierarchy schemes,
-        # and ensure that the last residue in the iterator is now chain "Z"
-        dipeptide_hierarchy_perceived.atoms[1].metadata["chain_id"] = "Z"
-        dipeptide_hierarchy_perceived.atoms[2].metadata["residue_number"] = 999
-        dipeptide_hierarchy_perceived.atoms[3].metadata["residue_name"] = "ZZZ"
-        dipeptide_hierarchy_perceived.update_hierarchy_schemes()
-        assert dipeptide_hierarchy_perceived.residues[-1].chain_id == "Z"
-        assert dipeptide_hierarchy_perceived.residues[-2].residue_number == 999
-        assert dipeptide_hierarchy_perceived.residues[-4].residue_name == "ZZZ"
+        # Compare the sorted hierarchyelements to their expected sortings
+        # (assuming that the atom indices indicate valid positions for the resulting elements in the proper sorting)
+        for idx, ele in enumerate(hs.hierarchy_elements):
+            assert idx in ele.atom_indices

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5785,9 +5785,20 @@ class HierarchyScheme:
         their identifiers.
         """
 
-        # hard-code the sort_func value here, since it's hard to serialize safely
         def sort_func(x):
-            return version.parse(".".join([str(i) for i in x.identifier]))
+            """Sort by int-like tags, using version.Version as a quick hack."""
+            tag = ""
+            for i in x.identifier:
+                try:
+                    int(i)
+                except ValueError:
+                    continue
+                tag += i + "."
+
+            if tag.endswith("."):
+                tag = tag[:-1]
+
+            return version.parse(tag)
 
         self.hierarchy_elements.sort(key=sort_func)
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5812,7 +5812,7 @@ class HierarchyScheme:
 
             return tuple()
 
-        if False:
+        if True:
             # Using chain- and residue-specific sorting functions might be safer against some corner
             # cases, but the logic built into the fallback `_sort_other` works for existing tests
             _sort_functions = {

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -50,7 +50,6 @@ import numpy as np
 from openff.units import Quantity, unit
 from openff.units.elements import MASSES, SYMBOLS
 from openff.utilities.exceptions import MissingOptionalDependencyError
-from packaging import version
 from typing_extensions import TypeAlias
 
 from openff.toolkit.utils.constants import DEFAULT_AROMATICITY_MODEL
@@ -5789,31 +5788,7 @@ class HierarchyScheme:
         Semantically sort the HierarchyElements belonging to this object, according to
         their identifiers.
         """
-
-        def sort_func(x: HierarchyElement) -> version.Version:
-            """Sort by int-like tags, using version.Version as a quick hack."""
-            tag = ""
-            for i in x.identifier:
-                if isinstance(i, int):
-                    _str_i = str(i)
-                elif isinstance(i, str):
-                    try:
-                        int(i)
-                    except ValueError:
-                        continue
-                    _str_i = i
-                else:
-                    raise Exception(f"Unexpected type {type(i)} as identifier")
-                tag += _str_i + "."
-
-            if tag.endswith("."):
-                # If something was smooshed together, return that without the trailing dot,
-                return version.Version(tag[:-1])
-            else:
-                # otherwise just return a zero version placeholder
-                return version.Version("0")
-
-        self.hierarchy_elements.sort(key=sort_func)
+        self.hierarchy_elements.sort(key=lambda x: str([*x.identifier]))
 
     def __str__(self):
         return (

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5846,7 +5846,7 @@ class HierarchyElement:
     def __init__(
         self,
         scheme: HierarchyScheme,
-        identifier: Tuple[str, int],
+        identifier: Tuple[Union[str, int]],
         atom_indices: Sequence[int],
     ):
         """

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5810,7 +5810,7 @@ class HierarchyScheme:
                 except ValueError:
                     x.append(identifier)
 
-            return tuple()
+            return tuple(x)
 
         if True:
             # Using chain- and residue-specific sorting functions might be safer against some corner

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5790,7 +5790,7 @@ class HierarchyScheme:
         their identifiers.
         """
 
-        def sort_func(x):
+        def sort_func(x: HierarchyElement) -> version.Version:
             """Sort by int-like tags, using version.Version as a quick hack."""
             tag = ""
             for i in x.identifier:
@@ -5807,9 +5807,11 @@ class HierarchyScheme:
                 tag += _str_i + "."
 
             if tag.endswith("."):
-                tag = tag[:-1]
-
-            return version.parse(tag)
+                # If something was smooshed together, return that without the trailing dot,
+                return version.Version(tag[:-1])
+            else:
+                # otherwise just return a zero version placeholder
+                return version.Version("0")
 
         self.hierarchy_elements.sort(key=sort_func)
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5789,42 +5789,20 @@ class HierarchyScheme:
         their identifiers.
         """
 
-        def _sort_chains(element: HierarchyScheme) -> str:
-            return str(element.identifier[0])
-
-        def _sort_residues(element: HierarchyScheme) -> tuple[str, int]:
-            return (
-                str(element.identifier[0]),
-                int(element.identifier[1]),
-                str(element.identifier[2]),
-                str(element.identifier[3]),
-            )
-
-        def _sort_other(element: HierarchyScheme) -> tuple[str, int]:
-            x = list()
+        def _sort(element: HierarchyElement) -> Tuple[Union[str, int], ...]:
+            keys: List[Union[str, int]] = list()
             for identifier in element.identifier:
                 # If an identifier is int-ish, cast it to int,
                 # otherwise let it remain as a string
                 try:
-                    x.append(int(identifier))
+                    keys.append(int(identifier))  # type: ignore[call-overload]
                 except ValueError:
-                    x.append(identifier)
+                    assert isinstance(identifier, str)
+                    keys.append(identifier)
 
-            return tuple(x)
+            return tuple(keys)
 
-        if True:
-            # Using chain- and residue-specific sorting functions might be safer against some corner
-            # cases, but the logic built into the fallback `_sort_other` works for existing tests
-            _sort_functions = {
-                "chains": _sort_chains,
-                "residues": _sort_residues,
-            }
-
-            self.hierarchy_elements.sort(
-                key=_sort_functions.get(self.iterator_name, _sort_other)
-            )
-        else:
-            self.hierarchy_elements.sort(key=_sort_other)
+        self.hierarchy_elements.sort(key=_sort)
 
     def __str__(self):
         return (

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5798,7 +5798,10 @@ class HierarchyScheme:
                     keys.append(int(identifier))  # type: ignore[call-overload]
                 except ValueError:
                     assert isinstance(identifier, str)
-                    keys.append(identifier)
+                    if identifier == "None":
+                        keys.append(0)
+                    else:
+                        keys.append(identifier)
 
             return tuple(keys)
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5876,7 +5876,7 @@ class HierarchyElement:
         ):
             setattr(self, uniqueness_component, id_component)
 
-    def to_dict(self) -> Dict[str, Union[Tuple[str, int], Sequence[int]]]:
+    def to_dict(self) -> Dict[str, Union[Tuple[Union[str, int]], Sequence[int]]]:
         """
         Serialize this object to a basic dict of strings and lists of ints.
         """

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5802,7 +5802,7 @@ class HierarchyScheme:
 
             # Iterate over identifier components for comparison
             for val1, val2 in zip(a.identifier, b.identifier):
-                # Try converting strings to ints
+                # Try converting any strings to ints
                 try:
                     val1 = int(val1)
                 except ValueError:
@@ -5812,7 +5812,7 @@ class HierarchyScheme:
                 except ValueError:
                     pass
 
-                # If a_ele and b_ele are the same type, use built-in comparison
+                # If val1 and val2 are the same type, use built-in comparison
                 if type(val1) is type(val2):
                     if val1 < val2:
                         return -1
@@ -5820,12 +5820,16 @@ class HierarchyScheme:
                         return 1
                     else:
                         continue
+
+                # Otherwise, assume that ints are "greater than" strings.
                 else:
-                    # Otherwise, assume that ints are "greater than" strings.
                     if type(val1) is int:
                         return 1
-                    else:
+                    elif type(val2) is int:
                         return -1
+            # If we've finished comparing the values in the identifiers without
+            # finding one to be greater than the other, then these two identifiers
+            # must be equal.
             return 0
 
         self.hierarchy_elements.sort(key=cmp_to_key(compare_hier_identifiers))

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5788,7 +5788,43 @@ class HierarchyScheme:
         Semantically sort the HierarchyElements belonging to this object, according to
         their identifiers.
         """
-        self.hierarchy_elements.sort(key=lambda x: str([*x.identifier]))
+
+        def _sort_chains(element: HierarchyScheme) -> str:
+            return str(element.identifier[0])
+
+        def _sort_residues(element: HierarchyScheme) -> tuple[str, int]:
+            return (
+                str(element.identifier[0]),
+                int(element.identifier[1]),
+                str(element.identifier[2]),
+                str(element.identifier[3]),
+            )
+
+        def _sort_other(element: HierarchyScheme) -> tuple[str, int]:
+            x = list()
+            for identifier in element.identifier:
+                # If an identifier is int-ish, cast it to int,
+                # otherwise let it remain as a string
+                try:
+                    x.append(int(identifier))
+                except ValueError:
+                    x.append(identifier)
+
+            return tuple()
+
+        if False:
+            # Using chain- and residue-specific sorting functions might be safer against some corner
+            # cases, but the logic built into the fallback `_sort_other` works for existing tests
+            _sort_functions = {
+                "chains": _sort_chains,
+                "residues": _sort_residues,
+            }
+
+            self.hierarchy_elements.sort(
+                key=_sort_functions.get(self.iterator_name, _sort_other)
+            )
+        else:
+            self.hierarchy_elements.sort(key=_sort_other)
 
     def __str__(self):
         return (

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -38,6 +38,7 @@ from typing import (
     Generator,
     List,
     Optional,
+    Sequence,
     Set,
     TextIO,
     Tuple,
@@ -5760,7 +5761,11 @@ class HierarchyScheme:
 
         self.sort_hierarchy_elements()
 
-    def add_hierarchy_element(self, identifier, atom_indices):
+    def add_hierarchy_element(
+        self,
+        identifier: Tuple[str, int],
+        atom_indices: Sequence[int],
+    ):
         """
         Instantiate a new HierarchyElement belonging to this HierarchyScheme.
 
@@ -5771,7 +5776,7 @@ class HierarchyScheme:
         identifier : tuple of str and int
             Tuple of metadata values (not keys) that define the uniqueness
             criteria for this element
-        atom_indices : iterable int
+        atom_indices : sequence of int
             The indices of atoms in ``scheme.parent`` that are in this
             element
         """
@@ -5789,11 +5794,17 @@ class HierarchyScheme:
             """Sort by int-like tags, using version.Version as a quick hack."""
             tag = ""
             for i in x.identifier:
-                try:
-                    int(i)
-                except ValueError:
-                    continue
-                tag += i + "."
+                if isinstance(i, int):
+                    _str_i = str(i)
+                elif isinstance(i, str):
+                    try:
+                        int(i)
+                    except ValueError:
+                        continue
+                    _str_i = i
+                else:
+                    raise Exception(f"Unexpected type {type(i)} as identifier")
+                tag += _str_i + "."
 
             if tag.endswith("."):
                 tag = tag[:-1]
@@ -5819,7 +5830,7 @@ class HierarchyElement:
         self,
         scheme: HierarchyScheme,
         identifier: Tuple[str, int],
-        atom_indices: List[int],
+        atom_indices: Sequence[int],
     ):
         """
         Create a new hierarchy element.
@@ -5832,7 +5843,7 @@ class HierarchyElement:
         identifier : tuple of str and int
             Tuple of metadata values (not keys) that define the uniqueness
             criteria for this element
-        atom_indices : list of int
+        atom_indices : sequence of int
             The indices of particles in ``scheme.parent`` that are in this
             element
         """
@@ -5844,7 +5855,7 @@ class HierarchyElement:
         ):
             setattr(self, uniqueness_component, id_component)
 
-    def to_dict(self) -> Dict[str, Union[Tuple[str, int], List[int]]]:
+    def to_dict(self) -> Dict[str, Union[Tuple[str, int], Sequence[int]]]:
         """
         Serialize this object to a basic dict of strings and lists of ints.
         """


### PR DESCRIPTION
Fixes #1487 

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
