### PR TITLE
Use built-in `type` in annotations

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -41,7 +41,6 @@ from typing import (
     Optional,
     Sequence,
     TextIO,
-    Type,
     TypeVar,
     Union,
     overload,
@@ -300,7 +299,7 @@ class Atom(Particle):
         }
 
     @classmethod
-    def from_dict(cls: Type[A], atom_dict: dict) -> A:
+    def from_dict(cls: type[A], atom_dict: dict) -> A:
         """Create an Atom from a dict representation."""
         return cls(**atom_dict)
 
@@ -694,7 +693,7 @@ class Bond(Serializable):
         }
 
     @classmethod
-    def from_dict(cls: Type[B], molecule: FM, d: dict) -> B:  # type: ignore[override]
+    def from_dict(cls: type[B], molecule: FM, d: dict) -> B:  # type: ignore[override]
         """Create a Bond from a dict representation."""
         # TODO: This is not used anywhere (`Molecule._initialize_bonds_from_dict()` just calls grabs
         #       the two atoms and calls `Molecule._add_bond`). Remove or change that?
@@ -1641,7 +1640,7 @@ class FrozenMolecule(Serializable):
 
     @classmethod
     def from_inchi(
-        cls: Type[FM],
+        cls: type[FM],
         inchi: str,
         allow_undefined_stereo: bool = False,
         toolkit_registry: TKR = GLOBAL_TOOLKIT_REGISTRY,
@@ -1800,7 +1799,7 @@ class FrozenMolecule(Serializable):
 
     @classmethod
     def from_smiles(
-        cls: Type[FM],
+        cls: type[FM],
         smiles: str,
         hydrogens_are_explicit: bool = False,
         toolkit_registry: TKR = GLOBAL_TOOLKIT_REGISTRY,
@@ -3585,7 +3584,7 @@ class FrozenMolecule(Serializable):
 
     @classmethod
     def from_iupac(
-        cls: Type[FM],
+        cls: type[FM],
         iupac_name: str,
         toolkit_registry: TKR = GLOBAL_TOOLKIT_REGISTRY,
         allow_undefined_stereo: bool = False,
@@ -3680,7 +3679,7 @@ class FrozenMolecule(Serializable):
         return result
 
     @classmethod
-    def from_topology(cls: Type[FM], topology) -> FM:
+    def from_topology(cls: type[FM], topology) -> FM:
         """Return a Molecule representation of an OpenFF Topology containing a single Molecule object.
 
         Parameters
@@ -3738,7 +3737,7 @@ class FrozenMolecule(Serializable):
 
     @classmethod
     def from_file(
-        cls: Type[FM],
+        cls: type[FM],
         file_path: Union[str, pathlib.Path, TextIO],
         file_format=None,
         toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
@@ -3892,7 +3891,7 @@ class FrozenMolecule(Serializable):
     @classmethod
     @requires_package("openmm")
     def from_polymer_pdb(
-        cls: Type[FM],
+        cls: type[FM],
         file_path: Union[str, pathlib.Path, TextIO],
         toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
         name: str = "",
@@ -4277,7 +4276,7 @@ class FrozenMolecule(Serializable):
     @classmethod
     @RDKitToolkitWrapper.requires_toolkit()
     def from_rdkit(
-        cls: Type[FM],
+        cls: type[FM],
         rdmol,
         allow_undefined_stereo: bool = False,
         hydrogens_are_explicit: bool = False,
@@ -4363,7 +4362,7 @@ class FrozenMolecule(Serializable):
     @classmethod
     @OpenEyeToolkitWrapper.requires_toolkit()
     def from_openeye(
-        cls: Type[FM],
+        cls: type[FM],
         oemol,
         allow_undefined_stereo: bool = False,
     ) -> "Molecule":
@@ -4488,7 +4487,7 @@ class FrozenMolecule(Serializable):
 
     @classmethod
     def from_mapped_smiles(
-        cls: Type[FM],
+        cls: type[FM],
         mapped_smiles: str,
         toolkit_registry: TKR = GLOBAL_TOOLKIT_REGISTRY,
         allow_undefined_stereo: bool = False,

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -26,7 +26,7 @@ import copy
 import logging
 import os
 import pathlib
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from packaging.version import Version
 
@@ -304,7 +304,7 @@ class ForceField:
             # module each come from is the safest way to know which are plugins; another
             # option is explicitly defining a set of default handlers
 
-            default_handlers: list[Type[ParameterHandler]] = [
+            default_handlers: list[type[ParameterHandler]] = [
                 handler
                 for handler in all_subclasses(ParameterHandler)
                 if handler.__module__ == internal_module

--- a/openff/toolkit/typing/engines/smirnoff/plugins.py
+++ b/openff/toolkit/typing/engines/smirnoff/plugins.py
@@ -22,7 +22,6 @@ where in this example your package is named ``myapp`` and contains a class which
 inherits from ``ParameterHandler`` named ``CustomHandler``.
 """
 import logging
-from typing import Type
 
 from openff.toolkit.typing.engines.smirnoff.parameters import ParameterHandler
 
@@ -31,7 +30,7 @@ logger = logging.getLogger(__name__)
 SUPPORTED_PLUGIN_NAMES = ["handlers"]  # io_handlers could be supported in future.
 
 
-def _load_handler_plugins(handler_name: str, expected_type) -> list[Type]:
+def _load_handler_plugins(handler_name: str, expected_type) -> list[type]:
     """Loads parameter handler plugins of a specified type which have been registered
     with the ``entrypoint`` plugin system.
 
@@ -53,7 +52,7 @@ def _load_handler_plugins(handler_name: str, expected_type) -> list[Type]:
             f"supported plugin names is: {SUPPORTED_PLUGIN_NAMES}."
         )
 
-    PluginType = Type[ParameterHandler]
+    PluginType = type[ParameterHandler]
 
     discovered_plugins: list[PluginType] = list()
 
@@ -82,7 +81,7 @@ def _load_handler_plugins(handler_name: str, expected_type) -> list[Type]:
     return valid_plugins
 
 
-def load_handler_plugins() -> list[Type[ParameterHandler]]:
+def load_handler_plugins() -> list[type[ParameterHandler]]:
     """Loads any ``ParameterHandler`` class plugins which have been registered through
     the ``entrypoint`` plugin system.
 

--- a/openff/toolkit/utils/nagl_wrapper.py
+++ b/openff/toolkit/utils/nagl_wrapper.py
@@ -1,6 +1,6 @@
 import importlib
 import warnings
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional
 
 from openff.toolkit import Quantity, unit
 from openff.toolkit.utils.base_wrapper import ToolkitWrapper
@@ -56,7 +56,7 @@ class NAGLToolkitWrapper(ToolkitWrapper):
         use_conformers: Optional[list["Quantity"]] = None,
         strict_n_conformers: bool = False,
         normalize_partial_charges: bool = True,
-        _cls: Optional[Type["FrozenMolecule"]] = None,
+        _cls: Optional[type["FrozenMolecule"]] = None,
     ):
         from openff.nagl import GNNModel
         from openff.nagl_models import validate_nagl_model_path

--- a/openff/toolkit/utils/serialization.py
+++ b/openff/toolkit/utils/serialization.py
@@ -12,7 +12,7 @@ Serialization mix-in
 
 """
 import abc
-from typing import Type, TypeVar
+from typing import TypeVar
 
 from openff.toolkit.utils.utils import requires_package
 
@@ -99,7 +99,7 @@ class Serializable(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def from_dict(cls: Type[S], d: dict) -> S:
+    def from_dict(cls: type[S], d: dict) -> S:
         pass
 
     def to_json(self, indent=None) -> str:


### PR DESCRIPTION
#1790 

These changes are not from `sed`, which would have captured too much. I grepped for `from typing.*Type` and `^    Type` and manually edited matching files.

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
