### PR TITLE
Add isomorphism checks on `_SimpleMolecule`

### DIFF
--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -3680,6 +3680,7 @@ class TestForceFieldParameterAssignment(_ForceFieldFixtures):
         #     modify_system=False,
         # )
 
+    @pytest.mark.slow
     @requires_openeye_mol2
     @pytest.mark.parametrize("zero_charges", [True, False])
     @pytest.mark.parametrize(("gbsa_model"), ["HCT", "OBC1", "OBC2"])

--- a/openff/toolkit/tests/test_mm_molecule.py
+++ b/openff/toolkit/tests/test_mm_molecule.py
@@ -144,17 +144,9 @@ class TestMMMolecule:
             assert found == expected_atomic_numbers[atom_index]
 
     def test_are_isomorphic(self, water, methane, methanol):
-        kwargs = {
-            "aromatic_matching": False,
-            "formal_charge_matching": False,
-            "bond_order_matching": False,
-            "atom_stereochemistry_matching": False,
-            "bond_stereochemistry_matching": False,
-        }
-
-        assert Molecule.are_isomorphic(water, water, **kwargs)[0]
-        assert Molecule.are_isomorphic(methane, methane, **kwargs)[0]
-        assert Molecule.are_isomorphic(methanol, methanol, **kwargs)[0]
-        assert not Molecule.are_isomorphic(water, methane, **kwargs)[0]
-        assert not Molecule.are_isomorphic(water, methanol, **kwargs)[0]
-        assert not Molecule.are_isomorphic(methane, methanol, **kwargs)[0]
+        assert Molecule.are_isomorphic(water, water)[0]
+        assert Molecule.are_isomorphic(methane, methane)[0]
+        assert Molecule.are_isomorphic(methanol, methanol)[0]
+        assert not Molecule.are_isomorphic(water, methane)[0]
+        assert not Molecule.are_isomorphic(water, methanol)[0]
+        assert not Molecule.are_isomorphic(methane, methanol)[0]

--- a/openff/toolkit/tests/test_mm_molecule.py
+++ b/openff/toolkit/tests/test_mm_molecule.py
@@ -18,6 +18,36 @@ class TestMMMolecule:
         return water
 
     @pytest.fixture()
+    def methane(self):
+        methane = _SimpleMolecule()
+        methane.add_atom(atomic_number=6)
+        methane.add_atom(atomic_number=1)
+        methane.add_atom(atomic_number=1)
+        methane.add_atom(atomic_number=1)
+        methane.add_atom(atomic_number=1)
+        methane.add_bond(0, 1)
+        methane.add_bond(0, 2)
+        methane.add_bond(0, 3)
+        methane.add_bond(0, 4)
+
+        return methane
+
+    @pytest.fixture()
+    def methanol(self):
+        methanol = _SimpleMolecule()
+        methanol.add_atom(atomic_number=8)
+        methanol.add_atom(atomic_number=6)
+        methanol.add_atom(atomic_number=1)
+        methanol.add_atom(atomic_number=1)
+        methanol.add_atom(atomic_number=1)
+        methanol.add_bond(0, 1)
+        methanol.add_bond(1, 2)
+        methanol.add_bond(1, 3)
+        methanol.add_bond(1, 4)
+
+        return methanol
+
+    @pytest.fixture()
     def molecule_with_zero_atom(self):
         molecule = _SimpleMolecule()
         molecule.add_atom(atomic_number=6)
@@ -112,3 +142,19 @@ class TestMMMolecule:
         for atom_index in range(converted.n_atoms):
             found = converted.atom(atom_index).atomic_number
             assert found == expected_atomic_numbers[atom_index]
+
+    def test_are_isomorphic(self, water, methane, methanol):
+        kwargs = {
+            "aromatic_matching": False,
+            "formal_charge_matching": False,
+            "bond_order_matching": False,
+            "atom_stereochemistry_matching": False,
+            "bond_stereochemistry_matching": False,
+        }
+
+        assert Molecule.are_isomorphic(water, water, **kwargs)[0]
+        assert Molecule.are_isomorphic(methane, methane, **kwargs)[0]
+        assert Molecule.are_isomorphic(methanol, methanol, **kwargs)[0]
+        assert not Molecule.are_isomorphic(water, methane, **kwargs)[0]
+        assert not Molecule.are_isomorphic(water, methanol, **kwargs)[0]
+        assert not Molecule.are_isomorphic(methane, methanol, **kwargs)[0]

