### PR TITLE
Skip some tests if unpackaged files not present, make some files path-y-er

### DIFF
--- a/openff/toolkit/_tests/test_links.py
+++ b/openff/toolkit/_tests/test_links.py
@@ -1,15 +1,12 @@
-import os
 import re
 from urllib.request import Request, urlopen
 
 import pytest
 
-ROOT_DIR_PATH = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), "..", "..", ".."
-)
+from openff.toolkit._tests.utils import _get_readme_path
 
 
-def find_readme_links():
+def find_readme_links() -> list[str]:
     """Yield all the links in the main README.md file.
 
     Returns
@@ -17,10 +14,16 @@ def find_readme_links():
     readme_examples : list[str]
         The list of links included in the README.md file.
     """
-    readme_file_path = os.path.join(ROOT_DIR_PATH, "README.md")
-    with open(readme_file_path, "r") as f:
-        readme_content = f.read()
-    return re.findall("http[s]?://(?:[0-9a-zA-Z]|[-/.%:_])+", readme_content)
+    readme_file_path = _get_readme_path()
+
+    if readme_file_path is None:
+        return list()
+
+    else:
+        with open(readme_file_path.as_posix(), "r") as f:
+            readme_content = f.read()
+
+        return re.findall("http[s]?://(?:[0-9a-zA-Z]|[-/.%:_])+", readme_content)
 
 
 @pytest.mark.parametrize("readme_link", find_readme_links())

--- a/openff/toolkit/_tests/utils.py
+++ b/openff/toolkit/_tests/utils.py
@@ -9,9 +9,11 @@ import functools
 import importlib
 import itertools
 import os
+import pathlib
 import pprint
 import textwrap
 from contextlib import contextmanager
+from typing import Union
 
 import numpy as np
 import openmm
@@ -43,6 +45,22 @@ requires_openeye_mol2 = pytest.mark.skipif(
     not OpenEyeToolkitWrapper.is_available(),
     reason="Test requires OE toolkit to read mol2 files",
 )
+
+
+def _get_readme_path() -> Union[pathlib.Path, None]:
+    """
+    Return a path to the README file or None if it cannot be assured to be the toolkit's README.
+    """
+    if "site-packages" in __file__:
+        # This test file is being collected from the installed package, which
+        # does not provide the README file.
+        # Note that there will likely be a mis-bundled file
+        # $CONDA_PREFIX/lib/python3.x/site-packages/README.md, but this is not
+        # the toolkit's README file!
+        return None
+
+    else:
+        return pathlib.Path(__file__).parents[3] / "README.md"
 
 
 def has_pkg(pkg_name):


### PR DESCRIPTION
The tests currently make some unsafe assumptions about files present relative to the Python package. For example, this does not necessarily point to the root of the repository, since many files are not packaged:

https://github.com/openforcefield/openff-toolkit/blob/5ffcb58714c93143d8c00841c00e73f46a6c296f/openff/toolkit/_tests/test_links.py#L7-L9

From this, peeking at the `README.md` file (or looking for an `examples/` directory) can introduce some surprises:

```python
In [1]: import pathlib, os

In [2]: from openff.toolkit._tests.test_links import __file__

In [3]: os.system(f"head {pathlib.Path(__file__).parents[3] / 'README.md'}")
# autoflake

[![Build Status](https://github.com/PyCQA/autoflake/actions/workflows/main.yaml/badge.svg?branch=main)](https://github.com/PyCQA/autoflake/actions/workflows/main.yaml)

## Introduction

_autoflake_ removes unused imports and unused variables from Python code. It
makes use of [pyflakes](https://pypi.org/pypi/pyflakes) to do this.

By default, autoflake only removes unused imports for modules that are part of
Out[3]: 0
```

This change simply has fixtures return empty lists when it looks like tests are being collected from a packaged path (as distinct from a local path, where the full contents of the repository may be present).