### PR TITLE
Add warnings

### DIFF
--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl ==0.3.0
+  - openff-nagl-base ==0.3.0
   - openff-nagl-models ==0.1.0
     # Toolkit-specific
   - ambertools >=22

--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -22,7 +22,7 @@ dependencies:
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
   - openff-nagl ==0.3.0
-  - openff-nagl-models >=0.0.2
+  - openff-nagl-models ==0.1.0
     # Toolkit-specific
   - ambertools >=22
   - rdkit

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl ==0.3.0
+  - openff-nagl-base ==0.3.0
   - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -21,7 +21,7 @@ dependencies:
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
   - openff-nagl ==0.3.0
-  - openff-nagl-models >=0.0.2
+  - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific
   - openeye-toolkits

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -21,7 +21,7 @@ dependencies:
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
   - openff-nagl ==0.3.0
-  - openff-nagl-models >=0.0.2
+  - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific
   - openeye-toolkits

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl ==0.3.0
+  - openff-nagl-base ==0.3.0
   - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -19,7 +19,7 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl ==0.3.0
+  - openff-nagl-base ==0.3.0
   - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
   - openff-nagl ==0.3.0
-  - openff-nagl-models >=0.0.2
+  - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific
   # AmberTools 23 brings in ParmEd 4, which doesn't yet work with examples

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
   - openff-nagl-base ==0.3.0
-  - openff-nagl-models ==0.0.3
+  - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific
   - ambertools >=22

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -19,8 +19,8 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl ==0.3.0
-  - openff-nagl-models >=0.0.2
+  - openff-nagl-base ==0.3.0
+  - openff-nagl-models ==0.0.3
   - typing_extensions
     # Toolkit-specific
   - ambertools >=22

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
   - openff-nagl-base ==0.3.0
-  - openff-nagl-models ==0.0.3
+  - openff-nagl-models ==0.1.0
     # Toolkit-specific
   - ambertools >=22
   - rdkit

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -20,8 +20,8 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.10
-  - openff-nagl ==0.3.0
-  - openff-nagl-models >=0.0.2
+  - openff-nagl-base ==0.3.0
+  - openff-nagl-models ==0.0.3
     # Toolkit-specific
   - ambertools >=22
   - rdkit

--- a/openff/toolkit/_tests/test_nagl.py
+++ b/openff/toolkit/_tests/test_nagl.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy
 import pytest
 from openff.units import unit
@@ -10,6 +12,7 @@ from openff.toolkit._tests.create_molecules import (
     create_ethanol,
     create_reversed_ethanol,
 )
+from openff.toolkit import Molecule
 from openff.toolkit._tests.utils import requires_openeye
 from openff.toolkit.utils._nagl_wrapper import _NAGLToolkitWrapper
 from openff.toolkit.utils.openeye_wrapper import OpenEyeToolkitWrapper
@@ -57,8 +60,7 @@ class TestNAGLToolkitWrapper:
         numpy.testing.assert_allclose(
             openeye_charges.m_as(unit.elementary_charge),
             nagl_charges,
-            atol=0.03,
-            rtol=0,
+            atol=0.07
         )
 
     def test_atom_order_dependence(self):
@@ -71,16 +73,33 @@ class TestNAGLToolkitWrapper:
                 partial_charge_method="_nagl_am1bccelf10",
                 toolkit_registry=_NAGLToolkitWrapper(),
             )
-
         numpy.testing.assert_allclose(
             forward.partial_charges,
             reverse.partial_charges[::-1],
-            rtol=1e-6,
+            atol=1e-7,
         )
 
     def test_unsupported_charge_method(self):
         with pytest.raises(ValueError, match="Charge model hartree_fock not supported"):
             create_ethanol().assign_partial_charges(
                 partial_charge_method="hartree_fock",
+                toolkit_registry=_NAGLToolkitWrapper(),
+            )
+
+
+    def test_unsupported_molecule_element(self):
+        si = Molecule.from_smiles("[Si+4]")
+        with pytest.raises(ValueError, match="Molecule contains forbidden element 14"):
+            si.assign_partial_charges(
+                partial_charge_method="_nagl_am1bccelf10",
+                toolkit_registry=_NAGLToolkitWrapper(),
+            )
+    
+    def test_unsupported_molecule_bond(self):
+        mol = Molecule.from_smiles("C=[Cl+1]")
+        err = re.escape("Molecule contains forbidden SMARTS pattern [#17:1]#,:,=[*:2]")
+        with pytest.raises(ValueError, match=err):
+            mol.assign_partial_charges(
+                partial_charge_method="_nagl_am1bccelf10",
                 toolkit_registry=_NAGLToolkitWrapper(),
             )

