### PR TITLE
_generate_unique_atom_names() tests

### DIFF
--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -930,10 +930,10 @@ class TestMolecule:
         atom_name = molecule.generate_unique_atom_names()
         assert atom_name.endswith("x")
         # Check that a non-default string works correctly
-        atom_name = molecule.generate_unique_atom_names(suffix = "y")
+        atom_name = molecule.generate_unique_atom_names(suffix="y")
         assert atom_name.endswith("y")
         # Check that an empty string works correctly
-        atom_name = molecule.generate_unique_atom_names(suffix = "")
+        atom_name = molecule.generate_unique_atom_names(suffix="")
         assert atom_name.endswith("")
 
     inchi_data = [

--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -925,6 +925,16 @@ class TestMolecule:
             len(set([atom.name for atom in molecule.atoms])) == molecule.n_atoms
         ) == molecule.has_unique_atom_names
         assert all("x" in a.name for a in molecule.atoms)
+        # generate_unique_atom_names tests
+        # Check that the default works correctly
+        atom_name = molecule.generate_unique_atom_names()
+        assert atom_name.endswith("x")
+        # Check that a non-default string works correctly
+        atom_name = molecule.generate_unique_atom_names(suffix = "y")
+        assert atom_name.endswith("y")
+        # Check that an empty string works correctly
+        atom_name = molecule.generate_unique_atom_names(suffix = "")
+        assert atom_name.endswith("")
 
     inchi_data = [
         {


### PR DESCRIPTION
Tests have been made simple as [j-wags](https://github.com/j-wags) suggested. Tests were added to the existing function since it makes sense for them to be in the same place. Let me know if they need to be separate. Note: a usage warning should be included in the _documentation_ to limit the suffix to 1-2 characters as overlap occurs in certain file types. I did not add this as a test since I can't ensure style consistency across all file types and maybe someone will need it. 

- [ ] [Tag issue being addressed](https://github.com/openforcefield/openff-toolkit/pull/1881)
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
