### PR TITLE
Use Pydantic v1 in tests

### DIFF
--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -7,7 +7,7 @@ channels:
 dependencies:
     # Base depends
   - python
-  - pip
+  - pydantic =1
   - packaging
   - numpy
   - networkx

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     # Base depends
   - python
-  - pip
+  - pydantic =1
   - packaging
   - numpy
   - networkx

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
     # Base depends
   - python
-  - pip
+  - pydantic =1
   - packaging
   - numpy
   - networkx

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
     # Base depends
   - python
-  - pip
+  - pydantic =1
   - packaging
   - numpy
   - networkx

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
     # Base depends
   - python
-  - pip
+  - pydantic =1
   - packaging
   - numpy
   - networkx

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -42,6 +42,7 @@ dependencies:
   - nbval
   - mypy
   - typing_extensions
+  - pydantic =1
   - pip:
     - types-setuptools
     - types-toml


### PR DESCRIPTION
None of our base dependencies require `pydantic =1`, but some of our test dependencies have not been updated. This PR updates the testing infrastructure until some of the remaining upstreams have been updated.