--- a/openff/toolkit/tests/test_mm_molecule.py
+++ b/openff/toolkit/tests/test_mm_molecule.py
@@ -151,6 +151,22 @@ class TestMMMolecule:
 
 
 class TestIsomorphism:
+    @pytest.fixture()
+    def n_propanol(self):
+        return _SimpleMolecule.from_molecule(
+            Molecule.from_mapped_smiles(
+                "[H:5][C:1]([H:6])([H:7])[C:2]([H:8])([H:9])[C:3]([H:10])([H:11])[O:4][H:12]"
+            )
+        )
+
+    @pytest.fixture()
+    def iso_propanol(self):
+        return _SimpleMolecule.from_molecule(
+            Molecule.from_mapped_smiles(
+                "[H:5][C:1]([H:6])([H:7])[C:2]([H:8])([C:3]([H:10])([H:11])[H:12])[O:4][H:9]"
+            )
+        )
+
     @pytest.mark.parametrize("as_graphs", [True, False])
     def test_are_isomorphic(self, water, methane, methanol, as_graphs):
         if as_graphs:
@@ -189,3 +205,6 @@ class TestIsomorphism:
 
         assert _SimpleMolecule.are_isomorphic(methanol, graph)[0]
         assert _SimpleMolecule.are_isomorphic(graph, methanol)[0]
+
+    def test_propanol_isopropanol_not_isomorphic(self, n_propanol, iso_propanol):
+        assert not _SimpleMolecule.are_isomorphic(n_propanol, iso_propanol)[0]

--- a/openff/toolkit/tests/test_mm_molecule.py
+++ b/openff/toolkit/tests/test_mm_molecule.py
@@ -151,7 +151,13 @@ class TestMMMolecule:
 
 
 class TestIsomorphism:
-    def test_are_isomorphic(self, water, methane, methanol):
+    @pytest.mark.parametrize("as_graphs", [True, False])
+    def test_are_isomorphic(self, water, methane, methanol, as_graphs):
+        if as_graphs:
+            water = water.to_networkx()
+            methane = methane.to_networkx()
+            methanol = methanol.to_networkx()
+
         assert _SimpleMolecule.are_isomorphic(water, water)[0]
         assert _SimpleMolecule.are_isomorphic(methane, methane)[0]
         assert _SimpleMolecule.are_isomorphic(methanol, methanol)[0]
@@ -177,3 +183,9 @@ class TestIsomorphism:
             _SimpleMolecule.from_molecule(create_ethanol()),
             create_ethanol(),
         )[0]
+
+    def test_graph_and_molecule_inputs(self, methanol):
+        graph = methanol.to_networkx()
+
+        assert _SimpleMolecule.are_isomorphic(methanol, graph)[0]
+        assert _SimpleMolecule.are_isomorphic(graph, methanol)[0]

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -1718,6 +1718,19 @@ class TestMolecule:
             "CCC[N@@](C)CC"
         )
 
