### PR TITLE
Raise exception when `Topology.from_openmm` is given virtual sites

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,6 +15,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Bugfixes
 
+- [PR #1667](https://github.com/openforcefield/openff-toolkit/pull/1667): A more helpful exception is now raised when `Topology.from_openmm` is given an OpenMM Topology with virtual sites.
+
 ### New features
 
 ### Improved documentation and warnings

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -321,6 +321,10 @@ class HierarchySchemeNotFoundException(OpenFFToolkitException):
     that doesn't have one with the given iterator name"""
 
 
+class VirtualSitesUnsupportedError(OpenFFToolkitException):
+    """Exception raised when trying to store virtual sites in a `Molecule` or `Topology` object."""
+
+
 class MissingIndexedAttributeError(
     OpenFFToolkitException, IndexError, KeyError, AttributeError
 ):


### PR DESCRIPTION
Resolves #1598

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
