### PR TITLE
Fix error message in scaling factors

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -16,6 +16,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Bugfixes
 
+- [PR #1726](https://github.com/openforcefield/openff-toolkit/pull/1726): Fix error message in setting `scale12`, `scale13`, and `scale15` attributes.
+
 ### New features
 
 - [PR #1698](https://github.com/openforcefield/openff-toolkit/pull/1698): Makes `openff.toolkit.utils.toolkit_registry.toolkit_registry_manager` public.

--- a/openff/toolkit/_tests/test_parameters.py
+++ b/openff/toolkit/_tests/test_parameters.py
@@ -1722,16 +1722,18 @@ class TestvdWHandler:
         assert vdw_handler.get_parameter({"smirks": "[#1:1]"})[0].id == "n00"
 
     def test_set_invalid_scale_factor(self):
+        import random
+
+        factors = {index: random.random() for index in (2, 3, 5)}
+
         handler = vdWHandler(version=0.4)
 
-        with pytest.raises(SMIRNOFFSpecError, match="unable to handle scale12"):
-            handler.scale12 = 0.1
-
-        with pytest.raises(SMIRNOFFSpecError, match="unable to handle scale13"):
-            handler.scale13 = 0.1
-
-        with pytest.raises(SMIRNOFFSpecError, match="unable to handle scale15"):
-            handler.scale15 = 0.1
+        for factor, value in factors.items():
+            with pytest.raises(
+                SMIRNOFFSpecError,
+                match=f"unable to handle scale1{factor}.*1-{factor} scaling was {value}",
+            ):
+                setattr(handler, f"scale1{factor}", value)
 
 
 class TestvdWHandlerUpConversion:

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -2859,8 +2859,8 @@ class vdWHandler(_NonbondedHandler):
     def scale12(self, attrs, new_scale12):
         if new_scale12 != 0.0:
             raise SMIRNOFFSpecError(
-                "Current OFF toolkit is unable to handle scale12 values other than 0.0. "
-                "Specified 1-2 scaling was {}".format(self.scale12)
+                "Current OpenFF toolkit is unable to handle scale12 values other than 0.0. "
+                f"Specified 1-2 scaling was {new_scale12}."
             )
         return new_scale12
 
@@ -2868,8 +2868,8 @@ class vdWHandler(_NonbondedHandler):
     def scale13(self, attrs, new_scale13):
         if new_scale13 != 0.0:
             raise SMIRNOFFSpecError(
-                "Current OFF toolkit is unable to handle scale13 values other than 0.0. "
-                "Specified 1-3 scaling was {}".format(self.scale13)
+                "Current OpenFF toolkit is unable to handle scale13 values other than 0.0. "
+                f"Specified 1-3 scaling was {new_scale13}."
             )
         return new_scale13
 
@@ -2877,8 +2877,8 @@ class vdWHandler(_NonbondedHandler):
     def scale15(self, attrs, new_scale15):
         if new_scale15 != 1.0:
             raise SMIRNOFFSpecError(
-                "Current OFF toolkit is unable to handle scale15 values other than 1.0. "
-                "Specified 1-5 scaling was {}".format(self.scale15)
+                "Current OpenFF toolkit is unable to handle scale15 values other than 1.0. "
+                f"Specified 1-5 scaling was {new_scale15}."
             )
         return new_scale15
 
@@ -2967,8 +2967,8 @@ class ElectrostaticsHandler(_NonbondedHandler):
     def scale12(self, attrs, new_scale12):
         if new_scale12 != 0.0:
             raise SMIRNOFFSpecError(
-                "Current OFF toolkit is unable to handle scale12 values other than 0.0. "
-                "Specified 1-2 scaling was {}".format(self.scale12)
+                "Current OpenFF toolkit is unable to handle scale12 values other than 0.0. "
+                f"Specified 1-2 scaling was {new_scale12}."
             )
         return new_scale12
 
@@ -2976,8 +2976,8 @@ class ElectrostaticsHandler(_NonbondedHandler):
     def scale13(self, attrs, new_scale13):
         if new_scale13 != 0.0:
             raise SMIRNOFFSpecError(
-                "Current OFF toolkit is unable to handle scale13 values other than 0.0. "
-                "Specified 1-3 scaling was {}".format(self.scale13)
+                "Current OpenFF toolkit is unable to handle scale13 values other than 0.0. "
+                f"Specified 1-3 scaling was {new_scale13}."
             )
         return new_scale13
 
@@ -2985,8 +2985,8 @@ class ElectrostaticsHandler(_NonbondedHandler):
     def scale15(self, attrs, new_scale15):
         if new_scale15 != 1.0:
             raise SMIRNOFFSpecError(
-                "Current OFF toolkit is unable to handle scale15 values other than 1.0. "
-                "Specified 1-5 scaling was {}".format(self.scale15)
+                "Current OpenFF toolkit is unable to handle scale15 values other than 1.0. "
+                f"Specified 1-5 scaling was {new_scale15}."
             )
         return new_scale15
 


### PR DESCRIPTION
Resolves #1725

```python
In [1]: from openff.toolkit import ForceField

In [2]: sage = ForceField("openff-2.0.0.offxml")

In [3]: sage["vdW"].scale12 = 1 / 3
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File ~/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/parameters.py:424, in ParameterAttribute._call_converter(self, value, instance)
    422 try:
    423     # Static function.
--> 424     return self._converter(value)
    425 except TypeError:
    426     # Instance method.

TypeError: vdWHandler.scale12() missing 2 required positional arguments: 'attrs' and 'new_scale12'

During handling of the above exception, another exception occurred:

SMIRNOFFSpecError                         Traceback (most recent call last)
Cell In[3], line 1
----> 1 sage["vdW"].scale12 = 1 / 3

File ~/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/parameters.py:1168, in _ParameterAttributeHandler.__setattr__(self, key, value)
   1163         raise MissingIndexedAttributeError(
   1164             f"'{key}' is out of bounds for indexed attribute '{attr_name}'"
   1165         )
   1167 # Forward the request to the next class in the MRO.
-> 1168 super().__setattr__(key, value)

File ~/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/parameters.py:373, in ParameterAttribute.__set__(self, instance, value)
    371 def __set__(self, instance, value):
    372     # Convert and validate the value.
--> 373     value = self._convert_and_validate(instance, value)
    374     setattr(instance, self._name, value)

File ~/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/parameters.py:391, in ParameterAttribute._convert_and_validate(self, instance, value)
    389 value = self._validate_units(value)
    390 # Call the custom converter before setting the value.
--> 391 value = self._call_converter(value, instance)
    392 return value

File ~/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/parameters.py:427, in ParameterAttribute._call_converter(self, value, instance)
    424         return self._converter(value)
    425     except TypeError:
    426         # Instance method.
--> 427         return self._converter(instance, self, value)
    428 return value

File ~/software/openff-toolkit/openff/toolkit/typing/engines/smirnoff/parameters.py:2861, in vdWHandler.scale12(self, attrs, new_scale12)
   2858 @scale12.converter
   2859 def scale12(self, attrs, new_scale12):
   2860     if new_scale12 != 0.0:
-> 2861         raise SMIRNOFFSpecError(
   2862             "Current OpenFF toolkit is unable to handle scale12 values other than 0.0. "
   2863             f"Specified 1-2 scaling was {new_scale12}."
   2864         )
   2865     return new_scale12

SMIRNOFFSpecError: Current OpenFF toolkit is unable to handle scale12 values other than 0.0. Specified 1-2 scaling was 0.3333333333333333.
```

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