+    def test_short_circuit_heterogeneous_input(self):
+        from openff.toolkit.topology._mm_molecule import _SimpleMolecule
+
+        assert not Molecule.are_isomorphic(
+            create_ethanol(),
+            _SimpleMolecule.from_molecule(create_ethanol()),
+        )[0]
+
+        assert not Molecule.are_isomorphic(
+            _SimpleMolecule.from_molecule(create_ethanol()),
+            create_ethanol(),
+        )[0]
+
     class TestRemap:
         """Tests for the ``Molecule.remap()`` method"""
 

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -41,6 +41,7 @@ from openff.toolkit.tests.utils import (
 )
 from openff.toolkit.topology.molecule import (
     Atom,
+    Bond,
     BondExistsError,
     FrozenMolecule,
     HierarchyElement,
@@ -426,11 +427,33 @@ class TestAtom:
 
 
 class TestBond:
-    def test_float_bond_order(self):
+    @pytest.fixture()
+    def bond(self):
+        return create_ethanol().bond(0)
+
+    def test_cannot_change_molecule(self, bond):
+        with pytest.raises(
+            AssertionError,
+            match="Bond.molecule is already set and can only be set once",
+        ):
+            bond.molecule = create_reversed_ethanol()
+
+    def test_initialize_from_dict(self):
         molecule = create_ethanol()
 
+        bond = Bond.from_dict(molecule=molecule, d=molecule.bond(0).to_dict())
+
+        assert bond.atom1_index == 0
+        assert bond.atom2_index == 1
+        assert bond.atom1.atomic_number == 6
+        assert bond.atom2.atomic_number == 6
+
+    def test_set_bond_order(self, bond):
+        bond.bond_order = 2
+
+    def test_float_bond_order(self, bond):
         with pytest.raises(InvalidBondOrderError):
-            molecule.bond(0).bond_order = 1.2
+            bond.bond_order = 1.2
 
 
 class TestMolecule:

--- a/openff/toolkit/tests/test_molecule.py
+++ b/openff/toolkit/tests/test_molecule.py
@@ -1731,6 +1731,13 @@ class TestMolecule:
             create_ethanol(),
         )[0]
 
+    def test_graph_and_molecule_inputs(self):
+        molecule = create_ethanol()
+        graph = molecule.to_networkx()
+
+        assert Molecule.are_isomorphic(molecule, graph)[0]
+        assert Molecule.are_isomorphic(graph, molecule)[0]
+
     class TestRemap:
         """Tests for the ``Molecule.remap()`` method"""
 

--- a/openff/toolkit/tests/test_topology.py
+++ b/openff/toolkit/tests/test_topology.py
@@ -42,6 +42,7 @@ from openff.toolkit.topology import (
     Topology,
     ValenceDict,
 )
+from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 from openff.toolkit.utils import (
     BASIC_CHEMINFORMATICS_TOOLKITS,
     OPENEYE_AVAILABLE,
@@ -105,6 +106,18 @@ def test_cheminformatics_toolkit_is_installed():
         msg = "No supported cheminformatics toolkits are installed. Please install a supported toolkit:\n"
         msg += str(BASIC_CHEMINFORMATICS_TOOLKITS)
         raise Exception(msg)
+
+
+@pytest.fixture()
+def mixed_topology():
+    return Topology.from_molecules(
+        [
+            create_ethanol(),
+            create_ethanol(),
+            _SimpleMolecule.from_molecule(create_ethanol()),
+            _SimpleMolecule.from_molecule(create_ethanol()),
+        ]
+    )
 
 
 # TODO: Refactor this to pytest
@@ -1522,6 +1535,9 @@ class TestTopology:
         assert_reversed_ethanol_is_grouped_correctly(groupings)
         assert_cyclohexane_is_grouped_correctly(groupings)
         assert_last_ethanol_is_grouped_correctly(groupings)
+
+    def test_identical_molecule_groups_mixed_topology(self, mixed_topology):
+        assert len(mixed_topology.identical_molecule_groups) == 2
 
     @requires_openeye
     def test_chemical_environments_matches_OE(self):

--- a/openff/toolkit/topology/_mm_molecule.py
+++ b/openff/toolkit/topology/_mm_molecule.py
@@ -344,13 +344,16 @@ class _SimpleMolecule:
         _cls = _SimpleMolecule
 
         if isinstance(mol1, nx.Graph) and isinstance(mol2, nx.Graph):
-            pass
+            mol1 = _SimpleMolecule._from_subgraph(mol1)
+            mol2 = _SimpleMolecule._from_subgraph(mol2)
 
         elif isinstance(mol1, nx.Graph):
             assert isinstance(mol2, _cls)
+            mol1 = _SimpleMolecule._from_subgraph(mol1)
 
         elif isinstance(mol2, nx.Graph):
             assert isinstance(mol1, _cls)
+            mol2 = _SimpleMolecule._from_subgraph(mol2)
 
         else:
             # static methods (by definition) know nothing about their class,

--- a/openff/toolkit/topology/_mm_molecule.py
+++ b/openff/toolkit/topology/_mm_molecule.py
@@ -341,15 +341,21 @@ class _SimpleMolecule:
     ) -> Tuple[bool, Optional[Dict[int, int]]]:
         import networkx as nx
 
