### PR TITLE
Simplify Toolkit Showcase example with `Topology.from_pdb`

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -139,6 +139,7 @@ jobs:
             NB_ARGS+=" --ignore=examples/check_dataset_parameter_coverage"
             NB_ARGS+=" --ignore=examples/conformer_energies"
             NB_ARGS+=" --ignore=examples/using_smirnoff_in_amber_or_gromacs"
+            NB_ARGS+=" --ignore=examples/toolkit_showcase"
           fi
 
           python -m pytest $PYTEST_ARGS $NB_ARGS examples

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -18,6 +18,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 - [PR #1564] Improve documentation of conformer selection in `Molecule.assign_partial_charges()`
 
+### Examples updates
+- [PR #1575](https://github.com/openforcefield/openff-toolkit/pull/1575): The Toolkit Showcase example has been simplified via use of `Topology.from_pdb`
+
 ## 0.12.1
 
 ### New features

--- a/examples/toolkit_showcase/toolkit_showcase.ipynb
+++ b/examples/toolkit_showcase/toolkit_showcase.ipynb
@@ -49,7 +49,6 @@
     "import numpy as np\n",
     "import openmm\n",
     "from openff.units import Quantity, unit\n",
-    "from openff.units.openmm import from_openmm\n",
     "from openmm import unit as openmm_unit\n",
     "from pdbfixer import PDBFixer\n",
     "\n",
@@ -201,66 +200,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An SDF file with an entire protein would be huge, and finding or constructing one in the first place would be tricky, so for polymers the Toolkit supports inferring chemical information from PDB files. Connectivity can be taken from residue and atom names or CONECT records, and formal charges and bond orders are inferred from a substructure dictionary distributed with the Toolkit. To help prevent ambiguities and mistakes, the toolkit requires the protein to be the only molecule in the PDB file.\n",
-    "\n",
-    "Our prepared PDB file has crystallographic waters, so we need to strip them out before we can load the protein. Don't worry! We'll pick them back up after we've created the receptor molecule. There's a million ways to break up a PDB; here, we'll use MDTraj."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Load the receptor with crystallographic waters\n",
-    "protein_xtalwater_mdtraj = mdtraj.load_pdb(receptor_path)\n",
-    "\n",
-    "# Get the indices for the protein's atoms\n",
-    "# See https://www.mdtraj.org/1.9.7/atom_selection.html\n",
-    "protein_atom_indices = protein_xtalwater_mdtraj.top.select(\"resname != HOH\")\n",
-    "\n",
-    "# Slice out just the protein and save it to a new PDB\n",
-    "protein_mdtraj = protein_xtalwater_mdtraj.atom_slice(protein_atom_indices)\n",
-    "protein_mdtraj.save_pdb(\"receptor.pdb\")"
+    "An SDF file with an entire protein would be huge, and finding or constructing one in the first place would be tricky, so for polymers the Toolkit supports inferring chemical information from PDB files. Connectivity can be taken from residue and atom names for supported molecules, and we can supply a list of arbitrary molecules that are in the PDB which are then identified via CONECT records."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we have the receptor alone in a PDB, we can load it into the toolkit. Once that's done, it's just like any other `Molecule`; you can even create a SMILES for it!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "receptor = Molecule.from_polymer_pdb(\"receptor.pdb\")\n",
-    "\n",
-    "# # This is not a good idea\n",
-    "# receptor.to_smiles()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"alert alert-info\" style=\"max-width: 700px; margin-left: auto; margin-right: auto;\">\n",
-    "    ℹ️ The warning here is just because MDTraj lost track of the insertion code for the NME cap; we don't need to worry about it.\n",
-    "</div>\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we'll solvate our system. [PDBFixer] makes it easy to add water and salt to our original receptor PDB, which already includes crystallographic waters. PDBFixer can also manage a number of other common processes, like restoring missing hydrogens or other atoms and even adding a membrane.\n",
-    "\n",
-    "Being based on OpenMM, PDBFixer is also very convenient for loading into the Toolkit without writing to disk. Since an OpenMM topology stores bond parameters rather than connectivity, we need to provide a list of the possible molecules that can be found in the file so that the Toolkit can match them to the atom connectivity graph implied by the topology. This is why we needed to load the receptor in on its own previously.\n",
+    "First we'll solvate our system. [PDBFixer] makes it easy to add water and salt to our original receptor PDB, which already includes crystallographic waters. PDBFixer can also manage a number of other common processes, like restoring missing hydrogens or other atoms and even adding a membrane. We can then save it to disk and load the resulting PDB into a topology!\n",
     "\n",
     "[PDBFixer]: https://htmlpreview.github.io/?https://github.com/openmm/pdbfixer/blob/master/Manual.html"
    ]
@@ -276,16 +223,10 @@
     "    padding=1.0 * openmm_unit.nanometer, ionicStrength=0.15 * openmm_unit.molar\n",
     ")\n",
     "\n",
-    "top = Topology.from_openmm(\n",
-    "    fixer.topology,\n",
-    "    unique_molecules=[\n",
-    "        receptor,\n",
-    "        Molecule.from_smiles(\"O\"),\n",
-    "        Molecule.from_smiles(\"[Na+]\"),\n",
-    "        Molecule.from_smiles(\"[Cl-]\"),\n",
-    "    ],\n",
-    ")\n",
-    "top.set_positions(from_openmm(fixer.positions))"
+    "with open(\"receptor_solvated.pdb\", \"w\") as f:\n",
+    "    openmm.app.PDBFile.writeFile(fixer.topology, fixer.positions, f)\n",
+    "\n",
+    "top = Topology.from_pdb(\"receptor_solvated.pdb\")"
    ]
   },
   {
@@ -757,7 +698,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1695,6 +1695,7 @@ class Topology(Serializable):
             off_atom.metadata["residue_number"] = atom.residue.id
             off_atom.metadata["insertion_code"] = atom.residue.insertionCode
             off_atom.metadata["chain_id"] = atom.residue.chain.id
+            off_atom.name = atom.name
 
         for offmol in topology.molecules:
             offmol.add_default_hierarchy_schemes()

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -316,6 +316,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
             top._add_molecule_keep_cache(offmol)
         if pdbfile.topology.getPeriodicBoxVectors() is not None:
             top.box_vectors = from_openmm(pdbfile.topology.getPeriodicBoxVectors())
+        top.set_positions(coords_angstrom * unit.angstrom)
 
         return top
 


### PR DESCRIPTION
This PR changes the Toolkit Showcase to use `Topology.from_pdb()` to load a receptor and its crystallographic waters instead of a complicated trip through MDTraj, OpenMM and back again.

It also fixes two bugs I found in `Topology.from_pdb()`:

1. Atom names were not stored in the OFFTK atoms. This meant that NGLView didn't know how to represent the protein. The documentation stated that atom names were stored.
2. When multiple identical molecules were in the PDB, every instance had the same coordinates loaded into the Topology. I think this is because of the logic to only run `from_rdkit` once on each molecule. I fixed this in the dumbest way possible: Adding a call to `top.set_positions()` to the end of the `_polymer_openmm_pdbfile_to_offtop` method.

It's possible the `top.set_positions()` should go in `from_pdb`, as the logic will be shared between RDKit and other toolkits, but the box vectors were set in `_polymer_openmm_pdbfile_to_offtop` and that logic would also be shared so I put it with that.

I have not added tests for these two bugs but I can if wanted!

- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
