### PR TITLE
Make ForceField.parse_sources docstring consistent with implementation

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -24,6 +24,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### Improved documentation and warnings
 
 - [PR #1732](https://github.com/openforcefield/openff-toolkit/pull/1732): Add documentation describing the use of PDB files with the toolkit.
+- [PR #1804](https://github.com/openforcefield/openff-toolkit/pull/1804): Makes `ForceField.parse_sources` docstring consistent with implementation.
 
 ## 0.14.5
 
@@ -39,7 +40,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Improved documentation and warnings
 
-- [PR #1747](https://github.com/openforcefield/openff-toolkit/pull/1747): Warns if a SMILES with full atom mappings is passed to `Moleucle.from_smiles`, which does not use the atom map for atom ordering (`Molecule.from_mapped_smiles` does).
+- [PR #1747](https://github.com/openforcefield/openff-toolkit/pull/1747): Warns if a SMILES with full atom mappings is passed to `Molecule.from_smiles`, which does not use the atom map for atom ordering (`Molecule.from_mapped_smiles` does).
 - [PR #1743](https://github.com/openforcefield/openff-toolkit/pull/1743): Uses a longer stride in OpenMM DCD reporter in the toolkit showcase and should better utilize GPU resources, if available.
 - [PR #1744](https://github.com/openforcefield/openff-toolkit/pull/1744): Updates the virtual site notebook to use new Interchange behavior.
 

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -280,6 +280,10 @@ class ForceField:
         >>> offxml = '<SMIRNOFF version="0.2" aromaticity_model="OEAroModel_MDL"/>'
         >>> forcefield = ForceField(offxml)
 
+        See Also
+        --------
+        parse_sources
+
         """
         # Clear all object fields
         self._initialize()
@@ -762,8 +766,8 @@ class ForceField:
 
         Parameters
         ----------
-        sources : string or file-like object or open file handle or URL (or iterable of these)
-            A list of files defining the SMIRNOFF force field to be loaded.
+        sources : iterable of string or file-like object or open file handle or URL
+            An iterable of files defining the SMIRNOFF force field to be loaded.
             Currently, only `the SMIRNOFF XML format <https://openforcefield.github.io/standards/standards/smirnoff/>`_
             is supported.  Each entry may be an absolute file path, a path relative to the current working directory, a
             path relative to this module's data subdirectory (for built in force fields), or an open file-like object


### PR DESCRIPTION
Handles #1803 

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
