### PR TITLE
Simplify unit handling in some setters

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -82,7 +82,12 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 - [PR #1584](https://github.com/openforcefield/openff-toolkit/pull/1584): Update some outdated docstrings and add some annotations.
 
 ### Examples updates
+
 - [PR #1575](https://github.com/openforcefield/openff-toolkit/pull/1575): The Toolkit Showcase example has been simplified via use of `Topology.from_pdb`
+
+### Miscellaneous
+
+- [PR #1570](https://github.com/openforcefield/openff-toolkit/pull/1570) Simplify unit handling in some setters.
 
 ## 0.12.1
 

--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -411,13 +411,6 @@ class TestAtom:
         with pytest.raises(ValueError, match="Cannot set.*'int'"):
             water.atoms[2].partial_charge = 4
 
-    @requires_pkg("openmm")
-    def test_set_partial_charges_openmm_quantity(self, water):
-        import openmm.unit
-
-        with pytest.raises(ValueError, match="Cannot set.*openmm.unit"):
-            water.atoms[2].partial_charge = 0.0 * openmm.unit.elementary_charge
-
     def test_set_partial_charges_array(self, water):
         with pytest.raises(ValueError, match="unit-wrapped.*numpy.ndarray"):
             water.atoms[2].partial_charge = unit.Quantity(
@@ -622,6 +615,18 @@ class TestMolecule:
 
         expected_repr = "Molecule with name '' with bad SMILES and Hill formula 'Cl3'"
         assert molecule.__repr__() == expected_repr
+
+    def test_set_partial_charges_bad_shape(self):
+        molecule = create_ethanol()
+
+        with pytest.raises(
+            ValueError,
+            match="incompatible shape.*4.*9",
+        ):
+            molecule.partial_charges = unit.Quantity(
+                np.zeros((4,)),
+                unit.elementary_charge,
+            )
 
     @pytest.mark.parametrize("toolkit", [OpenEyeToolkitWrapper, RDKitToolkitWrapper])
     @pytest.mark.parametrize("molecule", mini_drug_bank())

--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -620,8 +620,8 @@ class TestMolecule:
         molecule = create_ethanol()
 
         with pytest.raises(
-            ValueError,
-            match="incompatible shape.*4.*9",
+            IncompatibleShapeError,
+            match="Unsupported shape.*4.*9",
         ):
             molecule.partial_charges = unit.Quantity(
                 np.zeros((4,)),

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -59,6 +59,8 @@ from openff.toolkit.utils.exceptions import (
     BondExistsError,
     HierarchySchemeNotFoundException,
     HierarchySchemeWithIteratorNameAlreadyRegisteredException,
+    IncompatibleShapeError,
+    IncompatibleTypeError,
     IncompatibleUnitError,
     InvalidAtomMetadataError,
     InvalidBondOrderError,

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1929,7 +1929,7 @@ class Topology(Serializable):
 
             - ``openmm.unit.Quantity`` object which has atomic positions as a
               list of unit-tagged ``Vec3`` objects
-            - ``openff.units.unit.Quantity`` object which wraps a
+            - ``openff.units.Quantity`` object which wraps a
               ``numpy.ndarray`` with dimensions of length
             - (unitless) 2D ``numpy.ndarray``, in which it is assumed that the
               positions are in units of Angstroms.

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -138,13 +138,13 @@ def dict_to_quantity(input_dict):
 
 def quantity_to_string(input_quantity: Quantity) -> str:
     """
-    Serialize a openff.units.unit.Quantity to a string representation that is backwards-compatible
+    Serialize a openff.units.Quantity to a string representation that is backwards-compatible
     with older versions of the OpenFF Toolkit. This includes a " * " between numerical values and
     their units and "A" being used in place of the unicode Å ("\N{ANGSTROM SIGN}").
 
     Parameters
     ----------
-    input_quantity : openff.units.unit.Quantity
+    input_quantity : openff.units.Quantity
         The quantity to serialize
 
     Returns
@@ -162,23 +162,21 @@ def quantity_to_string(input_quantity: Quantity) -> str:
     output_string = "{} * {}".format(unitless_value, unit_string)
     return output_string
 
-    return str(input_quantity)
-
 
 def string_to_unit(unit_string):
     """
-    Deserializes a openff.units.unit.Quantity from a string representation, for
+    Deserializes a openff.units.Quantity from a string representation, for
     example: "kilocalories_per_mole / angstrom ** 2"
 
 
     Parameters
     ----------
     unit_string : dict
-        Serialized representation of a openff.units.unit.Quantity.
+        Serialized representation of a openff.units.Quantity.
 
     Returns
     -------
-    output_unit: openff.units.unit.Quantity
+    output_unit: openff.units.Quantity
         The deserialized unit from the string
     """
     return Unit(unit_string)
@@ -213,10 +211,10 @@ def convert_all_strings_to_quantity(
 ):
     """
     Traverses a SMIRNOFF data structure, attempting to convert all
-    quantity-defining strings into openff.units.unit.Quantity objects.
+    quantity-defining strings into openff.units.Quantity objects.
 
     Integers and floats are ignored and not converted into a dimensionless
-    ``openff.units.unit.Quantity`` object.
+    ``openff.units.Quantity`` object.
 
     Parameters
     ----------
@@ -229,7 +227,7 @@ def convert_all_strings_to_quantity(
     -------
     converted_smirnoff_data : dict
         A hierarchical dict structured in compliance with the SMIRNOFF spec,
-        with quantity-defining strings converted to openff.units.unit.Quantity objects
+        with quantity-defining strings converted to openff.units.Quantity objects
     """
     from pint import DefinitionSyntaxError
 
@@ -278,7 +276,7 @@ def convert_all_quantities_to_string(smirnoff_data):
     -------
     converted_smirnoff_data : dict
         A hierarchical dict structured in compliance with the SMIRNOFF spec,
-        with openff.units.unit.Quantitys converted to string
+        with openff.units.Quantitys converted to string
     """
 
     if isinstance(smirnoff_data, dict):


### PR DESCRIPTION
At various points in time we've needed to bake in logic to gracefully handle similar but heterogenous inputs. Each implementation has diverged over time; this change consolidates them and funnels most of the logic to a single choke point.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
