### PR TITLE
Warn if `Molecule.from_smiles` is provided a full atom map

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -20,9 +20,10 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ## Current development
 
+- [PR #1747](https://github.com/openforcefield/openff-toolkit/pull/1747): Warns if a SMILES with full atom mappings is passed to `Moleucle.from_smiles`, which does not use the atom map for atom ordering (`Molecule.from_mapped_smiles` does).
 - [PR #1731](https://github.com/openforcefield/openff-toolkit/pull/1731): Suppot SMIRNOFF vdW version 0.5.
 
-## 0.14.4 
+## 0.14.4
 
 ### Behavior changes
 

--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -17,6 +17,7 @@ import os
 import pathlib
 import pickle
 import re
+import warnings
 from tempfile import NamedTemporaryFile
 from unittest.mock import Mock
 
@@ -56,6 +57,7 @@ from openff.toolkit.topology.molecule import (
 )
 from openff.toolkit.utils import get_data_file_path
 from openff.toolkit.utils.exceptions import (
+    AtomMappingWarning,
     HierarchyIteratorNameConflictError,
     IncompatibleShapeError,
     IncompatibleTypeError,
@@ -2874,6 +2876,23 @@ class TestMolecule:
             match="The mapped smiles does not contain enough indexes",
         ):
             Molecule.from_mapped_smiles("[Cl:1][Cl]", toolkit_registry=toolkit_class())
+
+    def test_smiles_with_full_map_warning(
+        self,
+    ):
+        with pytest.warns(AtomMappingWarning):
+            Molecule.from_smiles("[H:2][O:1][H:3]")
+
+    def test_smiles_with_partial_map_no_warning(
+        self,
+    ):
+        """Ensure the 'do you mean from_mapped_smiles?' warning is not emitted with a partial map"""
+        with warnings.catch_warnings():
+            # This turns warnings into exceptions - one way of implementing
+            # "ensure there is not a warning raised"
+            warnings.simplefilter("error")
+
+            Molecule.from_smiles("H[O:1]H")
 
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_n_atoms(self, molecule):

--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -2883,6 +2883,7 @@ class TestMolecule:
         with pytest.warns(AtomMappingWarning):
             Molecule.from_smiles("[H:2][O:1][H:3]")
 
+    @requires_openeye
     def test_smiles_with_partial_map_no_warning(
         self,
     ):

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -58,6 +58,7 @@ from typing_extensions import TypeAlias
 
 from openff.toolkit.utils.constants import DEFAULT_AROMATICITY_MODEL
 from openff.toolkit.utils.exceptions import (
+    AtomMappingWarning,
     BondExistsError,
     HierarchyIteratorNameConflictError,
     HierarchySchemeNotFoundException,
@@ -1879,6 +1880,17 @@ class FrozenMolecule(Serializable):
                 "Invalid toolkit_registry passed to from_smiles. Expected ToolkitRegistry or ToolkitWrapper. "
                 f"Got {type(toolkit_registry)}"
             )
+
+        if "atom_map" in molecule._properties:
+            if len(molecule._properties["atom_map"]) == molecule.n_atoms:
+                warnings.warn(
+                    "Warning! Fully mapped SMILES pattern passed to `from_smiles`. The atom map is "
+                    "stored as a property in `Molecule._properties`, but these indices are NOT "
+                    "used to determine atom ordering. To use these indices for atom ordering, use "
+                    "`Molecule.from_mapped_smiles`.",
+                    AtomMappingWarning,
+                    stacklevel=2,
+                )
 
         return molecule
 
@@ -4534,12 +4546,18 @@ class FrozenMolecule(Serializable):
 
         # create the molecule from the smiles and check we have the right number of indexes
         # in the mapped SMILES
+        warnings.filterwarnings("ignore", category=AtomMappingWarning)
+
         offmol = cls.from_smiles(
             mapped_smiles,
             hydrogens_are_explicit=True,
             toolkit_registry=toolkit_registry,
             allow_undefined_stereo=allow_undefined_stereo,
         )
+
+        # https://stackoverflow.com/a/53763710
+        # this might be better: https://docs.python.org/3/library/warnings.html#warnings.catch_warnings
+        warnings.filterwarnings("default", category=AtomMappingWarning)
 
         # check we found some mapping and remove it as we do not want to expose atom maps
         try:

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -101,6 +101,11 @@ class SMILESParseError(OpenFFToolkitException, ValueError):
     """The record could not be parsed into the given format"""
 
 
+# TODO: Should warnings inherit from a sort of OpenFFToolkitWarning?
+class AtomMappingWarning(UserWarning):
+    """A warning when dealing with atom maping or indices."""
+
+
 class InChIParseError(MoleculeParseError, RuntimeError):
     """The InChI record could not be parsed."""
 


### PR DESCRIPTION
https://github.com/openforcefield/openff-toolkit/issues/1186#issuecomment-1767128056

There are a few corner cases I've left uncovered - a full atom map, but one with ambiguous or confusing indices, or what to do if given a partial atom map - for simplicity. This just warns if the atom mapping is as long as the number of atoms.
* If a user has partial atom maps, I'm not sure if directing them to use `Molecule.from_mapped_smiles` is a net positive
* If a user has funky atom maps, this warning may or may not be thrown (the criteria being a simple length check opens up some accidental collisions) and I'm not sure it's worth the effort to deeply consider, at least here, the numerous ways this input can be partially garbled.

Happy to update the language of the warning itself; I understand what I wrote but am not confident I'm using the best terms to describe the details.

I didn't think too deeply about adversarial cases, this handles the specific thing I care about:

```python
In [1]: from openff.toolkit import Molecule

In [2]: Molecule.from_smiles("[H:2][O:1][H:3]")
<ipython-input-2-74b6c4f20a48>:1: AtomMappingWarning: Warning! Fully mapped SMILES pattern passed to `from_smiles`. The atom map is stored as a property in `Molecule._properties`, but these indices are NOT used to determine atom ordering. To use these indices for atom ordering, use `Molecule.from_mapped_smiles`.
  Molecule.from_smiles("[H:2][O:1][H:3]")
Out[2]:
<IPython.core.display.SVG object>

In [3]: Molecule.from_mapped_smiles("[H:2][O:1][H:3]")
Out[3]: <IPython.core.display.SVG object>
```

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
  - [x] Warn if `Molecule.from_smiles` is provided a **full** atom map
  - [x] Do not warn if `Molecule.from_smiles` is provided a **partial** atom map
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
