### PR TITLE
Fix broken links in examples

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -20,6 +20,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Examples updated
 - [PR #1644](https://github.com/openforcefield/openff-toolkit/pull/1644): Streamlines several examples by using `Interchange.to_openmm_simulation`.
+- [PR #1651](https://github.com/openforcefield/openff-toolkit/pull/1651): Fix broken links in several examples.
 
 
 ## 0.13.2

--- a/examples/SMIRNOFF_simulation/run_simulation.ipynb
+++ b/examples/SMIRNOFF_simulation/run_simulation.ipynb
@@ -128,7 +128,7 @@
    "source": [
     "We now create the Open Force Field Toolkit `Topology` describing the system from an OpenMM `Topology` object. The OFF `Topology` include more information (supplied by the two `Molecule` objects) than the OpenMM `Topology` such as (optionally) partial charges and stereochemistry. In this example, partial charges are not explicitly given, and `ForceField` will assign AM1/BCC charges as specified by the \"Sage\" force field.\n",
     "\n",
-    "Note that the Open Force Field Toolkit produces deterministic charges that do not depend on the input conformation of parameterized molecules. See the [FAQ](https://docs.openforcefield.org/projects/toolkit/en/latest/faq.html#the-partial-charges-generated-by-the-toolkit-dont-seem-to-depend-on-the-molecules-conformation-is-this-a-bug) for more information.\n",
+    "Note that the Open Force Field Toolkit produces deterministic charges that do not depend on the input conformation of parameterized molecules. See the [FAQ](https://docs.openforcefield.org/projects/toolkit/en/stable/faq.html#the-partial-charges-generated-by-the-toolkit-dont-seem-to-depend-on-the-molecules-conformation-is-this-a-bug) for more information.\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "    <b>Note on partial charges:</b> The full 1.0.0 release will implement support for the definition of semiempirical partial charge treatment directly into the SMIRNOFF force field file (for details, see https://openforcefield.github.io/standards/standards/smirnoff/#partial-charge-and-electrostatics-models). Moreover, it will be possible to import charges directly from sdf and mol2 files.\n",

--- a/examples/SMIRNOFF_simulation/run_simulation.ipynb
+++ b/examples/SMIRNOFF_simulation/run_simulation.ipynb
@@ -128,7 +128,7 @@
    "source": [
     "We now create the Open Force Field Toolkit `Topology` describing the system from an OpenMM `Topology` object. The OFF `Topology` include more information (supplied by the two `Molecule` objects) than the OpenMM `Topology` such as (optionally) partial charges and stereochemistry. In this example, partial charges are not explicitly given, and `ForceField` will assign AM1/BCC charges as specified by the \"Sage\" force field.\n",
     "\n",
-    "Note that the Open Force Field Toolkit produces deterministic charges that do not depend on the input conformation of parameterized molecules. See the [FAQ](https://open-forcefield-toolkit.readthedocs.io/en/stable/faq.html#the-partial-charges-generated-by-the-toolkit-don-t-seem-to-depend-on-the-molecule-s-conformation-is-this-a-bug) for more information.\n",
+    "Note that the Open Force Field Toolkit produces deterministic charges that do not depend on the input conformation of parameterized molecules. See the [FAQ](https://docs.openforcefield.org/projects/toolkit/en/latest/faq.html#the-partial-charges-generated-by-the-toolkit-dont-seem-to-depend-on-the-molecules-conformation-is-this-a-bug) for more information.\n",
     "\n",
     "<div class=\"alert alert-block alert-info\">\n",
     "    <b>Note on partial charges:</b> The full 1.0.0 release will implement support for the definition of semiempirical partial charge treatment directly into the SMIRNOFF force field file (for details, see https://openforcefield.github.io/standards/standards/smirnoff/#partial-charge-and-electrostatics-models). Moreover, it will be possible to import charges directly from sdf and mol2 files.\n",
@@ -296,7 +296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/examples/forcefield_modification/forcefield_modification.ipynb
+++ b/examples/forcefield_modification/forcefield_modification.ipynb
@@ -870,7 +870,7 @@
    "source": [
     "### Bonus: Adding a cosmetic attribute to the new parameter\n",
     "\n",
-    "In some cases, you might want to tag a particular attribute with extra data. This might be useful, for example, in communicating to a fitting tool which parameters should be fitted, or simply to add extra metadata.. The toolkit allows for _cosmetic attributes_, which can be stored to individual parameters, will be included out when the `ForceField` object is written to disk, but will not otherwise affect the parameterization machinery. The API point for this is [`ParameterType.add_cosmetic_attribute`](https://docs.openforcefield.org/projects/toolkit/en/stable/api/generated/openff.toolkit.typing.engines.smirnoff.ParameterType.html#openff.toolkit.typing.engines.smirnoff.ParameterType.add_cosmetic_attribute).\n",
+    "In some cases, you might want to tag a particular attribute with extra data. This might be useful, for example, in communicating to a fitting tool which parameters should be fitted, or simply to add extra metadata.. The toolkit allows for _cosmetic attributes_, which can be stored to individual parameters, will be included out when the `ForceField` object is written to disk, but will not otherwise affect the parameterization machinery. The API point for this is [`ParameterType.add_cosmetic_attribute`](https://docs.openforcefield.org/projects/toolkit/en/stable/api/generated/openff.toolkit.typing.engines.smirnoff.parameters.ParameterType.html#openff.toolkit.typing.engines.smirnoff.parameters.ParameterType.add_cosmetic_attribute).\n",
     "\n",
     "Let's use this to tag our modified and new parameters with a note about why we introduced it."
    ]
@@ -997,7 +997,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.10.11"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/examples/using_smirnoff_in_amber_or_gromacs/export_with_interchange.ipynb
+++ b/examples/using_smirnoff_in_amber_or_gromacs/export_with_interchange.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "We start by loading a PDB file containing one copy of ethanol and cyclohexane. Our goal is to create an OpenFF `Topology` object describing this system that we can parametrize with the SMIRNOFF-format \"Sage\" force field.\n",
     "\n",
-    "The two `Molecule` objects created from the SMILES strings can contain information such as partial charges and stereochemistry that is not included in an OpenMM topology. In this example, partial charges are not explicitly given, and `ForceField` will assign AM1/BCC charges as specified by the \"Sage\" force field. Note that the OpenFF Toolkit produces partial charges that do not depend on the input conformation of parameterized molecules. See the [FAQ](https://open-forcefield-toolkit.readthedocs.io/en/latest/faq.html#the-partial-charges-generated-by-the-toolkit-don-t-seem-to-depend-on-the-molecule-s-conformation-is-this-a-bug) for more information."
+    "The two `Molecule` objects created from the SMILES strings can contain information such as partial charges and stereochemistry that is not included in an OpenMM topology. In this example, partial charges are not explicitly given, and `ForceField` will assign AM1/BCC charges as specified by the \"Sage\" force field. Note that the OpenFF Toolkit produces partial charges that do not depend on the input conformation of parameterized molecules. See the [FAQ](https://docs.openforcefield.org/projects/toolkit/en/stable/faq.html#the-partial-charges-generated-by-the-toolkit-dont-seem-to-depend-on-the-molecules-conformation-is-this-a-bug) for more information."
    ]
   },
   {
@@ -1074,7 +1074,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
https://github.com/openforcefield/openff-docs/pull/7 found several dead links in the notebooks here. One of them is just some journal blocking access to bots, but the others are actually dead links. There's probably a good way to automate checking for these - I've disabled the link checker for the examples for now so that I can get some green check marks.

- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
