### PR TITLE
Handle PluginCompatibilityError in create_openmm_system()

### DIFF
--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -1124,6 +1124,7 @@ class ForceField:
 
     # TODO: Should we also accept a Molecule as an alternative to a Topology?
     @requires_package("openmm")
+    @requires_package("openff.interchange")
     def create_openmm_system(
         self,
         topology: "Topology",

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -28,7 +28,7 @@ import os
 import pathlib
 from typing import TYPE_CHECKING, List, Optional, Type, Union
 
-import openff.interchange.exceptions
+from openff.interchange.exceptions import PluginCompatibilityError
 from packaging.version import Version
 
 from openff.toolkit.typing.engines.smirnoff.io import ParameterIOHandler
@@ -1170,7 +1170,7 @@ class ForceField:
                 partial_bond_orders_from_molecules=partial_bond_orders_from_molecules,
                 allow_nonintegral_charges=allow_nonintegral_charges,
             ).to_openmm(combine_nonbonded_forces=True)
-        except openff.interchange.exceptions.PluginCompatibilityError:
+        except PluginCompatibilityError:
             return self.create_interchange(
                 topology,
                 toolkit_registry,

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -28,7 +28,6 @@ import os
 import pathlib
 from typing import TYPE_CHECKING, List, Optional, Type, Union
 
-from openff.interchange.exceptions import PluginCompatibilityError
 from packaging.version import Version
 
 from openff.toolkit.typing.engines.smirnoff.io import ParameterIOHandler
@@ -1162,6 +1161,9 @@ class ForceField:
         allow_nonintegral_charges
             Allow charges that do not sum to an integer.
         """
+
+        from openff.interchange.exceptions import PluginCompatibilityError
+
         try:
             return self.create_interchange(
                 topology,

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -28,6 +28,7 @@ import os
 import pathlib
 from typing import TYPE_CHECKING, List, Optional, Type, Union
 
+import openff.interchange.exceptions
 from packaging.version import Version
 
 from openff.toolkit.typing.engines.smirnoff.io import ParameterIOHandler
@@ -1161,13 +1162,22 @@ class ForceField:
         allow_nonintegral_charges
             Allow charges that do not sum to an integer.
         """
-        return self.create_interchange(
-            topology,
-            toolkit_registry,
-            charge_from_molecules=charge_from_molecules,
-            partial_bond_orders_from_molecules=partial_bond_orders_from_molecules,
-            allow_nonintegral_charges=allow_nonintegral_charges,
-        ).to_openmm(combine_nonbonded_forces=True)
+        try:
+            return self.create_interchange(
+                topology,
+                toolkit_registry,
+                charge_from_molecules=charge_from_molecules,
+                partial_bond_orders_from_molecules=partial_bond_orders_from_molecules,
+                allow_nonintegral_charges=allow_nonintegral_charges,
+            ).to_openmm(combine_nonbonded_forces=True)
+        except openff.interchange.exceptions.PluginCompatibilityError:
+            return self.create_interchange(
+                topology,
+                toolkit_registry,
+                charge_from_molecules=charge_from_molecules,
+                partial_bond_orders_from_molecules=partial_bond_orders_from_molecules,
+                allow_nonintegral_charges=allow_nonintegral_charges,
+            ).to_openmm(combine_nonbonded_forces=False)
 
     @requires_package("openff.interchange")
     def create_interchange(


### PR DESCRIPTION
Currently trying to use a nonbonded plugin from smirnoff-plugins with openff-evaluator throws PluginCompatibilityError from interchange because the default behavior is combine_nonbonded_forces=True. This patch doesn't change the default behavior but trys to set that flag to False if an exception occurs.

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
