### PR TITLE
Resolve #1096 with an optional argument for <_generate_unique_atom_names()>

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1089,7 +1089,7 @@ class FrozenMolecule(Serializable):
         """``True`` if the molecule has unique atom names, ``False`` otherwise."""
         return _has_unique_atom_names(self)
 
-    def generate_unique_atom_names(self, suffix:str = None):
+    def generate_unique_atom_names(self, suffix: str = None):
         """
         Generate unique atom names from the element symbol and count.
 
@@ -6128,7 +6128,7 @@ class HierarchyElement:
         """``True`` if the element has unique atom names, ``False`` otherwise."""
         return _has_unique_atom_names(self)
 
-    def generate_unique_atom_names(self, suffix:str = None):
+    def generate_unique_atom_names(self, suffix: str = None):
         """
         Generate unique atom names from the element symbol and count.
 
@@ -6154,7 +6154,9 @@ def _has_unique_atom_names(
     return True
 
 
-def _generate_unique_atom_names(obj: Union[FrozenMolecule, HierarchyElement], suffix:str = "x"):
+def _generate_unique_atom_names(
+    obj: Union[FrozenMolecule, HierarchyElement], suffix: str = "x"
+):
     """
     Generate unique atom names from the element symbol and count.
 
@@ -6165,7 +6167,7 @@ def _generate_unique_atom_names(obj: Union[FrozenMolecule, HierarchyElement], su
     atom names might begin 'C1x', 'H1x', 'O1x', 'C2x', etc.
     """
     from collections import defaultdict
- 
+
     element_counts: DefaultDict[str, int] = defaultdict(int)
     for atom in obj.atoms:
         symbol = atom.symbol

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1089,17 +1089,20 @@ class FrozenMolecule(Serializable):
         """``True`` if the molecule has unique atom names, ``False`` otherwise."""
         return _has_unique_atom_names(self)
 
-    def generate_unique_atom_names(self):
+    def generate_unique_atom_names(self, suffix:str = None):
         """
         Generate unique atom names from the element symbol and count.
 
         Names are generated from the elemental symbol and the number of times
-        that element is found in the molecule. The character 'x' is appended to
-        these generated names to reduce the odds that they clash with an atom
-        name or type imported from another source. For example, generated atom
-        names might begin 'C1x', 'H1x', 'O1x', 'C2x', etc.
+        that element is found in the hierarchy element. The character 'x' is
+        appended to these generated names to reduce the odds that they clash
+        with an atom name or type imported from another source. For example,
+        generated atom names might begin 'C1x', 'H1x', 'O1x', 'C2x', etc.
         """
-        return _generate_unique_atom_names(self)
+        if suffix == None:
+            return _generate_unique_atom_names(self)
+        else:
+            return _generate_unique_atom_names(self, suffix)
 
     def _validate(self):
         """
@@ -6125,7 +6128,7 @@ class HierarchyElement:
         """``True`` if the element has unique atom names, ``False`` otherwise."""
         return _has_unique_atom_names(self)
 
-    def generate_unique_atom_names(self):
+    def generate_unique_atom_names(self, suffix:str = None):
         """
         Generate unique atom names from the element symbol and count.
 
@@ -6135,7 +6138,10 @@ class HierarchyElement:
         with an atom name or type imported from another source. For example,
         generated atom names might begin 'C1x', 'H1x', 'O1x', 'C2x', etc.
         """
-        return _generate_unique_atom_names(self)
+        if suffix == None:
+            return _generate_unique_atom_names(self)
+        else:
+            return _generate_unique_atom_names(self, suffix)
 
 
 def _has_unique_atom_names(
@@ -6148,7 +6154,7 @@ def _has_unique_atom_names(
     return True
 
 
-def _generate_unique_atom_names(obj: Union[FrozenMolecule, HierarchyElement]):
+def _generate_unique_atom_names(obj: Union[FrozenMolecule, HierarchyElement], suffix:str = "x"):
     """
     Generate unique atom names from the element symbol and count.
 
@@ -6159,14 +6165,9 @@ def _generate_unique_atom_names(obj: Union[FrozenMolecule, HierarchyElement]):
     atom names might begin 'C1x', 'H1x', 'O1x', 'C2x', etc.
     """
     from collections import defaultdict
-
+ 
     element_counts: DefaultDict[str, int] = defaultdict(int)
     for atom in obj.atoms:
         symbol = atom.symbol
         element_counts[symbol] += 1
-        # TODO: It may be worth exposing this as a user option, i.e. to avoid multiple ligands
-        # parameterized with OpenFF clashing because they have atom names like O1x, H3x, etc.
-        # i.e. an optional argument could enable a user to `generate_unique_atom_names(blah="y")
-        # to have one ligand be O1y, etc.
-        # https://github.com/openforcefield/openff-toolkit/pull/1096#pullrequestreview-767227391
-        atom.name = symbol + str(element_counts[symbol]) + "x"
+        atom.name = symbol + str(element_counts[symbol]) + suffix

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1099,10 +1099,7 @@ class FrozenMolecule(Serializable):
         with an atom name or type imported from another source. For example,
         generated atom names might begin 'C1x', 'H1x', 'O1x', 'C2x', etc.
         """
-        if suffix == None:
-            return _generate_unique_atom_names(self)
-        else:
-            return _generate_unique_atom_names(self, suffix)
+        return _generate_unique_atom_names(self, suffix)
 
     def _validate(self):
         """
@@ -6128,7 +6125,7 @@ class HierarchyElement:
         """``True`` if the element has unique atom names, ``False`` otherwise."""
         return _has_unique_atom_names(self)
 
-    def generate_unique_atom_names(self, suffix: str = None):
+    def generate_unique_atom_names(self, suffix: str = "x"):
         """
         Generate unique atom names from the element symbol and count.
 
@@ -6138,10 +6135,7 @@ class HierarchyElement:
         with an atom name or type imported from another source. For example,
         generated atom names might begin 'C1x', 'H1x', 'O1x', 'C2x', etc.
         """
-        if suffix == None:
-            return _generate_unique_atom_names(self)
-        else:
-            return _generate_unique_atom_names(self, suffix)
+        return _generate_unique_atom_names(self, suffix)
 
 
 def _has_unique_atom_names(


### PR DESCRIPTION
- [ ] Resolves: [Make atom names more unique #1096](https://github.com/openforcefield/openff-toolkit/pull/1096), with an optional suffix parameter. Avoids possible conflict with analyses that create atom dictionaries without referencing the resname. Also improves readability of simulation files.
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
