### PR TITLE
Convert ParameterAttribute based on units

### DIFF
--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -1065,6 +1065,11 @@ class TestForceField(_ForceFieldFixtures):
                     assert isinstance(parameter.name, str)
                     assert not isinstance(parameter.name, unit.Quantity)
 
+    def test_load_do_not_convert_id_to_quantities(self):
+        ff = ForceField("openff-2.1.0.offxml")
+        handler = ff.get_parameter_handler("LibraryCharges")
+        assert handler.parameters[2].id == "K+"
+
     def test_pickle(self):
         """
         Test pickling and unpickling a force field

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -951,7 +951,8 @@ class ForceField:
                 # `unit=unit.degrees`
                 if infotype._ELEMENT_NAME == "VirtualSite":
                     ignore_keys = [
-                        x for x in ignore_keys
+                        x
+                        for x in ignore_keys
                         if x not in ["outOfPlaneAngle", "inPlaneAngle"]
                     ]
 

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -930,7 +930,6 @@ class ForceField:
             # Get the parameter types serialization that is not passed to the ParameterHandler constructor.
             ph_class = self._get_parameter_handler_class(parameter_name)
 
-            # special case virtual sites
             try:
                 infotype = ph_class._INFOTYPE
                 parameter_list_tagname = infotype._ELEMENT_NAME

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -2821,6 +2821,7 @@ class vdWHandler(_NonbondedHandler):
     #       (it'll be easy when we switch to use the attrs library)
     @scale12.converter
     def scale12(self, attrs, new_scale12):
+        new_scale12 = float(new_scale12)
         if new_scale12 != 0.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale12 values other than 0.0. "
@@ -2830,6 +2831,7 @@ class vdWHandler(_NonbondedHandler):
 
     @scale13.converter
     def scale13(self, attrs, new_scale13):
+        new_scale13 = float(new_scale13)
         if new_scale13 != 0.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale13 values other than 0.0. "
@@ -2839,6 +2841,7 @@ class vdWHandler(_NonbondedHandler):
 
     @scale15.converter
     def scale15(self, attrs, new_scale15):
+        new_scale15 = float(new_scale15)
         if new_scale15 != 1.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale15 values other than 1.0. "
@@ -2924,6 +2927,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
     #       (it'll be easy when we switch to use the attrs library)
     @scale12.converter
     def scale12(self, attrs, new_scale12):
+        new_scale12 = float(new_scale12)
         if new_scale12 != 0.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale12 values other than 0.0. "
@@ -2933,6 +2937,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
 
     @scale13.converter
     def scale13(self, attrs, new_scale13):
+        new_scale13 = float(new_scale13)
         if new_scale13 != 0.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale13 values other than 0.0. "
@@ -2942,6 +2947,7 @@ class ElectrostaticsHandler(_NonbondedHandler):
 
     @scale15.converter
     def scale15(self, attrs, new_scale15):
+        new_scale15 = float(new_scale15)
         if new_scale15 != 1.0:
             raise SMIRNOFFSpecError(
                 "Current OFF toolkit is unable to handle scale15 values other than 1.0. "


### PR DESCRIPTION
Fixes #1633 

This is a potential long-term fix for accidentally reading stuff like "K+" as kelvin. Unfortunately it is clumsier than expected, because VirtualSiteType.outOfPlaneAngle and VirtualSiteType.inPlaneAngle unexpectedly have `_unit=None`, despite being defined as below. So this is less than ideal but I thought I'd put it up anyway for discussion :)

```
        outOfPlaneAngle = ParameterAttribute(unit=unit.degree)
        inPlaneAngle = ParameterAttribute(unit=unit.degree)
```

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
