### PR TITLE
Avoid installing broken OpenEye Toolkits package

### DIFF
--- a/devtools/conda-envs/conda_oe.yaml
+++ b/devtools/conda-envs/conda_oe.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - openff-toolkit-examples
     # Tests
-  - openeye-toolkits
+  - openeye-toolkits =2024.1.0
   - pytest=7.4
   - pytest-rerunfailures
   - nbval

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -25,7 +25,7 @@ dependencies:
   - typing_extensions
   - nglview
     # Toolkit-specific
-  - openeye-toolkits
+  - openeye-toolkits =2024.1.0
     # Test-only/optional/dev/typing/examples
   - pytest
   - pytest-xdist

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -24,7 +24,7 @@ dependencies:
   - openff-nagl-models ==0.1.0
   - typing_extensions
     # Toolkit-specific
-  - openeye-toolkits
+  - openeye-toolkits =2024.1.0
     # Test-only/optional/dev/typing
   - pytest
   - pytest-cov

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -26,7 +26,7 @@ dependencies:
   - ambertools >=22
     # https://github.com/rdkit/rdkit/issues/7221
   - rdkit <2023.09.6
-  - openeye-toolkits
+  - openeye-toolkits =2024.1.0
     # Test-only/optional/dev/typing
   - pytest
   - pytest-cov


### PR DESCRIPTION
2024.1.1 is broken on Anaconda Cloud