### PR TITLE
Update NAGL pins and default model in tests

### DIFF
--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -20,8 +20,8 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.19
-  - openff-nagl-base ~=0.3.7
-  - openff-nagl-models ==0.1.0
+  - openff-nagl-base ~=0.4.0
+  - openff-nagl-models ==0.3.0
   - typing_extensions
   - nglview
     # Toolkit-specific

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -20,8 +20,8 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.19
-  - openff-nagl-base ~=0.3.7
-  - openff-nagl-models ==0.1.0
+  - openff-nagl-base ~=0.4.0
+  - openff-nagl-models ==0.3.0
   - typing_extensions
     # Toolkit-specific
   - openeye-toolkits

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -19,8 +19,8 @@ dependencies:
   - openff-units =0.2.0
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.19
-  - openff-nagl-base ~=0.3.7
-  - openff-nagl-models ==0.1.0
+  - openff-nagl-base ~=0.4.0
+  - openff-nagl-models ==0.3.0
   - typing_extensions
   - nglview
     # Toolkit-specific

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -19,8 +19,8 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.19
-  - openff-nagl-base ~=0.3.7
-  - openff-nagl-models ==0.1.0
+  - openff-nagl-base ~=0.4.0
+  - openff-nagl-models ==0.3.0
   - typing_extensions
     # Toolkit-specific
   - ambertools >=22

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -20,8 +20,8 @@ dependencies:
   - openff-amber-ff-ports
   - openff-utilities >=0.1.5
   - openff-interchange-base >=0.3.19
-  - openff-nagl-base ~=0.3.7
-  - openff-nagl-models ==0.1.0
+  - openff-nagl-base ~=0.4.0
+  - openff-nagl-models ==0.3.0
     # Toolkit-specific
   - ambertools >=22
     # https://github.com/rdkit/rdkit/issues/7221

--- a/openff/toolkit/_tests/test_nagl.py
+++ b/openff/toolkit/_tests/test_nagl.py
@@ -21,7 +21,7 @@ from openff.toolkit.utils.exceptions import (
 from openff.toolkit.utils.nagl_wrapper import NAGLToolkitWrapper
 from openff.toolkit.utils.openeye_wrapper import OpenEyeToolkitWrapper
 
-_DEFAULT_MODEL = "openff-gnn-am1bcc-0.1.0-rc.1.pt"
+_DEFAULT_MODEL = "openff-gnn-am1bcc-0.1.0-rc.3.pt"
 
 try:
     from openff.nagl_models import list_available_nagl_models


### PR DESCRIPTION
This just updates NAGL pins to allow use of the rc3 model. It also updates tests to the rc3 model, which seem to pass without any modification required.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
