### PR TITLE
Bump Python version used in beta workflow

### DIFF
--- a/.github/workflows/beta_rc.yaml
+++ b/.github/workflows/beta_rc.yaml
@@ -20,7 +20,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python-version:
-          - "3.10"
+          - "3.11"
 
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt


### PR DESCRIPTION
There is some difference(s) between 3.10 and 3.11 that was causing a type checker to fail in the beta workflow but not normal CI. This syncs them up.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
