### PR TITLE
Fix 'Loentz-Berthelot' typo in test force field files

### DIFF
--- a/examples/deprecated/partial_bondorder/Frosst_AlkEthOH_extracarbons.ffxml
+++ b/examples/deprecated/partial_bondorder/Frosst_AlkEthOH_extracarbons.ffxml
@@ -55,7 +55,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[OX1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
    <!-- sigma is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-C):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openff/toolkit/data/test_forcefields/Frosst_AlkEthOH_GBSA.offxml
+++ b/openff/toolkit/data/test_forcefields/Frosst_AlkEthOH_GBSA.offxml
@@ -46,7 +46,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[#8X1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
    <!-- sigma is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-[#6]):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openff/toolkit/data/test_forcefields/Frosst_AlkEthOH_MDL.offxml
+++ b/openff/toolkit/data/test_forcefields/Frosst_AlkEthOH_MDL.offxml
@@ -44,7 +44,7 @@
    <Improper smirks="[a,A:1]~[#6X3:2]([a,A:3])~[OX1:4]" periodicity1="2" phase1="180.0" k1="10.5" id="i0001" parent_id="i0001"/> <!-- X -X -C -O  from frcmod.Frosst_AlkEthOH; none in set but here as format placeholder -->
 </ImproperTorsions>
 <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-<vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
+<vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
    <!-- sigma is in angstroms, epsilon is in kcal/mol -->
    <Atom smirks="[#1:1]" rmin_half="1.4870" epsilon="0.0157" id="n0001" parent_id="n0001"/> <!-- making HC the generic hydrogen -->
    <Atom smirks="[$([#1]-C):1]" rmin_half="1.4870" epsilon="0.0157" id="n0002" parent_id="n0001"/> <!-- HC from frcmod.Frosst_AlkEthOH -->

--- a/openff/toolkit/data/test_forcefields/ammonia_minimal.offxml
+++ b/openff/toolkit/data/test_forcefields/ammonia_minimal.offxml
@@ -19,7 +19,7 @@
     <Improper smirks="[#1:1]~[#7X3:2](~[#1:3])~[#1:4]" id="i3" k1="100" periodicity1="2" phase1="150."/>
   </ImproperTosions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n1" rmin_half="0.6000"/>
     <Atom smirks="[#1:1]-[#7]" epsilon="0.0157" id="n11" rmin_half="0.6000"/>
     <Atom smirks="[#7:1]" epsilon="0.1700" id="n20" rmin_half="1.8240"/>

--- a/openff/toolkit/data/test_forcefields/benzene_minimal.offxml
+++ b/openff/toolkit/data/test_forcefields/benzene_minimal.offxml
@@ -22,7 +22,7 @@
     <Improper smirks="[*:1]~[#6X3:2](~[*:3])~[*:4]" id="i1" k1="1.1" periodicity1="2" phase1="180."/>
   </ImproperTorsions>
   <!-- WARNING: AMBER formats typically use r_0/2=r_min/2 to describe the relevant distance parameter, where r0 = 2^(1/6)*sigma. The difference is important, and the two conventions can be used here by specifying sigma or rmin_half. -->
-  <vdW potential="Lennard-Jones-12-6" combining_rules="Loentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
+  <vdW potential="Lennard-Jones-12-6" combining_rules="Lorentz-Berthelot" scale12="0.0" scale13="0.0" scale14="0.5" scale15="1" sigma_unit="angstroms" epsilon_unit="kilocalories_per_mole" switch="8.0*angstroms" cutoff="9.0*angstroms" long_range_dispersion="isotropic">
     <Atom smirks="[#1:1]-[#6X3]" epsilon="0.0150" id="n8" rmin_half="1.4590"/>
     <Atom smirks="[#6:1]" epsilon="0.0860" id="n15" rmin_half="1.9080"/>
   </vdW>


### PR DESCRIPTION
This PR fixes several occurances of "Loentz-Berthelot" in test force field files. Other cases were noticed in https://github.com/openforcefield/openff-toolkit/pull/215 but these files have not been touched since 9ac8a4d. This does not resolve #1015.

```console
$ grep -r Loentz . | wc
       0       0       0
```

Given that this typo renders force fields un-parsable with recent SMIRNOFF section versions, many of these files are evidently not used in tests. These files take up space on every user's machine so might do more harm than good if not used at all:

```console
$ wget https://conda.anaconda.org/conda-forge/noarch/openff-toolkit-base-0.12.1-pyhd8ed1ab_1.conda
--2023-03-12 12:30:59--  https://conda.anaconda.org/conda-forge/noarch/openff-toolkit-base-0.12.1-pyhd8ed1ab_1.conda
Resolving conda.anaconda.org (conda.anaconda.org)... 104.17.92.24, 104.17.93.24
Connecting to conda.anaconda.org (conda.anaconda.org)|104.17.92.24|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 7786295 (7.4M) [binary/octet-stream]
Saving to: ‘openff-toolkit-base-0.12.1-pyhd8ed1ab_1.conda’

openff-toolkit-base-0.12.1-pyhd 100%[======================================================>]   7.42M  3.84MB/s    in 1.9s

2023-03-12 12:31:01 (3.84 MB/s) - ‘openff-toolkit-base-0.12.1-pyhd8ed1ab_1.conda’ saved [7786295/7786295]

$ tar -zxvf openff-toolkit-base-0.12.1-pyhd8ed1ab_1.conda                         12:31:19
x metadata.json
x pkg-openff-toolkit-base-0.12.1-pyhd8ed1ab_1.tar.zst
x info-openff-toolkit-base-0.12.1-pyhd8ed1ab_1.tar.zst
$ tar -zxvf pkg-openff-toolkit-base-0.12.1-pyhd8ed1ab_1.tar.zst 2> tar.log && grep ammonia_mi tar.log
x site-packages/openff/toolkit/data/test_forcefields/ammonia_minimal.offxml
```