### PR TITLE
Remove obsolete comments to `OrderedDict`

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -585,7 +585,7 @@ class Atom(Particle):
 #    self._neighbor2 = neighbor2
 
 # def to_dict(self):
-#    bs_dict = OrderedDict()
+#    bs_dict = dict()
 #    bs_dict['stereo_type'] = self._stereo_type
 #    bs_dict['neighbor1_index'] = self._neighbor1.molecule_atom_index
 #    bs_dict['neighbor2_index'] = self._neighbor2.molecule_atom_index

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -1853,7 +1853,7 @@ class ParameterHandler(_ParameterAttributeHandler):
                     f"0.3 SMIRNOFF spec requires each parameter section to have its own version."
                 )
 
-        # List of ParameterType objects (also behaves like an OrderedDict where keys are SMARTS).
+        # List of ParameterType objects (also behaves like a dict where keys are SMARTS).
         self._parameters = ParameterList()
 
         # Initialize ParameterAttributes and cosmetic attributes.

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -383,7 +383,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
                     )
                     residues = [
                         list(substructure_dictionary.keys())[i] for i in res_ids
-                    ]  # fyi substruct dict is now OrderedDict
+                    ]
                     # query_ids = [int(idx) for idx in list(query_ids)]
                     match_info = dict()
                     for res_name, query_idx, query_num in zip(

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -769,7 +769,7 @@ def sort_smirnoff_dict(data):
             sorted_dict[key] = sort_smirnoff_dict(val)
         elif isinstance(val, list):
             # Handle case of ParameterLists, which show up in
-            # the smirnoff dicts as lists of OrderedDicts or dicts
+            # the smirnoff dicts as lists of dicts
             new_parameter_list = list()
             for param in val:
                 new_parameter_list.append(sort_smirnoff_dict(param))


### PR DESCRIPTION
One detail that came up in #1782 is that `OrderedDict` is still made reference to in a couple locations. I removed most of them in  #1053 but some comments were missed.