+        _cls = _SimpleMolecule
+
         if isinstance(mol1, nx.Graph) and isinstance(mol2, nx.Graph):
             pass
+
+        elif isinstance(mol1, nx.Graph):
+            assert isinstance(mol2, _cls)
+
+        elif isinstance(mol2, nx.Graph):
+            assert isinstance(mol1, _cls)
 
         else:
             # static methods (by definition) know nothing about their class,
             # so the class to compare to must be hard-coded here
-            if not (
-                isinstance(mol1, _SimpleMolecule) and isinstance(mol2, _SimpleMolecule)
-            ):
+            if not (isinstance(mol1, _cls) and isinstance(mol2, _cls)):
                 return False, None
 
         if mol1.n_atoms != mol2.n_atoms:
@@ -358,7 +364,7 @@ class _SimpleMolecule:
         if mol1.n_bonds != mol2.n_bonds:
             return False, None
 
-        for this_atom, other_atom in zip(mol1.atoms, mol2.atoms, strict=True):
+        for this_atom, other_atom in zip(mol1.atoms, mol2.atoms):
             if this_atom.atomic_number != other_atom.atomic_number:
                 return False, None
 

--- a/openff/toolkit/topology/_mm_molecule.py
+++ b/openff/toolkit/topology/_mm_molecule.py
@@ -371,6 +371,15 @@ class _SimpleMolecule:
             if this_atom.atomic_number != other_atom.atomic_number:
                 return False, None
 
+            # With Python 3.10+, this can be quicker with `strict=True`
+            # (https://peps.python.org/pep-0618/)
+            for this_neighbor, other_neighor in zip(
+                this_atom.bonded_atoms,
+                other_atom.bonded_atoms,
+            ):
+                if this_neighbor.atomic_number != other_neighor.atomic_number:
+                    return False, None
+
         # These objects don't have well-defined atom indices, so just return 1:1 mapping
         if return_atom_map:
             return True, {index: index for index in range(mol1.n_atoms)}

