### PR TITLE
Enumerate input molecule with stereoisomers

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -12,6 +12,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Behavior changes
 
+- [PR #17XX](https://github.com/openforcefield/openff-toolkit/pull/17XX): `Molecule.enumerate_stereoisomers` now includes the input molecule in the returned list.
+
 ### Bugfixes
 
 ### New features

--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -2195,21 +2195,21 @@ class TestMolecule:
 
             # use the default options
             isomers = mol.enumerate_stereoisomers()
-            assert len(isomers) == 2
+            assert len(isomers) == 3
 
-            assert mol not in isomers
+            assert mol in isomers
             # make sure the input molecule is only different by bond stereo
-            for ismol in isomers:
+            for isomol in isomers:
                 assert (
                     Molecule.are_isomorphic(
                         mol,
-                        ismol,
+                        isomol,
                         return_atom_map=False,
                         bond_stereochemistry_matching=False,
                     )[0]
                     is True
                 )
-                assert mol.is_isomorphic_with(ismol) is False
+                assert mol.is_isomorphic_with(isomol) is False
 
             # make sure the isomers are different
             assert isomers[0].is_isomorphic_with(isomers[1]) is False
@@ -2233,19 +2233,19 @@ class TestMolecule:
 
             assert len(isomers) == 2
             # make sure the mol is not in the isomers and that they only differ by stereo chem
-            assert mol not in isomers
-            for ismol in isomers:
-                assert ismol.n_conformers != 0
+            assert mol in isomers
+            for isomol in isomers:
+                assert isomol.n_conformers != 0
                 assert (
                     Molecule.are_isomorphic(
                         mol,
-                        ismol,
+                        isomol,
                         return_atom_map=False,
                         atom_stereochemistry_matching=False,
                     )[0]
                     is True
                 )
-                assert mol.is_isomorphic_with(ismol) is False
+                assert mol.is_isomorphic_with(isomol) is False
 
             # make sure the two isomers are different
             assert isomers[0].is_isomorphic_with(isomers[1]) is False

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -4188,7 +4188,7 @@ class FrozenMolecule(Serializable):
         max_isomers=20,
         rationalise=True,
         toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
-    ):
+    ) -> list["Molecule"]:
         """
         Enumerate the stereocenters and bonds of the current molecule.
 
@@ -4209,8 +4209,8 @@ class FrozenMolecule(Serializable):
 
         Returns
         --------
-        molecules: List[openff.toolkit.topology.Molecule]
-            A list of :class:`Molecule` instances not including the input molecule.
+        molecules: list[openff.toolkit.Molecule]
+            A list of :class:`Molecule` instances including the input molecule.
 
         """
 

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -855,13 +855,13 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
         undefined_only: bool = False,
         max_isomers: int = 20,
         rationalise: bool = True,
-    ) -> List["Molecule"]:
+    ) -> list["Molecule"]:
         """
         Enumerate the stereocenters and bonds of the current molecule.
 
         Parameters
         ----------
-        molecule: openff.toolkit.topology.Molecule
+        molecule: openff.toolkit.Molecule
             The molecule whose state we should enumerate
 
         undefined_only: bool optional, default=False
@@ -876,8 +876,8 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         Returns
         --------
-        molecules: List[openff.toolkit.topology.Molecule]
-            A list of openff.toolkit.topology.Molecule instances
+        molecules: list[openff.toolkit.Molecule]
+            A list of openff.toolkit.Molecule instances including the input molecule.
 
         """
         from openeye import oechem, oeomega
@@ -900,14 +900,10 @@ class OpenEyeToolkitWrapper(base_wrapper.ToolkitWrapper):
                 mol = oechem.OEMol(isomer)
                 status = omega(mol)
                 if status:
-                    isomol = self.from_openeye(mol, _cls=molecule.__class__)
-                    if isomol != molecule:
-                        molecules.append(isomol)
+                    molecules.append(self.from_openeye(mol, _cls=molecule.__class__))
 
             else:
-                isomol = self.from_openeye(isomer, _cls=molecule.__class__)
-                if isomol != molecule:
-                    molecules.append(isomol)
+                molecules.append(self.from_openeye(isomer, _cls=molecule.__class__))
 
         return molecules[:max_isomers]
 

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -1279,13 +1279,13 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         undefined_only: bool = False,
         max_isomers: int = 20,
         rationalise: bool = True,
-    ) -> List["Molecule"]:
+    ) -> list["Molecule"]:
         """
         Enumerate the stereocenters and bonds of the current molecule.
 
         Parameters
         ----------
-        molecule: openff.toolkit.topology.Molecule
+        molecule: openff.toolkit.Molecule
             The molecule whose state we should enumerate
 
         undefined_only: bool optional, default=False
@@ -1299,8 +1299,8 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
 
         Returns
         --------
-        molecules: List[openff.toolkit.topology.Molecule]
-            A list of openff.toolkit.topology.Molecule instances
+        molecules: list[openff.toolkit.Molecule]
+            A list of openff.toolkit.Molecule instances including the input molecule.
 
         """
         from rdkit import Chem
@@ -1332,9 +1332,13 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
             # isomer has CIS/TRANS tags so convert back to E/Z
             Chem.SetDoubleBondNeighborDirections(isomer)
             Chem.AssignStereochemistry(isomer, force=True, cleanIt=True)
-            mol = self.from_rdkit(isomer, _cls=molecule.__class__)
-            if mol != molecule:
-                molecules.append(mol)
+
+            molecules.append(
+                self.from_rdkit(
+                    isomer,
+                    _cls=molecule.__class__,
+                )
+            )
 
         return molecules
 


### PR DESCRIPTION
Suggestion #<space>3 in https://github.com/openforcefield/openff-toolkit/issues/1464#issuecomment-1328660311

- [ ] Deal with cases involving input molecule having undefined stereochemistry
- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
