### PR TITLE
[DNM] Test CI on osx-ar64

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-12, macos-14]
         python-version: ["3.10", "3.11", "3.12"]
         rdkit: [true, false]
         openeye: [true, false]


### PR DESCRIPTION
RE: #1911 I wanted to see what sort of stuff crops up in CI, I think enough of the ecosystem on conda-forge has osx-arm64 builds, but it also might not work at all.