### PR TITLE
Add `Topology.clear_positions`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -16,6 +16,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### New features
 
+- [PR #1827](https://github.com/openforcefield/openff-toolkit/pull/1827): Adds `Topology.clear_positions`
+
 ### Improved documentation and warnings
 
 - [PR #1795](https://github.com/openforcefield/openff-toolkit/pull/1795): Add `NAGLToolkitWrapper` to API reference

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -2242,6 +2242,14 @@ class TestTopologyPositions:
 
         return topology
 
+    @pytest.fixture()
+    def topology_with_positions(self, topology) -> Topology:
+        # These conformers will obviously overlap, but they'll be the right data type
+        for molecule in topology.molecules:
+            molecule.generate_conformers(n_conformers=1)
+
+        return topology
+
     def test_set_positions_fails_without_units(self, topology):
         # Generate positions without units deterministically
         positions_no_units = np.arange(topology.n_atoms * 3).reshape(-1, 3)
@@ -2324,6 +2332,30 @@ class TestTopologyPositions:
         topology.set_positions(positions)
         topology._molecules[0]._conformers = None
         assert topology.get_positions() is None
+
+    def test_clear_and_re_set_positions(self, topology_with_positions):
+        initial_positions = topology_with_positions.get_positions()
+        assert initial_positions is not None
+        assert initial_positions.shape == (topology_with_positions.n_atoms, 3)
+
+        with pytest.raises(
+            ValueError,
+            match="cannot be None.*use clear_positions",
+        ):
+            topology_with_positions.set_positions(None)
+
+        topology_with_positions.clear_positions()
+
+        assert topology_with_positions.get_positions() is None
+
+        for molecule in topology_with_positions.molecules:
+            assert molecule.conformers is None
+
+        # re-set positions back to their original values
+        topology_with_positions.set_positions(initial_positions)
+
+        assert initial_positions is not None
+        assert initial_positions.shape == (topology_with_positions.n_atoms, 3)
 
 
 @requires_rdkit

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -2066,6 +2066,7 @@ class Topology(Serializable):
         See Also
         ========
         set_positions
+        clear_positions
         """
         conformers = []
         for molecule in self.molecules:
@@ -2080,6 +2081,21 @@ class Topology(Serializable):
         positions = np.concatenate(conformers, axis=0)
 
         return Quantity(positions, unit.nanometer)
+
+    def clear_positions(self):
+        """
+        Clear the positions of this topology by removing all conformers from its consituent molecules.
+
+        Note that all conformers will be deleted (in-place) from all molecules. Use `Topology.get_positions()`
+        if you wish to save them before clearing.
+
+        See Also
+        --------
+        get_positions
+        set_positions
+        """
+        for molecule in self.molecules:
+            molecule._conformers = None
 
     def set_positions(self, array: Quantity):
         """
@@ -2098,7 +2114,13 @@ class Topology(Serializable):
         See Also
         ========
         get_positions
+        clear_positions
         """
+        if array is None:
+            raise ValueError(
+                "array argument cannot be None, use clear_positions instead."
+            )
+
         if not isinstance(array, Quantity):
             raise IncompatibleUnitError(
                 "array should be an OpenFF Quantity with dimensions of length"


### PR DESCRIPTION
This adds `Topology.clear_positions()` which does what the name implies, instead of allowing `Topology.set_positions(None)` as I originally advocated for in #1820. Today I think it's better to just have a separate method that does this one thing - it handles what I remember my use case to be - instead of allowing `set_positions` to take different types.

I hold this preference weakly (I've already changed my mine once on my own) and can easily be talked out of it


- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
