### PR TITLE
Do not raise bare `Exception`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -8,6 +8,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ## Current development
 
+### Behavior changes
+- [PR #1569](https://github.com/openforcefield/openff-toolkit/pull/1569): Several instances of `Exception` being raised are now replaced with other exceptions being raised.
+
 ### Improved documentation and warnings
 
 - [PR #1564] Improve documentation of conformer selection in `Molecule.assign_partial_charges()`

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -1107,6 +1107,17 @@ class TestMolecule:
             cholesterol, Molecule.from_iupac(cholesterol_iupac)
         )
 
+    def test_to_from_iupac_wrapper(self):
+        """Test that IUPAC methods work if passed just `OpenEyeToolkitWrapper`."""
+        from openff.toolkit.utils import OpenEyeToolkitWrapper
+
+        assert (
+            Molecule.from_iupac(
+                "benzene", toolkit_registry=OpenEyeToolkitWrapper()
+            ).to_iupac(toolkit_registry=OpenEyeToolkitWrapper())
+            == "benzene"
+        )
+
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_to_from_topology(self, molecule):
         """Test that conversion/creation of a molecule to and from a Topology is consistent."""

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -1107,6 +1107,7 @@ class TestMolecule:
             cholesterol, Molecule.from_iupac(cholesterol_iupac)
         )
 
+    @requires_openeye
     def test_to_from_iupac_wrapper(self):
         """Test that IUPAC methods work if passed just `OpenEyeToolkitWrapper`."""
         from openff.toolkit.utils import OpenEyeToolkitWrapper

--- a/openff/toolkit/topology/_mm_molecule.py
+++ b/openff/toolkit/topology/_mm_molecule.py
@@ -46,7 +46,7 @@ class _SimpleMolecule:
             atom1_atom = atom1
             atom2_atom = atom2
         else:
