### PR TITLE
Do not install `openff-nagl` 0.3.1rc1

### DIFF
--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl >=0.2.2
+  - openff-nagl =0.2.2
   - openff-nagl-models >=0.0.2
     # Toolkit-specific
   - ambertools >=22

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl >=0.2.2
+  - openff-nagl =0.2.2
   - openff-nagl-models >=0.0.2
   - typing_extensions
     # Toolkit-specific

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl >=0.2.2
+  - openff-nagl =0.2.2
   - openff-nagl-models >=0.0.2
   - typing_extensions
     # Toolkit-specific

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -19,7 +19,7 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl >=0.2.2
+  - openff-nagl =0.2.2
   - openff-nagl-models >=0.0.2
   - typing_extensions
     # Toolkit-specific

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -19,7 +19,7 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl >=0.2.2
+  - openff-nagl =0.2.3
   - openff-nagl-models >=0.0.2
   - typing_extensions
     # Toolkit-specific

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl >=0.2.2
+  - openff-nagl =0.2.2
   - openff-nagl-models >=0.0.2
     # Toolkit-specific
   - ambertools >=22


### PR DESCRIPTION
`openff-nagl` 0.3.0rc1 landed on the `main` label, this simply avoids that while it is not released and these tests have not been updated.