--- a/openff/toolkit/topology/_mm_molecule.py
+++ b/openff/toolkit/topology/_mm_molecule.py
@@ -315,7 +315,7 @@ class _SimpleMolecule:
 
     def is_isomorphic_with(
         self, other: Union["FrozenMolecule", "_SimpleMolecule", "nx.Graph"], **kwargs
-    ):
+    ) -> bool:
         """
         Check for pseudo-isomorphism.
 
@@ -339,19 +339,18 @@ class _SimpleMolecule:
         mol2: Union["FrozenMolecule", "_SimpleMolecule", "nx.Graph"],
         return_atom_map: bool = False,
     ) -> Tuple[bool, Optional[Dict[int, int]]]:
-        if return_atom_map:
-            raise NotImplementedError(
-                "The _SimpleMolecule does not currently support atom mapping."
-            )
+        import networkx as nx
 
-        # static methods (by definition) know nothing about their class,
-        # so the class to compare to must be hard-coded here
-        if not issubclass(type(mol2), _SimpleMolecule):
-            return False, None
-        if not (
-            isinstance(mol1, _SimpleMolecule) and isinstance(mol2, _SimpleMolecule)
-        ):
-            return False, None
+        if isinstance(mol1, nx.Graph) and isinstance(mol2, nx.Graph):
+            pass
+
+        else:
+            # static methods (by definition) know nothing about their class,
+            # so the class to compare to must be hard-coded here
+            if not (
+                isinstance(mol1, _SimpleMolecule) and isinstance(mol2, _SimpleMolecule)
+            ):
+                return False, None
 
         if mol1.n_atoms != mol2.n_atoms:
             return False, None
@@ -359,11 +358,15 @@ class _SimpleMolecule:
         if mol1.n_bonds != mol2.n_bonds:
             return False, None
 
-        for this_atom, other_atom in zip(mol1.atoms, mol1.atoms):
+        for this_atom, other_atom in zip(mol1.atoms, mol2.atoms, strict=True):
             if this_atom.atomic_number != other_atom.atomic_number:
                 return False, None
 
-        return True, None
+        # These objects don't have well-defined atom indices, so just return 1:1 mapping
+        if return_atom_map:
+            return True, {index: index for index in range(mol1.n_atoms)}
+        else:
+            return True, None
 
     def generate_unique_atom_names(self):
         """Generate unique atom names. See `Molecule.generate_unique_atom_names`."""

--- a/openff/toolkit/topology/_mm_molecule.py
+++ b/openff/toolkit/topology/_mm_molecule.py
@@ -350,9 +350,11 @@ class _SimpleMolecule:
         elif isinstance(mol1, networkx.Graph):
             assert isinstance(mol2, _cls)
             graph1 = _SimpleMolecule._from_subgraph(mol1).to_networkx()
+            graph2 = mol2.to_networkx()
 
         elif isinstance(mol2, networkx.Graph):
             assert isinstance(mol1, _cls)
+            graph1 = mol1.to_networkx()
             graph2 = _SimpleMolecule._from_subgraph(mol2).to_networkx()
 
         else:
@@ -360,6 +362,9 @@ class _SimpleMolecule:
             # so the class to compare to must be hard-coded here
             if not (isinstance(mol1, _cls) and isinstance(mol2, _cls)):
                 return False, None
+
+            graph1 = mol1.to_networkx()
+            graph2 = mol2.to_networkx()
 
         def node_match_func(node1, node2):
             return node1["atomic_number"] == node2["atomic_number"]

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1877,7 +1877,7 @@ class FrozenMolecule(Serializable):
         bond_stereochemistry_matching: bool = True,
         strip_pyrimidal_n_atom_stereo: bool = True,
         toolkit_registry: TKR = GLOBAL_TOOLKIT_REGISTRY,
-    ):
+    ) -> Tuple[bool, Optional[Dict[int, int]]]:
         """
         Determine if ``mol1`` is isomorphic to ``mol2``.
 
@@ -1956,7 +1956,9 @@ class FrozenMolecule(Serializable):
             [Dict[int,int]] ordered by mol1 indexing {mol1_index: mol2_index}
             If molecules are not isomorphic given input arguments, will return None instead of dict.
         """
-        if not issubclass(type(mol2), Molecule):
+        # static methods (by definition) know nothing about their class,
+        # so the class to compare to must be hard-coded here
+        if not (isinstance(mol1, FrozenMolecule) and isinstance(mol2, FrozenMolecule)):
             return False, None
 
         from openff.toolkit.topology._mm_molecule import _SimpleMolecule
@@ -2031,9 +2033,7 @@ class FrozenMolecule(Serializable):
             edge_match_func = None  # type: ignore
 
         # Here we should work out what data type we have, also deal with lists?
-        def to_networkx(
-            data: Union[FrozenMolecule, nx.Graph]
-        ) -> nx.Graph:
+        def to_networkx(data: Union[FrozenMolecule, nx.Graph]) -> nx.Graph:
             """For the given data type, return the networkx graph"""
             import networkx as nx
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1958,17 +1958,22 @@ class FrozenMolecule(Serializable):
         """
         import networkx as nx
 
+        _cls = FrozenMolecule
+
         if isinstance(mol1, nx.Graph) and isinstance(mol2, nx.Graph):
             pass
+
+        elif isinstance(mol1, nx.Graph):
+            assert isinstance(mol2, _cls)
+
+        elif isinstance(mol2, nx.Graph):
+            assert isinstance(mol1, _cls)
+
         else:
             # static methods (by definition) know nothing about their class,
             # so the class to compare to must be hard-coded here
