### PR TITLE
Add more `Bond` tests

### DIFF
--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -41,6 +41,7 @@ from openff.toolkit.tests.utils import (
 )
 from openff.toolkit.topology.molecule import (
     Atom,
+    Bond,
     BondExistsError,
     FrozenMolecule,
     HierarchyElement,
@@ -426,11 +427,33 @@ class TestAtom:
 
 
 class TestBond:
-    def test_float_bond_order(self):
+    @pytest.fixture()
+    def bond(self):
+        return create_ethanol().bond(0)
+
+    def test_cannot_change_molecule(self, bond):
+        with pytest.raises(
+            AssertionError,
+            match="Bond.molecule is already set and can only be set once",
+        ):
+            bond.molecule = create_reversed_ethanol()
+
+    def test_initialize_from_dict(self):
         molecule = create_ethanol()
 
+        bond = Bond.from_dict(molecule=molecule, d=molecule.bond(0).to_dict())
+
+        assert bond.atom1_index == 0
+        assert bond.atom2_index == 1
+        assert bond.atom1.atomic_number == 6
+        assert bond.atom2.atomic_number == 6
+
+    def test_set_bond_order(self, bond):
+        bond.bond_order = 2
+
+    def test_float_bond_order(self, bond):
         with pytest.raises(InvalidBondOrderError):
-            molecule.bond(0).bond_order = 1.2
+            bond.bond_order = 1.2
 
 
 class TestMolecule:

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -689,11 +689,21 @@ class Bond(Serializable):
     @classmethod
     def from_dict(cls, molecule, d):
         """Create a Bond from a dict representation."""
-        # TODO
-        d["molecule"] = molecule
+        # TODO: This is not used anywhere (`Molecule._initialize_bonds_from_dict()` just calls grabs
+        #       the two atoms and calls `Molecule._add_bond`). Remove or change that?
+        # TODO: There is no point in feeding in a `molecule` argument since `Bond.__init__` already
+        #       requires (and checks) that the two atoms are part of the same molecule
         d["atom1"] = molecule.atoms[d["atom1"]]
         d["atom2"] = molecule.atoms[d["atom2"]]
-        return cls(*d)
+
+        return cls(
+            atom1=d["atom1"],
+            atom2=d["atom2"],
+            bond_order=d["bond_order"],
+            is_aromatic=d["is_aromatic"],
+            stereochemistry=d["stereochemistry"],
+            fractional_bond_order=d["fractional_bond_order"],
+        )
 
     @property
     def atom1(self):
@@ -757,7 +767,12 @@ class Bond(Serializable):
         """
         Sets the Bond's parent molecule. Can not be changed after assignment
         """
-        assert self._molecule is None
+        # TODO: This is an impossible state (the constructor requires that atom1 and atom2
+        #       are in a molecule, the same molecule, and sets that as self._molecule).
+        #       Should we remove this?
+        assert (
+            self._molecule is None
+        ), "Bond.molecule is already set and can only be set once"
         self._molecule = value
 
     @property
@@ -767,6 +782,7 @@ class Bond(Serializable):
 
         """
         if self._molecule is None:
+            # TODO: This is unreachable; see `Bond.molecule` setter
             raise ValueError("This Atom does not belong to a Molecule object")
         return self._molecule.bonds.index(self)
 


### PR DESCRIPTION
I noticed a couple of strange/untested bits in `Bond`.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
