### PR TITLE
Update `convert_all_strings_to_quantity` docstring

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -26,6 +26,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 - [PR #1795](https://github.com/openforcefield/openff-toolkit/pull/1795): Add `NAGLToolkitWrapper` to API reference
 - [PR #1796](https://github.com/openforcefield/openff-toolkit/pull/1796): Update docs tooling and fix warnings
 - [PR #1786](https://github.com/openforcefield/openff-toolkit/pull/1786): Describe contributing to documentation notebooks in developers guide.
+- [PR #1845](https://github.com/openforcefield/openff-toolkit/pull/1845): Update convert_all_strings_to_quantity docstring.
 
 ## 0.15.2
 

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -223,6 +223,8 @@ def convert_all_strings_to_quantity(
     Integers and floats are ignored and not converted into a dimensionless
     ``openff.units.unit.Quantity`` object.
 
+    Some good keys to ignore include `ignore_keys=["smirks", "name", "id", "parent_id"]`.
+
     Parameters
     ----------
     smirnoff_data
@@ -323,15 +325,15 @@ def convert_all_quantities_to_string(
 @functools.singledispatch
 def object_to_quantity(object):
     """
-    Attempts to turn the provided object into openmm.unit.Quantity(s).
+    Attempts to turn the provided object into `openff.units.Quantity`s.
 
-    Can handle float, int, strings, quantities, or iterators over
+    Can handle float, int, str, `Quantity`, `openmm.unit.Quantity`, or iterators over
     the same. Raises an exception if unable to convert all inputs.
 
     Parameters
     ----------
     object
-        The object to convert to a ``openmm.unit.Quantity`` object.
+        The object to convert to a ``Quantity`` object.
 
     Returns
     -------

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -144,7 +144,7 @@ def dict_to_quantity(input_dict):
 
 def quantity_to_string(input_quantity: Quantity) -> str:
     """
-    Serialize a openff.units.unit.Quantity to a string representation that is backwards-compatible
+    Serialize a ``openff.units.Quantity`` to a string representation that is backwards-compatible
     with older versions of the OpenFF Toolkit. This includes a " * " between numerical values and
     their units and "A" being used in place of the unicode Å ("\N{ANGSTROM SIGN}").
 
@@ -172,14 +172,14 @@ def quantity_to_string(input_quantity: Quantity) -> str:
 
 def string_to_unit(unit_string):
     """
-    Deserializes a openff.units.unit.Quantity from a string representation, for
+    Deserializes a ``openff.units.Quantity`` from a string representation, for
     example: "kilocalories_per_mole / angstrom ** 2"
 
 
     Parameters
     ----------
     unit_string
-        Serialized representation of a openff.units.unit.Quantity.
+        Serialized representation of a ``openff.units.Quantity``.
 
     Returns
     -------
@@ -190,9 +190,9 @@ def string_to_unit(unit_string):
 
 
 def string_to_quantity(quantity_string) -> Union[str, int, float, Quantity]:
-    """Attempt to parse a string into a unit.Quantity.
+    """Attempt to parse a string into a ``Quantity``.
 
-    Note that dimensionless floats and ints are returns as floats or ints, not Quantity objects.
+    Note that dimensionless floats and ints are returns as floats or ints, not ``Quantity`` objects.
     """
 
     from tokenize import TokenError
@@ -215,15 +215,19 @@ def string_to_quantity(quantity_string) -> Union[str, int, float, Quantity]:
 def convert_all_strings_to_quantity(
     smirnoff_data: dict,
     ignore_keys: Iterable[str] = tuple(),
-):
+) -> dict:
     """
     Traverses a SMIRNOFF data structure, attempting to convert all
-    quantity-defining strings into openff.units.unit.Quantity objects.
+    quantity-defining strings into ``openff.units.Quantity`` objects.
 
     Integers and floats are ignored and not converted into a dimensionless
-    ``openff.units.unit.Quantity`` object.
+    ``openff.units.Quantity`` object.
 
-    Some good keys to ignore include `ignore_keys=["smirks", "name", "id", "parent_id"]`.
+    Some good keys to ignore include `ignore_keys=["smirks", "name", "id", "parent_id"]`
+    since these are commonly used in SMIRNOFF force fields in ways that are meant to
+    remain strings. For more context, see `Issue #1635`_.
+
+    .. _Issue #1635: https://github.com/openforcefield/openff-toolkit/issues/1635.
 
     Parameters
     ----------
@@ -236,7 +240,7 @@ def convert_all_strings_to_quantity(
     -------
     converted_smirnoff_data
         A hierarchical dict structured in compliance with the SMIRNOFF spec,
-        with quantity-defining strings converted to openff.units.unit.Quantity objects
+        with quantity-defining strings converted to ``openff.units.Quantity`` objects
     """
     from pint import DefinitionSyntaxError
 
@@ -305,7 +309,7 @@ def convert_all_quantities_to_string(
     -------
     converted_smirnoff_data
         A hierarchical dict structured in compliance with the SMIRNOFF spec,
-        with openff.units.unit.Quantitys converted to string
+        with ``openff.units.Quantity``s converted to string
     """
 
     if isinstance(smirnoff_data, dict):
@@ -333,7 +337,7 @@ def object_to_quantity(object):
     Parameters
     ----------
     object
-        The object to convert to a ``Quantity`` object.
+        The object to convert to a ``Quantity`` object(s).
 
     Returns
     -------
@@ -366,7 +370,7 @@ def _(obj):
 
 
 try:
-    import openmm
+    import openmm.unit
     from openff.units.openmm import from_openmm
 
     @object_to_quantity.register(openmm.unit.Quantity)


### PR DESCRIPTION
Some crucial context (https://github.com/openforcefield/openff-toolkit/issues/1635#issuecomment-1593365681) was not captured in the docstring in ways that I wish was previously there. Also, the docstring was incorrect in some other details.