-            if not (
-                isinstance(mol1, FrozenMolecule) and isinstance(mol2, FrozenMolecule)
-            ):
+            if not (isinstance(mol1, _cls) and isinstance(mol2, _cls)):
                 return False, None
-
-        from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 
         def _object_to_n_atoms(obj):
             if isinstance(obj, FrozenMolecule):
@@ -3460,15 +3465,11 @@ class FrozenMolecule(Serializable):
         return self._hill_formula
 
     @staticmethod
-    def _object_to_hill_formula(
-        obj: Union["FrozenMolecule", "nx.Graph"]
-    ) -> str:
+    def _object_to_hill_formula(obj: Union["FrozenMolecule", "nx.Graph"]) -> str:
         """Take a Molecule or NetworkX graph and generate its Hill formula.
         This provides a backdoor to the old functionality of Molecule.to_hill_formula, which
         was a static method that duck-typed inputs of Molecule or graph objects."""
         import networkx as nx
-
-        from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 
         if isinstance(obj, FrozenMolecule):
             return obj.to_hill_formula()

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1971,8 +1971,7 @@ class FrozenMolecule(Serializable):
         from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 
         def _object_to_n_atoms(obj):
-            # if hasattr(obj, "n_atoms") would also work, but possibly be too permissive
-            if isinstance(obj, (FrozenMolecule, _SimpleMolecule)):
+            if isinstance(obj, FrozenMolecule):
                 return obj.n_atoms
             elif isinstance(obj, nx.Graph):
                 return obj.number_of_nodes()
@@ -3462,7 +3461,7 @@ class FrozenMolecule(Serializable):
 
     @staticmethod
     def _object_to_hill_formula(
-        obj: Union["FrozenMolecule", "_SimpleMolecule", "nx.Graph"]
+        obj: Union["FrozenMolecule", "nx.Graph"]
     ) -> str:
         """Take a Molecule or NetworkX graph and generate its Hill formula.
         This provides a backdoor to the old functionality of Molecule.to_hill_formula, which
@@ -3471,8 +3470,7 @@ class FrozenMolecule(Serializable):
 
         from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 
-        # if hasattr(obj, "to_hill_formula") might also work
-        if isinstance(obj, (FrozenMolecule, _SimpleMolecule)):
+        if isinstance(obj, FrozenMolecule):
             return obj.to_hill_formula()
         elif isinstance(obj, nx.Graph):
             return _networkx_graph_to_hill_formula(obj)

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1956,16 +1956,21 @@ class FrozenMolecule(Serializable):
             [Dict[int,int]] ordered by mol1 indexing {mol1_index: mol2_index}
             If molecules are not isomorphic given input arguments, will return None instead of dict.
         """
-        # static methods (by definition) know nothing about their class,
-        # so the class to compare to must be hard-coded here
-        if not (isinstance(mol1, FrozenMolecule) and isinstance(mol2, FrozenMolecule)):
-            return False, None
+        import networkx as nx
+
+        if isinstance(mol1, nx.Graph) and isinstance(mol2, nx.Graph):
+            pass
+        else:
+            # static methods (by definition) know nothing about their class,
+            # so the class to compare to must be hard-coded here
+            if not (
+                isinstance(mol1, FrozenMolecule) and isinstance(mol2, FrozenMolecule)
+            ):
+                return False, None
 
         from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 
         def _object_to_n_atoms(obj):
-            import networkx as nx
-
             # if hasattr(obj, "n_atoms") would also work, but possibly be too permissive
             if isinstance(obj, (FrozenMolecule, _SimpleMolecule)):
                 return obj.n_atoms
@@ -2035,8 +2040,6 @@ class FrozenMolecule(Serializable):
         # Here we should work out what data type we have, also deal with lists?
         def to_networkx(data: Union[FrozenMolecule, nx.Graph]) -> nx.Graph:
             """For the given data type, return the networkx graph"""
-            import networkx as nx
-
             if strip_pyrimidal_n_atom_stereo:
                 SMARTS = "[N+0X3:1](-[*])(-[*])(-[*])"
 
