### PR TITLE
Fix force field parsing with Pint 0.22 or of OpenFF 2.1.0

### DIFF
--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -16,7 +16,7 @@ dependencies:
   - xmltodict
   - python-constraint
   - openmm >=7.6
-  - openff-forcefields
+  - openff-forcefields >=2023.05.1
   - smirnoff99Frosst
   - openff-units >=0.2
   - openff-utilities >=0.1.5

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -14,7 +14,7 @@ dependencies:
   - xmltodict
   - python-constraint
   - openmm >=7.6
-  - openff-forcefields
+  - openff-forcefields >=2023.05.1
   - smirnoff99Frosst
   - openff-amber-ff-ports >=0.0.3
   - openff-units >=0.2

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -14,7 +14,7 @@ dependencies:
   - xmltodict
   - python-constraint
   - openmm >=7.6
-  - openff-forcefields
+  - openff-forcefields >=2023.05.1
   - smirnoff99Frosst
   - openff-units >=0.2
   - openff-utilities >=0.1.5

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -13,7 +13,7 @@ dependencies:
   - xmltodict
   - python-constraint
   - openmm >=7.6
-  - openff-forcefields
+  - openff-forcefields >=2023.05.1
   - smirnoff99Frosst
   - openff-amber-ff-ports >=0.0.3
   - openff-units >=0.2

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -13,7 +13,7 @@ dependencies:
   - xmltodict
   - python-constraint
   - openmm >=7.6
-  - openff-forcefields
+  - openff-forcefields >=2023.05.1
   - smirnoff99Frosst
   - openff-units >=0.2
   - openff-utilities >=0.1.5

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -14,7 +14,7 @@ dependencies:
   - xmltodict
   - python-constraint
   - openmm >=7.6
-  - openff-forcefields
+  - openff-forcefields >=2023.05.1
   - smirnoff99Frosst
   - openff-units >=0.2
   - openff-utilities >=0.1.5

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -12,6 +12,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Bugfixes
 
+- [PR #1640](https://github.com/openforcefield/openff-toolkit/pull/1640): Fixes issue [#1633](https://github.com/openforcefield/openff-toolkit/issues/1633) in which some force field attributes were erroneously parsed as `Quantity` objects and  issue [#1635](https://github.com/openforcefield/openff-toolkit/issues/1635) in which OpenFF 2.1.0 ("Sage") could not be loaded with Pint 0.22.
+
 ### New features
 
 ### Improved documentation and warnings

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -1065,6 +1065,11 @@ class TestForceField(_ForceFieldFixtures):
                     assert isinstance(parameter.name, str)
                     assert not isinstance(parameter.name, unit.Quantity)
 
+    def test_load_do_not_convert_id_to_quantities(self):
+        ff = ForceField("openff-2.1.0.offxml")
+        handler = ff.get_parameter_handler("LibraryCharges")
+        assert handler.parameters[2].id == "K+"
+
     def test_pickle(self):
         """
         Test pickling and unpickling a force field

--- a/openff/toolkit/tests/test_forcefield.py
+++ b/openff/toolkit/tests/test_forcefield.py
@@ -892,6 +892,7 @@ class TestForceField(_ForceFieldFixtures):
             "openff_unconstrained-1.0.0.offxml",
             "openff-1.3.0.offxml",
             "openff-2.0.0.offxml",
+            "openff-2.1.0.offxml",
             "ff14sb_off_impropers_0.0.3.offxml",
         ]
 

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -907,7 +907,7 @@ class ForceField:
         # Go through the whole SMIRNOFF data structure, trying to convert all strings to Quantity
         smirnoff_data = convert_all_strings_to_quantity(
             smirnoff_data,
-            ignore_keys=["smirks", "name"],
+            ignore_keys=["smirks", "name", "id", "parent_id"],
         )
 
         # Go through the subsections, delegating each to the proper ParameterHandler


### PR DESCRIPTION
#1635 #1633

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
