### PR TITLE
[WIP] Allow duplicate SMIRKS and have lookups return the LAST one found

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,11 +15,20 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Behavior changes
 
+- [PR #1852](https://github.com/openforcefield/openff-toolkit/pull/1852): Fixes issue 
+  [#1363](https://github.com/openforcefield/openff-toolkit/issues/1363): If multiple parameters have identical 
+  SMIRKS, calls to `ParameterHandler[smirks]` and `ParameterList[smirks]` will now return the LAST parameter 
+  with a matching SMIRKS. Previously this would return the FIRST parameter with a matching SMIRKS, which was 
+  a confusing behavior given SMIRNOFF hierarchy rules.
+
 ### Bugfixes
 
 ### New features
 
 - [PR #1827](https://github.com/openforcefield/openff-toolkit/pull/1827): Adds `Topology.clear_positions`
+- [PR #1852](https://github.com/openforcefield/openff-toolkit/pull/1852): Adds the `allow_duplicate_smirks` named
+  argument to `ParameterHandler.add_parameter`. Previously it was possible to make a force field with duplicate
+  SMIRKS by loading it from file or combining multiple FFs, so this also lets you do it using the API.
 
 ### Improved documentation and warnings
 

--- a/openff/toolkit/_tests/test_forcefield.py
+++ b/openff/toolkit/_tests/test_forcefield.py
@@ -1711,6 +1711,18 @@ class TestForceField(_ForceFieldFixtures):
         ):
             force_field["vdW"][smirks]
 
+    def test_lookup_duplicate_parameter_type(self, force_field):
+        """Test that if a parameter SMIRKS appears twice, lookups will yield the second copy"""
+        first_bond = force_field["Bonds"][0]
+        force_field["Bonds"].add_parameter({"smirks": first_bond.smirks,
+                                            "k": first_bond.k / 2,
+                                            "length": first_bond.length/2,
+                                            "id": first_bond.id+"2"})
+        result = force_field["Bonds"][first_bond.smirks]
+        assert result.id == force_field["Bonds"][0].id + "2"
+        assert result.k == first_bond.k / 2
+        assert result.length == first_bond.length/2
+
     @pytest.mark.parametrize(
         "to_deregister",
         [

--- a/openff/toolkit/_tests/test_forcefield.py
+++ b/openff/toolkit/_tests/test_forcefield.py
@@ -1724,7 +1724,7 @@ class TestForceField(_ForceFieldFixtures):
             allow_duplicate_smirks=True,
         )
         result = force_field["Bonds"][first_bond.smirks]
-        assert result == forcefield['Bonds'].parameters[first_bond.smirks]
+        assert result == forcefield["Bonds"].parameters[first_bond.smirks]
         assert result.id == force_field["Bonds"][0].id + "2"
         assert result.k == first_bond.k / 2
         assert result.length == first_bond.length / 2

--- a/openff/toolkit/_tests/test_forcefield.py
+++ b/openff/toolkit/_tests/test_forcefield.py
@@ -1724,7 +1724,7 @@ class TestForceField(_ForceFieldFixtures):
             allow_duplicate_smirks=True,
         )
         result = force_field["Bonds"][first_bond.smirks]
-        assert result == forcefield["Bonds"].parameters[first_bond.smirks]
+        assert result == force_field["Bonds"].parameters[first_bond.smirks]
         assert result.id == force_field["Bonds"][0].id + "2"
         assert result.k == first_bond.k / 2
         assert result.length == first_bond.length / 2

--- a/openff/toolkit/_tests/test_forcefield.py
+++ b/openff/toolkit/_tests/test_forcefield.py
@@ -1724,6 +1724,7 @@ class TestForceField(_ForceFieldFixtures):
             allow_duplicate_smirks=True,
         )
         result = force_field["Bonds"][first_bond.smirks]
+        assert result == forcefield['Bonds'].parameters[first_bond.smirks]
         assert result.id == force_field["Bonds"][0].id + "2"
         assert result.k == first_bond.k / 2
         assert result.length == first_bond.length / 2

--- a/openff/toolkit/_tests/test_forcefield.py
+++ b/openff/toolkit/_tests/test_forcefield.py
@@ -1714,14 +1714,18 @@ class TestForceField(_ForceFieldFixtures):
     def test_lookup_duplicate_parameter_type(self, force_field):
         """Test that if a parameter SMIRKS appears twice, lookups will yield the second copy"""
         first_bond = force_field["Bonds"][0]
-        force_field["Bonds"].add_parameter({"smirks": first_bond.smirks,
-                                            "k": first_bond.k / 2,
-                                            "length": first_bond.length/2,
-                                            "id": first_bond.id+"2"})
+        force_field["Bonds"].add_parameter(
+            {
+                "smirks": first_bond.smirks,
+                "k": first_bond.k / 2,
+                "length": first_bond.length / 2,
+                "id": first_bond.id + "2",
+            }
+        )
         result = force_field["Bonds"][first_bond.smirks]
         assert result.id == force_field["Bonds"][0].id + "2"
         assert result.k == first_bond.k / 2
-        assert result.length == first_bond.length/2
+        assert result.length == first_bond.length / 2
 
     @pytest.mark.parametrize(
         "to_deregister",

--- a/openff/toolkit/_tests/test_forcefield.py
+++ b/openff/toolkit/_tests/test_forcefield.py
@@ -1714,11 +1714,15 @@ class TestForceField(_ForceFieldFixtures):
     def test_lookup_duplicate_parameter_type(self, force_field):
         """Test that if a parameter SMIRKS appears twice, lookups will yield the second copy"""
         first_bond = force_field["Bonds"][0]
-        force_field["Bonds"].add_parameter({"smirks": first_bond.smirks,
-                                            "k": first_bond.k / 2,
-                                            "length": first_bond.length/2,
-                                            "id": first_bond.id+"2"},
-                                           allow_duplicate_smirks=True)
+        force_field["Bonds"].add_parameter(
+            {
+                "smirks": first_bond.smirks,
+                "k": first_bond.k / 2,
+                "length": first_bond.length / 2,
+                "id": first_bond.id + "2",
+            },
+            allow_duplicate_smirks=True,
+        )
         result = force_field["Bonds"][first_bond.smirks]
         assert result.id == force_field["Bonds"][0].id + "2"
         assert result.k == first_bond.k / 2

--- a/openff/toolkit/_tests/test_forcefield.py
+++ b/openff/toolkit/_tests/test_forcefield.py
@@ -1714,14 +1714,11 @@ class TestForceField(_ForceFieldFixtures):
     def test_lookup_duplicate_parameter_type(self, force_field):
         """Test that if a parameter SMIRKS appears twice, lookups will yield the second copy"""
         first_bond = force_field["Bonds"][0]
-        force_field["Bonds"].add_parameter(
-            {
-                "smirks": first_bond.smirks,
-                "k": first_bond.k / 2,
-                "length": first_bond.length / 2,
-                "id": first_bond.id + "2",
-            }
-        )
+        force_field["Bonds"].add_parameter({"smirks": first_bond.smirks,
+                                            "k": first_bond.k / 2,
+                                            "length": first_bond.length/2,
+                                            "id": first_bond.id+"2"},
+                                           allow_duplicate_smirks=True)
         result = force_field["Bonds"][first_bond.smirks]
         assert result.id == force_field["Bonds"][0].id + "2"
         assert result.k == first_bond.k / 2

--- a/openff/toolkit/_tests/test_parameters.py
+++ b/openff/toolkit/_tests/test_parameters.py
@@ -493,10 +493,14 @@ class TestParameterHandler:
             "smirks": param2["smirks"],
             "length": 2 * self.length,
             "k": 2 * self.k,
+            "id": "b4",
         }
 
-        # Ensure a duplicate parameter CAN be added
-        bh.add_parameter(param_duplicate_smirks)
+        # Ensure a duplicate parameter cannot be added under default conditions
+        with pytest.raises(DuplicateParameterError):
+            bh.add_parameter(param_duplicate_smirks)
+        # Ensure a duplicate parameter CAN be added if `allow_duplicate_smirks=True`
+        bh.add_parameter(param_duplicate_smirks, allow_duplicate_smirks=True)
 
         dict_to_add_by_smirks = {
             "smirks": "[#1:1]-[#6:2]",
@@ -551,17 +555,17 @@ class TestParameterHandler:
         # Add d1 before param b2
         bh.add_parameter(dict_to_add_by_smirks, before="[*:1]=[*:2]")
 
-        assert [p.id for p in bh._parameters] == ["b1", "d1", "b2", "b3"]
+        assert [p.id for p in bh._parameters] == ["b1", "d1", "b2", "b3", "b4"]
 
         # Add d2 after index 2 (which is also param b2)
         bh.add_parameter(dict_to_add_by_index, after=2)
 
-        assert [p.id for p in bh._parameters] == ["b1", "d1", "b2", "d2", "b3"]
+        assert [p.id for p in bh._parameters] == ["b1", "d1", "b2", "d2", "b3", "b4"]
 
         # Add p1 before param b3
         bh.add_parameter(parameter=param_to_add_by_smirks, before="[*:1]=[*:2]")
 
-        assert [p.id for p in bh._parameters] == ["b1", "d1", "p1", "b2", "d2", "b3"]
+        assert [p.id for p in bh._parameters] == ["b1", "d1", "p1", "b2", "d2", "b3", "b4"]
 
         # Add p2 after index 2 (which is param p1)
         bh.add_parameter(parameter=param_to_add_by_index, after=2)
@@ -574,6 +578,7 @@ class TestParameterHandler:
             "b2",
             "d2",
             "b3",
+            "b4",
         ]
 
         # Add s0 between params that are several positions apart
@@ -588,6 +593,7 @@ class TestParameterHandler:
             "b2",
             "d2",
             "b3",
+            "b4",
         ]
 
     def test_different_units_to_dict(self):

--- a/openff/toolkit/_tests/test_parameters.py
+++ b/openff/toolkit/_tests/test_parameters.py
@@ -495,9 +495,8 @@ class TestParameterHandler:
             "k": 2 * self.k,
         }
 
