### PR TITLE
Use stacklevel 2

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -97,6 +97,7 @@ def _molecule_deprecation(old_method, new_method):
     warnings.warn(
         f"Molecule.{old_method} is deprecated. Use Molecule.{new_method} instead.",
         MoleculeDeprecationWarning,
+        stacklevel=2,
     )
 
 
@@ -2493,6 +2494,7 @@ class FrozenMolecule(Serializable):
                     f"run on this molecule (found {self.n_atoms} atoms). For more, see "
                     "https://docs.openforcefield.org/projects/toolkit/en/stable/faq.html"
                     "#parameterizing-my-system-which-contains-a-large-molecule-is-taking-forever-whats-wrong",
+                    stacklevel=2,
                 )
 
         if isinstance(toolkit_registry, ToolkitRegistry):
@@ -5391,7 +5393,8 @@ class Molecule(FrozenMolecule):
                 warnings.warn(
                     "RDKit was requested as a visualization backend but "
                     "it was not found to be installed. Falling back to "
-                    "trying to use OpenEye for visualization."
+                    "trying to use OpenEye for visualization.",
+                    stacklevel=2,
                 )
                 backend = "openeye"
         if backend == "openeye":

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -79,6 +79,7 @@ def _topology_deprecation(old_method, new_method):
     warnings.warn(
         f"Topology.{old_method} is deprecated. Use Topology.{new_method} instead.",
         TopologyDeprecationWarning,
+        stacklevel=2,
     )
 
 

--- a/openff/toolkit/typing/chemistry/environment.py
+++ b/openff/toolkit/typing/chemistry/environment.py
@@ -78,6 +78,7 @@ class ChemicalEnvironment:
             "release. If you rely on the functionality in this class, please "
             "open an issue on the openff-toolkit GitHub.",
             ChemicalEnvironmentDeprecationWarning,
+            stacklevel=2,
         )
 
         # Support string input for toolkit names for legacy reasons

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -1179,7 +1179,7 @@ class ForceField:
                 "`Interchange.to_openmm_topology`, and `Interchange.to_openmm` "
                 "for long-term replacements for `return_topology` functionality."
             )
-            warnings.warn(warning_msg, DeprecationWarning)
+            warnings.warn(warning_msg, DeprecationWarning, stacklevel=2)
             return openmm_system, copy.deepcopy(interchange.topology)
 
     @requires_package("openff.interchange")

--- a/openff/toolkit/utils/base_wrapper.py
+++ b/openff/toolkit/utils/base_wrapper.py
@@ -253,7 +253,7 @@ class ToolkitWrapper:
             wrong_confs_msg += exception_suffix
             raise IncorrectNumConformersError(wrong_confs_msg)
         else:
-            warnings.warn(wrong_confs_msg, IncorrectNumConformersWarning)
+            warnings.warn(wrong_confs_msg, IncorrectNumConformersWarning, stacklevel=2)
 
     def __repr__(self):
         return (

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -987,7 +987,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
                     f" as {element_name}. Does your mol2 file uses Tripos SYBYL atom types?"
                     " Other atom types such as GAFF are not supported."
                 )
-                warnings.warn(warn_msg, GAFFAtomTypeWarning)
+                warnings.warn(warn_msg, GAFFAtomTypeWarning, stacklevel=2)
 
     @staticmethod
     def _openeye_cip_atom_stereochemistry(oemol, oeatom):

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ exclude_lines =
 [flake8]
 # Flake8, PyFlakes, etc
 max-line-length = 119
-ignore = E203,W605,W503,B028
+ignore = E203,W605,W503
 exclude =
     openff/toolkit/tests/_stale_tests.py
 per-file-ignores =


### PR DESCRIPTION
A recent change in `flake8-bugbear` suggests using `warnings.warn(..., stacklevel=2)` to ["provide more information to the user"](https://pypi.org/project/flake8-bugbear/#description). The difference is how far back into the stack trace something is spat out to the user; the default is to show just where `warnings.warn` was called but `stacklevel=2` goes farther back and displays more about where it was called. Not a ton of information is added for some of our warnings but I like this lint - more information is better and it's not a bad habit to get into. 

```console
$ git checkout 0.12.1                                                  12:45:46  ☁  e05c8766 ☂
HEAD is now at e05c8766 0.12.1 release prep (#1556)
$ python                                                               12:45:47  ☁  e05c8766 ☂
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:27:35) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from openff.toolkit import Molecule
>>> Molecule.from_smiles("O").to_topology().reference_molecules
/Users/mattthompson/software/openff-toolkit/openff/toolkit/topology/topology.py:79: TopologyDeprecationWarning: Topology.reference_molecules is deprecated. Use Topology.unique_molecules instead.
  warnings.warn(
<generator object Topology.unique_molecules at 0x176d22b20>
>>>
$ git checkout -                                                       12:46:02  ☁  e05c8766 ☂
Previous HEAD position was e05c8766 0.12.1 release prep (#1556)
Switched to branch 'stacklevel-2'
$ python                                                           12:46:05  ☁  stacklevel-2 ☂
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:27:35) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from openff.toolkit import Molecule
>>> Molecule.from_smiles("O").to_topology().reference_molecules
/Users/mattthompson/software/openff-toolkit/openff/toolkit/topology/topology.py:2546: TopologyDeprecationWarning: Topology.reference_molecules is deprecated. Use Topology.unique_molecules instead.
  _topology_deprecation("reference_molecules", "unique_molecules")
<generator object Topology.unique_molecules at 0x17916ab20>
>>>
```