### PR TITLE
Fix GBSA tests in normal CI

### DIFF
--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -3680,6 +3680,7 @@ class TestForceFieldParameterAssignment(_ForceFieldFixtures):
         #     modify_system=False,
         # )
 
+    @pytest.mark.slow
     @requires_openeye_mol2
     @pytest.mark.parametrize("zero_charges", [True, False])
     @pytest.mark.parametrize(("gbsa_model"), ["HCT", "OBC1", "OBC2"])


### PR DESCRIPTION
CI has been failing for a week or two because some MOL2 files requires for GBSA energy tests are not found. The source of this error is that these tests require files only accessible in "slow" tests but lacked the decorator that set that up. These tests have been turned off for a long time, so this went un-noticed.