### PR TITLE
Ensure `pytest` finds `conftest.py`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -148,8 +148,6 @@ jobs:
             PYTEST_ARGS+=" --runslow"
           fi
 
-          PYTEST_ARGS+=" --runslow"
-
           python -m pytest $PYTEST_ARGS $COV
 
       - name: Run code snippets in docs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,6 +147,9 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
             PYTEST_ARGS+=" --runslow"
           fi
+
+          PYTEST_ARGS+=" --runslow"
+
           python -m pytest $PYTEST_ARGS $COV openff/toolkit/
 
       - name: Run code snippets in docs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,7 +150,7 @@ jobs:
 
           PYTEST_ARGS+=" --runslow"
 
-          python -m pytest $PYTEST_ARGS $COV openff/toolkit/
+          python -m pytest $PYTEST_ARGS $COV
 
       - name: Run code snippets in docs
         if: ${{ matrix.rdkit == true && matrix.openeye == true }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,12 @@
 # Helper file to handle all configs
 
+[tool:pytest]
+doctest_optionflags =
+    ELLIPSIS
+    DONT_ACCEPT_TRUE_FOR_1
+    NORMALIZE_WHITESPACE
+testpaths = openff/toolkit/_tests/
+
 [coverage:run]
 # .coveragerc to control coverage.py and pytest-cov
 omit =
@@ -172,10 +179,3 @@ ignore_missing_imports = True
 
 [mypy-constraint]
 ignore_missing_imports = True
-
-[tool:pytest]
-doctest_optionflags =
-    ELLIPSIS
-    DONT_ACCEPT_TRUE_FOR_1
-    NORMALIZE_WHITESPACE
-


### PR DESCRIPTION
After #1649, the nightly cron job isn't finding `conftest.py` which sets up the `--runslow` option.

https://github.com/openforcefield/openff-toolkit/actions/runs/5395786436