### PR TITLE
Lazy load `networkx` in topology modules

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -25,6 +25,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### New features
 
 - [PR #1866](https://github.com/openforcefield/openff-toolkit/pull/1866): Implements a safer AmberTools version check.
+- [PR #1874](https://github.com/openforcefield/openff-toolkit/pull/1874): Improves some loading times by lazy-loading `networkx`.
 
 ### Improved documentation and warnings
 

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -48,7 +48,6 @@ from typing import (
     overload,
 )
 
-import networkx as nx
 import numpy as np
 from openff.units.elements import MASSES, SYMBOLS
 from openff.utilities.exceptions import MissingOptionalDependencyError
@@ -92,6 +91,7 @@ from openff.toolkit.utils.utils import get_data_file_path, requires_package
 
 if TYPE_CHECKING:
     import IPython.display
+    import networkx as nx
     import nglview
     from rdkit.Chem import Mol as RDMol
 
@@ -1939,8 +1939,8 @@ class FrozenMolecule(Serializable):
 
     @staticmethod
     def are_isomorphic(
-        mol1: Union["FrozenMolecule", "_SimpleMolecule", nx.Graph],
-        mol2: Union["FrozenMolecule", "_SimpleMolecule", nx.Graph],
+        mol1: Union["FrozenMolecule", "_SimpleMolecule", "nx.Graph"],
+        mol2: Union["FrozenMolecule", "_SimpleMolecule", "nx.Graph"],
         return_atom_map: bool = False,
         aromatic_matching: bool = True,
         formal_charge_matching: bool = True,
@@ -2167,7 +2167,7 @@ class FrozenMolecule(Serializable):
 
     def is_isomorphic_with(
         self,
-        other: Union["FrozenMolecule", "_SimpleMolecule", nx.Graph],
+        other: Union["FrozenMolecule", "_SimpleMolecule", "nx.Graph"],
         **kwargs,
     ) -> bool:
         """
@@ -2785,7 +2785,7 @@ class FrozenMolecule(Serializable):
             if "_molecule_atom_index" in atom.__dict__:
                 del atom.__dict__["_molecule_atom_index"]
 
-    def to_networkx(self) -> nx.Graph:
+    def to_networkx(self) -> "nx.Graph":
         """Generate a NetworkX undirected graph from the molecule.
 
         Nodes are Atoms labeled with atom indices and atomic elements (via the ``element`` node atrribute).
@@ -3541,7 +3541,7 @@ class FrozenMolecule(Serializable):
         return self._hill_formula
 
     @staticmethod
-    def _object_to_hill_formula(obj: Union["FrozenMolecule", nx.Graph]) -> str:
+    def _object_to_hill_formula(obj: Union["FrozenMolecule", "nx.Graph"]) -> str:
         """Take a Molecule or NetworkX graph and generate its Hill formula.
         This provides a backdoor to the old functionality of Molecule.to_hill_formula, which
         was a static method that duck-typed inputs of Molecule or graph objects."""
@@ -5730,7 +5730,7 @@ class Molecule(FrozenMolecule):
             pass
 
 
-def _networkx_graph_to_hill_formula(graph: nx.Graph) -> str:
+def _networkx_graph_to_hill_formula(graph: "nx.Graph") -> str:
     """
     Convert a NetworkX graph to a Hill formula.
 
@@ -5810,6 +5810,8 @@ def _nth_degree_neighbors_from_graphlike(
     neighbors
         tuples (len 2) of atom that are separated by ``n`` bonds.
     """
+    import networkx as nx
+
     graph = graphlike.to_networkx()
 
     for node_i in graph.nodes:

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -30,7 +30,6 @@ from typing import (
 )
 
 import numpy as np
-from networkx import Graph
 from numpy.typing import NDArray
 from openff.units import ensure_quantity
 from typing_extensions import TypeAlias
@@ -71,6 +70,7 @@ from openff.toolkit.utils.utils import get_data_file_path, requires_package
 if TYPE_CHECKING:
     import mdtraj
     import openmm.app
+    from networkx import Graph
     from nglview import NGLWidget
     from openmm.unit import Quantity as OMMQuantity
 
@@ -1419,7 +1419,7 @@ class Topology(Serializable):
 
         # Convert all unique mols to graphs
         topology = cls()
-        graph_to_unq_mol: dict[Graph, FrozenMolecule] = {}
+        graph_to_unq_mol: dict["Graph", FrozenMolecule] = {}
         for unq_mol in unique_molecules:
             unq_mol_graph = unq_mol.to_networkx()
             for existing_graph in graph_to_unq_mol.keys():


### PR DESCRIPTION
I was profiling some other code and found that a ~100 ms import of `networkx` happens in the toolkit whether or not it's actually used. I remember lazy-loading this in the past, but that's reflected in the current code.

This way of profiling here shows roughly a 50-100 ms speedup depending on how one squints their eyes

```shell
$ git checkout upstream/main
$ hyperfine 'python -c "from openff.toolkit import Molecule"' --prepare 'python -c "from openff.toolkit import Molecule"'
Benchmark 1: python -c "from openff.toolkit import Molecule"
  Time (mean ± σ):      1.119 s ±  0.047 s    [User: 0.909 s, System: 0.142 s]
  Range (min … max):    1.085 s …  1.241 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

$ git checkout lazy-load-networkx
Previous HEAD position was ef2f514f Drop py311 from conda tests (#1873)
Switched to branch 'lazy-load-networkx'
$ hyperfine 'python -c "from openff.toolkit import Molecule"' --prepare 'python -c "from openff.toolkit import Molecule"'
Benchmark 1: python -c "from openff.toolkit import Molecule"
  Time (mean ± σ):      1.050 s ±  0.048 s    [User: 0.864 s, System: 0.121 s]
  Range (min … max):    1.007 s …  1.143 s    10 runs
```

With this patch, here's a rough picture of what takes so long to run this import. There are some other obvious candidates for lazy-loading, but I'm not going for them now:

![image](https://github.com/openforcefield/openff-toolkit/assets/7935382/f0c626b3-1479-4e1b-bc0f-2a1e443147a1)

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)