### PR TITLE
Make conda ci use pytest 7.4

### DIFF
--- a/devtools/conda-envs/conda.yaml
+++ b/devtools/conda-envs/conda.yaml
@@ -5,5 +5,5 @@ dependencies:
     # Base depends
   - openff-toolkit-examples
     # Tests
-  - pytest
+  - pytest=7.4
   - pytest-rerunfailures

--- a/devtools/conda-envs/conda_oe.yaml
+++ b/devtools/conda-envs/conda_oe.yaml
@@ -7,5 +7,5 @@ dependencies:
   - openff-toolkit-examples
     # Tests
   - openeye-toolkits
-  - pytest
+  - pytest=7.4
   - pytest-rerunfailures


### PR DESCRIPTION
[Conda CI is failing](https://github.com/openforcefield/openff-toolkit/actions/runs/7689310335/job/20951573409) with pytest 8. Until we find the root cause I'm downpinning pytest to 7.4. 