-            raise Exception(
+            raise ValueError(
                 "Invalid inputs to molecule._add_bond. Expected ints or Atoms. "
                 "Received {} (type {}) and {} (type {}) ".format(
                     atom1, type(atom1), atom2, type(atom2)

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -64,6 +64,7 @@ from openff.toolkit.utils.exceptions import (
     InvalidBondOrderError,
     InvalidConformerError,
     MissingPartialChargesError,
+    MoleculeParseError,
     MultipleMoleculesInPDBError,
     RemapIndexError,
     SmilesParsingError,
@@ -337,7 +338,7 @@ class Atom(Particle):
             if not isinstance(other, openmm_unit.Quantity):
                 raise IncompatibleUnitError(
                     "Unsupported type passed to formal_charge setter. "
-                    "Found object of type {type(other)}."
+                    f"Found object of type {type(other)}."
                 )
 
             from openff.units.openmm import from_openmm
@@ -472,7 +473,7 @@ class Atom(Particle):
             The new name for this atom
         """
         if type(other) != str:
-            raise Exception(
+            raise ValueError(
                 f"In setting atom name. Expected str, received {other} (type {type(other)})."
             )
         self._name = other
@@ -2892,7 +2893,7 @@ class FrozenMolecule(Serializable):
             atom1_atom = atom1
             atom2_atom = atom2
         else:
-            raise Exception(
+            raise ValueError(
                 "Invalid inputs to molecule._add_bond. Expected ints or Atoms. "
                 f"Received {atom1} (type {type(atom1)}) and {atom2} (type {type(atom2)}) "
             )
@@ -3396,7 +3397,7 @@ class FrozenMolecule(Serializable):
         elif type(other) is str:
             self._name = other
         else:
-            raise Exception("Molecule name must be a string")
+            raise ValueError("Molecule name must be a string")
 
     @property
     def properties(self) -> Dict[str, Any]:
@@ -3568,7 +3569,7 @@ class FrozenMolecule(Serializable):
                 **kwargs,
             )
         else:
-            raise Exception(
+            raise InvalidToolkitRegistryError(
                 "Invalid toolkit_registry passed to from_iupac. Expected ToolkitRegistry or ToolkitWrapper. "
                 f"Got {type(toolkit_registry)}."
             )
@@ -3599,7 +3600,7 @@ class FrozenMolecule(Serializable):
         elif isinstance(toolkit_registry, ToolkitWrapper):
             to_iupac_method = toolkit_registry.to_iupac
         else:
-            raise Exception(
+            raise InvalidToolkitRegistryError(
                 "Invalid toolkit_registry passed to to_iupac. Expected ToolkitRegistry or ToolkitWrapper. "
                 f"Got {type(toolkit_registry)}"
             )
@@ -3716,7 +3717,7 @@ class FrozenMolecule(Serializable):
             if isinstance(file_path, pathlib.Path):
                 file_path: str = file_path.as_posix()
             if not isinstance(file_path, str):
-                raise Exception(
+                raise ValueError(
                     "If providing a file-like object for reading molecules, the format must be specified"
                 )
             # Assume that files ending in ".gz" should use their second-to-last suffix for compatibility check
@@ -3809,7 +3810,7 @@ class FrozenMolecule(Serializable):
             )
 
         if len(mols) == 0:
-            raise Exception(f"Unable to read molecule from file: {file_path}")
+            raise MoleculeParseError(f"Unable to read molecule from file: {file_path}")
         elif len(mols) == 1:
             return mols[0]
 
@@ -5587,7 +5588,7 @@ def _networkx_graph_to_hill_formula(graph: "nx.Graph") -> str:
     import networkx as nx
 
     if not isinstance(graph, nx.Graph):
-        raise Exception("The graph must be a NetworkX graph.")
+        raise ValueError("The graph must be a NetworkX graph.")
 
     atom_nums = list(dict(graph.nodes(data="atomic_number", default=1)).values())
     return _atom_nums_to_hill_formula(atom_nums)

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -514,7 +514,7 @@ class ForceField:
             tagname = parameter_handler_class._TAGNAME
             if tagname is not None:
                 if tagname in self._parameter_handler_classes:
-                    raise Exception(
+                    raise ParameterHandlerRegistrationError(
                         "Attempting to register ParameterHandler {}, which provides a parser for tag"
                         " '{}', but ParameterHandler {} has already been registered to handle that tag.".format(
                             parameter_handler_class,
@@ -546,7 +546,7 @@ class ForceField:
             serialization_format = parameter_io_handler_class._FORMAT
             if serialization_format is not None:
                 if serialization_format in self._parameter_io_handler_classes.keys():
-                    raise Exception(
+                    raise ParameterHandlerRegistrationError(
                         "Attempting to register ParameterIOHandler {}, which provides a IO parser for format "
                         "'{}', but ParameterIOHandler {} has already been registered to handle that tag.".format(
                             parameter_io_handler_class,

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -1813,7 +1813,7 @@ class ParameterHandler(_ParameterAttributeHandler):
         elif isinstance(new_version, (float, int)):
             new_version = Version(str(new_version))
         else:
-            raise Exception(f"Could not convert type {type(new_version)}")
+            raise ValueError(f"Could not convert type {type(new_version)}")
 
         # Use PEP-440 compliant version number comparison, if requested
         if (new_version > self._MAX_SUPPORTED_SECTION_VERSION) or (

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -81,6 +81,10 @@ class AntechamberNotFoundError(OpenFFToolkitException):
     """The antechamber executable was not found"""
 
 
+class MoleculeParseError(OpenFFToolkitException):
+    """The molecule could not be created from the given format"""
+
+
 class SMILESParseError(OpenFFToolkitException, ValueError):
     """The record could not be parsed into the given format"""
 
@@ -134,6 +138,10 @@ class InvalidAtomMetadataError(OpenFFToolkitException):
 
 class BondExistsError(OpenFFToolkitException):
     """The program attempted to add a bond that already exists"""
+
+
+class ConstraintExsistsError(OpenFFToolkitException):
+    """Attempting to override a constraint that already exists with a specified distance."""
 
 
 class DuplicateUniqueMoleculeError(OpenFFToolkitException):
@@ -323,6 +331,14 @@ class InconsistentStereochemistryError(OpenFFToolkitException):
 
 class UnsupportedFileTypeError(OpenFFToolkitException):
     """Error raised when attempting to parse an unsupported file type."""
+
+
+class OpenEyeError(OpenFFToolkitException):
+    """Error raised when an OpenEye Toolkits operation fails."""
+
+
+class OpenEyeImportError(OpenFFToolkitException):
+    """Error raised when importing an OpenEye module fails."""
 
 
 class MultipleMoleculesInPDBError(OpenFFToolkitException):

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -40,6 +40,8 @@ from openff.toolkit.utils.exceptions import (
     InvalidIUPACNameError,
     LicenseError,
     NotAttachedToMoleculeError,
+    OpenEyeError,
+    OpenEyeImportError,
     RadicalsNotSupportedError,
     SMILESParseError,
     ToolkitUnavailableException,
@@ -2082,7 +2084,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         oechem.OETriposAtomNames(oemol)
         result = oechem.OEAddExplicitHydrogens(oemol)
         if not result:
-            raise Exception("Addition of explicit hydrogens failed in from_iupac")
+            raise OpenEyeError("Addition of explicit hydrogens failed in from_iupac")
 
         molecule = self.from_openeye(
             oemol, allow_undefined_stereo=allow_undefined_stereo, _cls=_cls, **kwargs
@@ -2540,7 +2542,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             for conformer in use_conformers:
                 temp_mol._add_conformer(conformer)
         if temp_mol.n_conformers == 0:
-            raise Exception(
+            raise ValueError(
                 "No conformers present in molecule submitted for fractional bond order calculation. Consider "
                 "loading the molecule from a file with geometry already present or running "
                 "molecule.generate_conformers() before calling molecule.compute_wiberg_bond_orders()"
@@ -2586,7 +2588,7 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
             status = am1.CalcAM1(am1results, oemol)
 
             if status is False:
-                raise Exception(
+                raise OpenEyeError(
                     "Unable to assign charges (in the process of calculating "
                     "fractional bond orders)"
                 )
@@ -2789,13 +2791,11 @@ def requires_openeye_module(module_name):
             try:
                 module = importlib.import_module("openeye." + module_name)
             except ImportError:
-                # TODO: Custom exception
-                raise Exception("openeye." + module_name)
+                raise OpenEyeImportError("openeye." + module_name)
             try:
                 license_func = OpenEyeToolkitWrapper._license_functions[module_name]
             except KeyError:
-                # TODO: Custom exception
-                raise Exception(f"we do not currently use {module_name}")
+                raise OpenEyeImportError(f"we do not currently use {module_name}")
 
             # TODO: Custom exception
             assert getattr(module, license_func)()

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -28,6 +28,7 @@ from openff.toolkit.utils.exceptions import (
     ChargeMethodUnavailableError,
     ConformerGenerationError,
     InvalidAromaticityModelError,
+    MoleculeParseError,
     NotAttachedToMoleculeError,
     RadicalsNotSupportedError,
     SMILESParseError,
@@ -556,7 +557,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
                 mols.append(mol)
 
         elif file_format == "PDB":
-            raise Exception(
+            raise MoleculeParseError(
                 "RDKit can not safely read PDBs on their own. Information about bond order "
                 "and aromaticity is likely to be lost. To read a PDB using RDKit use "
                 "Molecule.from_pdb_and_smiles()"
@@ -648,7 +649,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
                 )
 
         elif file_format == "PDB":
-            raise Exception(
+            raise MoleculeParseError(
                 "RDKit can not safely read PDBs on their own. Information about bond order and aromaticity "
                 "is likely to be lost. To read a PDB using RDKit use Molecule.from_pdb_and_smiles()"
             )

--- a/openff/toolkit/utils/serialization.py
+++ b/openff/toolkit/utils/serialization.py
@@ -436,7 +436,7 @@ def _contains_bytes(val) -> bool:
     elif isinstance(val, dict):
         return any([_contains_bytes(x) for x in val.values()])
     else:
-        raise Exception(f"type {val}")
+        raise ValueError(f"type {val}")
 
 
 def _prep_numpy_data_for_json(data: Dict) -> Dict:


### PR DESCRIPTION
I noticed a handful of cases in which important errors are triggered as `raise Exception`. We should not do this.

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
