### PR TITLE
Ensure v1 `ValidationError` is checked in test

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -6,17 +6,11 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 * `minor` increments add features but do not break API compatibility
 * `micro` increments represent bugfix releases or improvements in documentation
 
-## Current development
+## 0.15.1
 
-### API-breaking changes
+### Tests updated
 
-### Behavior changes
-
-### Bugfixes
-
-### New features
-
-### Improved documentation and warnings
+- [PR #1814](https://github.com/openforcefield/openff-toolkit/pull/1814): Fixes a test to be compatible with both pydantic 1 and 2.
 
 ## 0.15.0
 

--- a/openff/toolkit/_tests/test_forcefield.py
+++ b/openff/toolkit/_tests/test_forcefield.py
@@ -14,7 +14,6 @@ from numpy.testing import assert_almost_equal
 from openff.units.openmm import from_openmm, to_openmm
 from openmm import NonbondedForce, Platform, XmlSerializer, app
 from openmm import unit as openmm_unit
-from pydantic import ValidationError
 
 from openff.toolkit import unit
 from openff.toolkit._tests.create_molecules import (
@@ -4006,6 +4005,14 @@ class TestForceFieldParameterAssignment(_ForceFieldFixtures):
             "ProperTorsions"
         )._fractional_bondorder_interpolation = "invalid method name"
         topology = Topology.from_molecules([mol])
+
+        # This error will be either from v1 of the package (if v1 is installed)
+        # or the faked v1 API (if v2 is installed). Ensure the v1 error or a
+        # mimick of it is imported
+        try:
+            from pydantic.v1 import ValidationError
+        except ImportError:
+            from pydantic import ValidationError
 
         # If important, this can be a custom exception instead of a verbose ValidationError
         with pytest.raises(


### PR DESCRIPTION
The current code blindly does `from Pydantic import ValidationError`, which later causes problems when attempting to later catch the error which is always from v1.

This works locally with each of v1 and v2 installed