### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4 (#1721)"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -172,7 +172,7 @@ jobs:
           pytest -v --no-cov --doctest-modules --ignore=openff/toolkit/_tests/ --ignore=openff/toolkit/data/ --ignore=openff/toolkit/utils/utils.py openff/
 
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -85,7 +85,7 @@ jobs:
           pytest -v --doctest-glob="docs/*.rst" --doctest-glob="docs/*.md" docs/
 
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml


### PR DESCRIPTION
This reverts commit b13cc4d990198d08406dab7ced6eef80ad39e3e0.

The release was made and then removed: https://github.com/codecov/codecov-action/issues/1089#issuecomment-1720709850