@@ -2085,7 +2088,7 @@ class FrozenMolecule(Serializable):
 
     def is_isomorphic_with(
         self, other: Union["FrozenMolecule", "_SimpleMolecule", nx.Graph], **kwargs
-    ):
+    ) -> bool:
         """
         Check if the molecule is isomorphic with the other molecule which can be an openff.toolkit.topology.Molecule
         or nx.Graph(). Full matching is done using the options described bellow.

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1867,8 +1867,8 @@ class FrozenMolecule(Serializable):
 
     @staticmethod
     def are_isomorphic(
-        mol1: Union["FrozenMolecule", nx.Graph],
-        mol2: Union["FrozenMolecule", nx.Graph],
+        mol1: Union["FrozenMolecule", "_SimpleMolecule", nx.Graph],
+        mol2: Union["FrozenMolecule", "_SimpleMolecule", nx.Graph],
         return_atom_map: bool = False,
         aromatic_matching: bool = True,
         formal_charge_matching: bool = True,
@@ -1990,26 +1990,6 @@ class FrozenMolecule(Serializable):
             if mol1._is_exactly_the_same_as(mol2):
                 return True, {i: i for i in range(mol1.n_atoms)}
 
-        if _SimpleMolecule in (type(mol1), type(mol2)):
-            if (
-                aromatic_matching
-                or formal_charge_matching
-                or bond_order_matching
-                or atom_stereochemistry_matching
-                or atom_stereochemistry_matching
-                or bond_stereochemistry_matching
-            ):
-                # TODO: There should be a better way of handling this case - modifying arguments is bad!
-                # Maybe this case should just be split out into _SimpleMolecule.are_isomorphic?
-                # Would require a change in Topology._identify_chemically_identical_molecules
-                warnings.warn("Doing a simple comparison", stacklevel=2)
-                aromatic_matching = False
-                formal_charge_matching = False
-                bond_order_matching = False
-                atom_stereochemistry_matching = False
-                atom_stereochemistry_matching = False
-                bond_stereochemistry_matching = False
-
         # Build the user defined matching functions
         def node_match_func(x, y):
             # always match by atleast atomic number
@@ -2052,7 +2032,7 @@ class FrozenMolecule(Serializable):
 
         # Here we should work out what data type we have, also deal with lists?
         def to_networkx(
-            data: Union[FrozenMolecule, "_SimpleMolecule", nx.Graph]
+            data: Union[FrozenMolecule, nx.Graph]
         ) -> nx.Graph:
             """For the given data type, return the networkx graph"""
             import networkx as nx
@@ -2068,9 +2048,6 @@ class FrozenMolecule(Serializable):
                     data.strip_atom_stereochemistry(
                         SMARTS, toolkit_registry=toolkit_registry
                     )
-                return data.to_networkx()
-
-            elif isinstance(data, _SimpleMolecule):
                 return data.to_networkx()
 
             elif isinstance(data, nx.Graph):

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -690,11 +690,21 @@ class Bond(Serializable):
     @classmethod
     def from_dict(cls, molecule, d):
         """Create a Bond from a dict representation."""
-        # TODO
-        d["molecule"] = molecule
+        # TODO: This is not used anywhere (`Molecule._initialize_bonds_from_dict()` just calls grabs
+        #       the two atoms and calls `Molecule._add_bond`). Remove or change that?
+        # TODO: There is no point in feeding in a `molecule` argument since `Bond.__init__` already
+        #       requires (and checks) that the two atoms are part of the same molecule
         d["atom1"] = molecule.atoms[d["atom1"]]
         d["atom2"] = molecule.atoms[d["atom2"]]
-        return cls(*d)
+
+        return cls(
+            atom1=d["atom1"],
+            atom2=d["atom2"],
+            bond_order=d["bond_order"],
+            is_aromatic=d["is_aromatic"],
+            stereochemistry=d["stereochemistry"],
+            fractional_bond_order=d["fractional_bond_order"],
+        )
 
     @property
     def atom1(self):
@@ -758,7 +768,12 @@ class Bond(Serializable):
         """
         Sets the Bond's parent molecule. Can not be changed after assignment
         """
-        assert self._molecule is None
+        # TODO: This is an impossible state (the constructor requires that atom1 and atom2
+        #       are in a molecule, the same molecule, and sets that as self._molecule).
+        #       Should we remove this?
+        assert (
+            self._molecule is None
+        ), "Bond.molecule is already set and can only be set once"
         self._molecule = value
 
     @property
@@ -768,6 +783,7 @@ class Bond(Serializable):
 
         """
         if self._molecule is None:
