### PR TITLE
Update NAGL pins in test environments

### DIFF
--- a/devtools/conda-envs/beta_rc_env.yaml
+++ b/devtools/conda-envs/beta_rc_env.yaml
@@ -21,7 +21,7 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.23
-  - openff-nagl-base ==0.3.0
+  - openff-nagl-base >=0.3.7,<0.4
   - openff-nagl-models ==0.1.0
     # Toolkit-specific
   - ambertools >=22

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.17
-  - openff-nagl-base ==0.3.0
+  - openff-nagl-base >=0.3.7,<0.4
   - openff-nagl-models ==0.1.0
   - typing_extensions
   - nglview

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.17
-  - openff-nagl-base ==0.3.0
+  - openff-nagl-base >=0.3.7,<0.4
   - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -19,7 +19,7 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.17
-  - openff-nagl-base ==0.3.0
+  - openff-nagl-base >=0.3.7,<0.4
   - openff-nagl-models ==0.1.0
   - typing_extensions
   - nglview

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -19,7 +19,7 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.17
-  - openff-nagl-base ==0.3.0
+  - openff-nagl-base >=0.3.7,<0.4
   - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -20,7 +20,7 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.17
-  - openff-nagl-base ==0.3.0
+  - openff-nagl-base >=0.3.7,<0.4
   - openff-nagl-models ==0.1.0
     # Toolkit-specific
   - ambertools >=22


### PR DESCRIPTION
Would it be possible to update the NAGL pins to stay current with new 0.3.x releases?
I dropped Python 3.9 in 0.3.8, whereas the toolkit still tests on it, so I've set the lower bound to 0.3.7 here.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
