### PR TITLE
fix: fix releasehistory link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@
 - [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
 - [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
 - [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
-- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
+- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)


### PR DESCRIPTION
This PR fixes an issue in the PR template relating to an incorrect link to the release history.

- [x] Tag issue being addressed #1879 
- [ ] ~~Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)~~
- [ ] ~~Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable~~
- [ ] ~~[Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase~~
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.rst)