+            # TODO: This is unreachable; see `Bond.molecule` setter
             raise ValueError("This Atom does not belong to a Molecule object")
         return self._molecule.bonds.index(self)
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1956,6 +1956,8 @@ class FrozenMolecule(Serializable):
             [Dict[int,int]] ordered by mol1 indexing {mol1_index: mol2_index}
             If molecules are not isomorphic given input arguments, will return None instead of dict.
         """
+        if not issubclass(type(mol2), Molecule):
+            return False, None
 
         from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1176,7 +1176,7 @@ class Topology(Serializable):
                     continue
                 mol2 = self.molecule(mol2_idx)
                 if isinstance(mol1, type(mol2)) and isinstance(mol2, type(mol1)):
-                    are_isomorphic, atom_map = mol1.__class__.are_isomorphic(
+                    are_isomorphic, atom_map = mol1.are_isomorphic(
                         mol1, mol2, return_atom_map=True
                     )
                 else:

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1175,9 +1175,13 @@ class Topology(Serializable):
                 if mol2_idx in already_matched_mols:
                     continue
                 mol2 = self.molecule(mol2_idx)
-                are_isomorphic, atom_map = Molecule.are_isomorphic(
-                    mol1, mol2, return_atom_map=True
-                )
+                if issubclass(mol1, mol2):
+                    are_isomorphic, atom_map = mol1.is_isomorphic_with(
+                        mol2, return_atom_map=True
+                    )
+                else:
+                    are_isomorphic = False
+
                 if are_isomorphic:
                     identity_maps[mol2_idx] = (
                         mol1_idx,

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1175,9 +1175,9 @@ class Topology(Serializable):
                 if mol2_idx in already_matched_mols:
                     continue
                 mol2 = self.molecule(mol2_idx)
-                if issubclass(mol1, mol2):
-                    are_isomorphic, atom_map = mol1.is_isomorphic_with(
-                        mol2, return_atom_map=True
+                if isinstance(mol1, type(mol2)) and isinstance(mol2, type(mol1)):
+                    are_isomorphic, atom_map = mol1.__class__.are_isomorphic(
+                        mol1, mol2, return_atom_map=True
                     )
                 else:
                     are_isomorphic = False

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1421,12 +1421,12 @@ class Topology(Serializable):
                 )
                 if isomorphic:
                     # Take the first valid atom indexing map
-                    first_topology_atom_index = min(mapping.keys())
+                    first_topology_atom_index = min(mapping.keys())  # type: ignore[union-attr]
                     topology_molecules_to_add.append(
                         (
                             first_topology_atom_index,
                             unq_mol_G,
-                            mapping.items(),
+                            mapping.items(),  # type: ignore[union-attr]
                             omm_mol_G,
                         )
                     )


### PR DESCRIPTION
Resolves #1580 

- [x] Ensure `Topology.identical_molecule_groups` functions on a topology containing ONLY `_SimpleMolecule`
  - [x] Add `_SimpleMolecule.are_isomorphic`
  - [x] Add `_SimpleMolecule.is_isomorphic_with`
  - [x] Short-circuit `Molecule.are_isomorphic` on input of different subclass
  - [x] Short-circuit `_SimpleMolecule.are_isomorphic` on input of different subclass
- [x] Add tests
  - [x] Unit tests for new `_SimpleMolecule` methods
  - [x] Unit tests for short-circuits on each method
  - [x] create a Topology of _SimpleMolecule ensure that `Topology.identical_molecule_groups` behaves as expected
- [x] Tag issue being addressed
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