--- a/openff/toolkit/_tests/test_nagl.py
+++ b/openff/toolkit/_tests/test_nagl.py
@@ -5,6 +5,7 @@ import pytest
 from openff.units import unit
 from openff.utilities.testing import skip_if_missing
 
+from openff.toolkit import Molecule
 from openff.toolkit._tests.create_molecules import (
     create_acetaldehyde,
     create_cis_1_2_dichloroethene,
@@ -12,7 +13,6 @@ from openff.toolkit._tests.create_molecules import (
     create_ethanol,
     create_reversed_ethanol,
 )
-from openff.toolkit import Molecule
 from openff.toolkit._tests.utils import requires_openeye
 from openff.toolkit.utils._nagl_wrapper import _NAGLToolkitWrapper
 from openff.toolkit.utils.openeye_wrapper import OpenEyeToolkitWrapper
@@ -58,9 +58,7 @@ class TestNAGLToolkitWrapper:
         assert nagl_charges.dtype == float
 
         numpy.testing.assert_allclose(
-            openeye_charges.m_as(unit.elementary_charge),
-            nagl_charges,
-            atol=0.07
+            openeye_charges.m_as(unit.elementary_charge), nagl_charges, atol=0.07
         )
 
     def test_atom_order_dependence(self):
@@ -86,7 +84,6 @@ class TestNAGLToolkitWrapper:
                 toolkit_registry=_NAGLToolkitWrapper(),
             )
 
-
     def test_unsupported_molecule_element(self):
         si = Molecule.from_smiles("[Si+4]")
         with pytest.raises(ValueError, match="Molecule contains forbidden element 14"):
@@ -94,7 +91,7 @@ class TestNAGLToolkitWrapper:
                 partial_charge_method="_nagl_am1bccelf10",
                 toolkit_registry=_NAGLToolkitWrapper(),
             )
-    
+
     def test_unsupported_molecule_bond(self):
         mol = Molecule.from_smiles("C=[Cl+1]")
         err = re.escape("Molecule contains forbidden SMARTS pattern [#17:1]#,:,=[*:2]")

--- a/openff/toolkit/utils/_nagl_wrapper.py
+++ b/openff/toolkit/utils/_nagl_wrapper.py
@@ -86,7 +86,6 @@ class _NAGLToolkitWrapper(ToolkitWrapper):
 
             from openff.nagl import GNNModel
             from openff.nagl_models import (
-                list_available_nagl_models,
                 validate_nagl_model_path,
             )
 

--- a/openff/toolkit/utils/_nagl_wrapper.py
+++ b/openff/toolkit/utils/_nagl_wrapper.py
@@ -85,9 +85,7 @@ class _NAGLToolkitWrapper(ToolkitWrapper):
             import pathlib
 
             from openff.nagl import GNNModel
-            from openff.nagl_models import (
-                validate_nagl_model_path,
-            )
+            from openff.nagl_models import validate_nagl_model_path
 
             model_name = "openff-gnn-am1bcc-0.1.0-rc.1.pt"
             _only_model = validate_nagl_model_path(model_name)

--- a/openff/toolkit/utils/_nagl_wrapper.py
+++ b/openff/toolkit/utils/_nagl_wrapper.py
@@ -84,19 +84,27 @@ class _NAGLToolkitWrapper(ToolkitWrapper):
         if partial_charge_method == "_nagl_am1bccelf10":
             import pathlib
 
-            from openff.nagl.nn._models import GNNModel
+            from openff.nagl import GNNModel
             from openff.nagl_models import (
                 list_available_nagl_models,
                 validate_nagl_model_path,
             )
 
-            _only_model = validate_nagl_model_path(list_available_nagl_models()[0])
+            model_name = "openff-gnn-am1bcc-0.1.0-rc.1.pt"
+            _only_model = validate_nagl_model_path(model_name)
 
             if not pathlib.Path(_only_model).exists():
                 raise FileNotFoundError(f"Could not find model {_only_model.name}")
 
             model = GNNModel.load(_only_model, eval_mode=True)
-            charges = model.compute_property(molecule, as_numpy=True)
+            charges = model.compute_property(
+                molecule,
+                as_numpy=True,
+                readout_name="am1bcc_charges",
+                check_domains=True,
+                # if False, only warns
+                error_if_unsupported=True,
+            )
             molecule.partial_charges = Quantity(
                 charges.astype(float),
                 unit.elementary_charge,


### PR DESCRIPTION
This PR adds errors if the molecule getting assigned charges has elements that are not covered (which will actually break the model) or simply has bonds that are not represented in the training data (simply not recommended).

Side note -- looks like training partly to dipole/ESPs really did decrease similarity to actual charge values, especially for small molecules... I had to loosen tests.

- [ ] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