-        # Ensure a duplicate parameter cannot be added
-        with pytest.raises(DuplicateParameterError):
-            bh.add_parameter(param_duplicate_smirks)
+        # Ensure a duplicate parameter CAN be added
+        bh.add_parameter(param_duplicate_smirks)
 
         dict_to_add_by_smirks = {
             "smirks": "[#1:1]-[#6:2]",
@@ -843,6 +842,14 @@ class TestParameterList:
         p4 = ParameterType(smirks="[#2:1]")
         with pytest.raises(ValueError, match="is not in list"):
             parameters.index(p4)
+
+    def test_index_duplicates(self):
+        """Test ParameterList.index when multiple parameters have identical SMIRKS"""
+        p1 = ParameterType(smirks="[*:1]")
+        p2 = ParameterType(smirks="[*:1]")
+        parameters = ParameterList([p1, p2])
+        assert parameters.index("[*:1]") == 1
+
 
     def test_contains(self):
         """Test ParameterList __contains__ overloading."""

--- a/openff/toolkit/_tests/test_parameters.py
+++ b/openff/toolkit/_tests/test_parameters.py
@@ -565,7 +565,15 @@ class TestParameterHandler:
         # Add p1 before param b3
         bh.add_parameter(parameter=param_to_add_by_smirks, before="[*:1]=[*:2]")
 
-        assert [p.id for p in bh._parameters] == ["b1", "d1", "p1", "b2", "d2", "b3", "b4"]
+        assert [p.id for p in bh._parameters] == [
+            "b1",
+            "d1",
+            "p1",
+            "b2",
+            "d2",
+            "b3",
+            "b4",
+        ]
 
         # Add p2 after index 2 (which is param p1)
         bh.add_parameter(parameter=param_to_add_by_index, after=2)

--- a/openff/toolkit/_tests/test_parameters.py
+++ b/openff/toolkit/_tests/test_parameters.py
@@ -850,7 +850,6 @@ class TestParameterList:
         parameters = ParameterList([p1, p2])
         assert parameters.index("[*:1]") == 1
 
-
     def test_contains(self):
         """Test ParameterList __contains__ overloading."""
         p1 = ParameterType(smirks="[*:1]")

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -1543,7 +1543,8 @@ class ParameterList(list):
 
     def __getitem__(self, item: Union[int, slice, str, "ParameterType"]):  # type: ignore[override]
         """
-        Retrieve item by index or SMIRKS
+        Retrieve item by index or SMIRKS. If multiple parameters have the same
+        SMIRKS, this returns the last one.
 
         Parameters
         ----------
@@ -1987,6 +1988,7 @@ class ParameterHandler(_ParameterAttributeHandler):
         parameter: Optional[ParameterType] = None,
         after: Optional[str] = None,
         before: Optional[str] = None,
+        allow_duplicate_smirks: bool = False,
     ):
         """Add a parameter to the force field, ensuring all parameters are valid.
 
@@ -2002,6 +2004,9 @@ class ParameterHandler(_ParameterAttributeHandler):
         before
             The SMIRKS pattern (if str) or index (if int) of the parameter directly after where
             the new parameter will be added
+        allow_duplicate_smirks
+            If False, a DuplicateParameterError will be raised if the parameter being added has
+            a SMIRKS that already appears in another parameter owned by this ParameterHandler.
 
         Note the following behavior:
           * Either `parameter_kwargs` or `parameter` must be specified.
@@ -2052,9 +2057,10 @@ class ParameterHandler(_ParameterAttributeHandler):
         else:
             raise ValueError("One of (parameter, parameter_kwargs) must be specified")
 
-        # if self._index_of_parameter(new_parameter) is not None:
-        #     msg = f"A parameter SMIRKS pattern {new_parameter.smirks} already exists."
-        #     raise DuplicateParameterError(msg)
+        if not allow_duplicate_smirks:
+            if self._index_of_parameter(new_parameter) is not None:
+                msg = f"A parameter SMIRKS pattern {new_parameter.smirks} already exists."
+                raise DuplicateParameterError(msg)
 
         before_index, after_index = None, None
 
@@ -2387,7 +2393,7 @@ class ParameterHandler(_ParameterAttributeHandler):
 
     def __getitem__(self, val):
         """
-        Syntax sugar for lookikng up a ParameterType in a ParameterHandler
+        Syntax sugar for looking up a ParameterType in a ParameterHandler
         based on its SMIRKS.
         """
         return self.parameters[val]

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -2059,7 +2059,9 @@ class ParameterHandler(_ParameterAttributeHandler):
 
         if not allow_duplicate_smirks:
             if self._index_of_parameter(new_parameter) is not None:
-                msg = f"A parameter SMIRKS pattern {new_parameter.smirks} already exists."
+                msg = (
+                    f"A parameter SMIRKS pattern {new_parameter.smirks} already exists."
+                )
                 raise DuplicateParameterError(msg)
 
         before_index, after_index = None, None

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -1506,7 +1506,7 @@ class ParameterList(list):
         if isinstance(item, ParameterType):
             return super().index(item)
         else:
-            for parameter in self:
+            for parameter in self[::-1]:
                 if parameter.smirks == item:
                     return self.index(parameter)
             raise ParameterLookupError(f"SMIRKS {item} not found in ParameterList")
@@ -2052,9 +2052,9 @@ class ParameterHandler(_ParameterAttributeHandler):
         else:
             raise ValueError("One of (parameter, parameter_kwargs) must be specified")
 
-        if self._index_of_parameter(new_parameter) is not None:
-            msg = f"A parameter SMIRKS pattern {new_parameter.smirks} already exists."
-            raise DuplicateParameterError(msg)
+        # if self._index_of_parameter(new_parameter) is not None:
+        #     msg = f"A parameter SMIRKS pattern {new_parameter.smirks} already exists."
+        #     raise DuplicateParameterError(msg)
 
         before_index, after_index = None, None
 


### PR DESCRIPTION
- [x] Resolves #1363 
    - If multiple parameters have identical SMIRKS, this will make `__getitem__` calls return the LAST instance in the ParameterList/ParameterHandler (rather than the first)
    - Adds named argument `ParameterHander.add_parameter(..., allow_duplicates=True)`
    - Since the default behavior remains the same, this won't affect amber-ff-porting https://github.com/openforcefield/amber-ff-porting/blob/c6d3412f5c94cd1c3ed1b8b6ba56909fe4706080/ConvertResidueParameters.py#L747
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)

