### PR TITLE
docs: updated docs for SMIRNOFF spec around AMBER/GROMACS

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -28,6 +28,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Improved documentation and warnings
 
+- [PR #1878](https://github.com/openforcefield/openff-toolkit/pull/1878): docs: updated docs for SMIRNOFF spec around AMBER/GROMACS
 - [PR #1870](https://github.com/openforcefield/openff-toolkit/pull/1870): Updates examples to use openff-2.2.0, 
   and modernizes use of some API points. 
 - [PR #1787](https://github.com/openforcefield/openff-toolkit/pull/1787): Improve documentation for toolkit wrappers and registries

--- a/examples/using_smirnoff_in_amber_or_gromacs/README.md
+++ b/examples/using_smirnoff_in_amber_or_gromacs/README.md
@@ -4,5 +4,5 @@ This example shows how you can convert an OpenMM `System` generated with the Ope
 
 #### Manifest:
 
-- `convert_to_amber_gromacs.ipynb`: IPython notebook showing how to generate AMBER and GROMACS topology and coordinates files starting from a PDB.
+- `export_with_interchange.ipynyb`: IPython notebook showing how to generate AMBER and GROMACS topology and coordinates files starting from a PDB using Interchange.
 - `1_cyclohexane_1_ethanol.pdb`: PDB file containing one molecule of cyclohexane and one of ethanol in vacuum.


### PR DESCRIPTION
Updated to reference the new notebook instead of the older one. Related to https://github.com/openforcefield/standards/issues/66.

- [x] Tag issue being addressed https://github.com/openforcefield/standards/issues/66
- [ ] ~~Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)~~
- [ ] ~~Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable~~
- [ ] ~~[Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase~~
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)

What would I need to do to update the changelog?