### PR TITLE
Fix t4 tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,9 +150,9 @@ jobs:
         run: |
           PYTEST_ARGS+=" --ignore=openff/toolkit/_tests/test_examples.py"
           PYTEST_ARGS+=" --ignore=openff/toolkit/_tests/test_links.py"
-          #if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
-          PYTEST_ARGS+=" --runslow"
-          #fi
+          if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+            PYTEST_ARGS+=" --runslow"
+          fi
 
           python -m pytest $PYTEST_ARGS $COV
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,9 +150,9 @@ jobs:
         run: |
           PYTEST_ARGS+=" --ignore=openff/toolkit/_tests/test_examples.py"
           PYTEST_ARGS+=" --ignore=openff/toolkit/_tests/test_links.py"
-          if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
-            PYTEST_ARGS+=" --runslow"
-          fi
+          #if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+          PYTEST_ARGS+=" --runslow"
+          #fi
 
           python -m pytest $PYTEST_ARGS $COV
 

--- a/openff/toolkit/_tests/test_mm_molecule.py
+++ b/openff/toolkit/_tests/test_mm_molecule.py
@@ -77,7 +77,6 @@ def molecule_with_bogus_atom():
 
 
 @pytest.fixture()
-@requires_rdkit
 def t4():
     return _SimpleMolecule.from_molecule(
         Topology.from_pdb(get_data_file_path("proteins/T4-protein.pdb")).molecule(0)
@@ -180,6 +179,7 @@ class TestMMMolecule:
                 assert atom_copy.molecule is molecule_copy
 
     @pytest.mark.slow
+    @requires_rdkit
     def test_deepcopy_t4(self, t4):
         t4_copy = copy.deepcopy(t4)
 
@@ -205,6 +205,7 @@ class TestMMMolecule:
         assert topology.n_bonds == methanol.n_bonds
 
     @pytest.mark.slow
+    @requires_rdkit
     def test_to_t4_topology(self, t4):
         topology = t4.to_topology()
 

--- a/openff/toolkit/_tests/test_mm_molecule.py
+++ b/openff/toolkit/_tests/test_mm_molecule.py
@@ -8,6 +8,7 @@ from openff.toolkit._tests.create_molecules import create_ethanol
 from openff.toolkit._tests.create_molecules import (
     dipeptide_residues_perceived as create_dipeptide,
 )
+from openff.toolkit._tests.utils import get_data_file_path, requires_rdkit
 from openff.toolkit.topology._mm_molecule import _SimpleMolecule
 
 
@@ -76,9 +77,10 @@ def molecule_with_bogus_atom():
 
 
 @pytest.fixture()
+@requires_rdkit
 def t4():
     return _SimpleMolecule.from_molecule(
-        Topology.from_pdb("openff/toolkit/data/proteins/T4-protein.pdb").molecule(0)
+        Topology.from_pdb(get_data_file_path("proteins/T4-protein.pdb")).molecule(0)
     )
 
 


### PR DESCRIPTION
#1805 introduced tests that should only run when RDKit is installed, but since some of them are slow tests, they didn't run in the normal CI until after the PR was merged (since regularly the slow tests only run in nightlies)
