### PR TITLE
Update Zenodo link, skip BibTeX link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The toolkit currently covers two main areas we have committed to stably maintain
 
 ## How to cite
 
-Please cite the OpenFF Toolkit using the [Zenodo record](https://zenodo.org/record/7506404) of the [latest release](https://zenodo.org/record/7506404) or the version that was used. The BibTeX reference of the latest release can be found [here](https://zenodo.org/record/7506404/export/hx#.Y7cYbOzMKrM).
+Please cite the OpenFF Toolkit using the [Zenodo record](https://zenodo.org/record/8412072) of the [latest release](https://zenodo.org/record/8412072) or the version that was used. The BibTeX reference of the latest release can be found [here](https://zenodo.org/record/8412072/export/hx#.Y7cYbOzMKrM).
 
 ## Installation
 

--- a/openff/toolkit/_tests/test_links.py
+++ b/openff/toolkit/_tests/test_links.py
@@ -40,6 +40,12 @@ def test_readme_links(readme_link):
         pytest.skip("DOI links are behind DDoS protection and do not resolve")
     if "codecov.io" in readme_link:
         pytest.skip("Codecov website DOI also may be behind DDoS protection")
+    if "export" in readme_link:
+        # October 2023 Zenodo upgrade seems to have broken this link - although
+        # it is still accessible from the web UI (go to the landing page of a
+        # record, Export section (select BibTeX in drop-down) and click "Export"
+        # button will bring you to this link.
+        pytest.skip("Seems to be a Zenodo regression in bibtex link")
 
     # Try to connect 5 times, keeping track of exceptions so useful feedback can be provided.
     success = False


### PR DESCRIPTION
This has been causing [failures](https://github.com/openforcefield/openff-toolkit/actions/runs/6527283119/job/17721923943) in CI for a week or so now; see comments in code for context.