### PR TITLE
Update some inherited method signatures flagged by mypy 1.11

### DIFF
--- a/openff/toolkit/_tests/test_parameters.py
+++ b/openff/toolkit/_tests/test_parameters.py
@@ -856,6 +856,11 @@ class TestParameterList:
         with pytest.raises(ValueError, match="is not in list"):
             parameters.index(p4)
 
+        with pytest.raises(TypeError, match="non-None values for start"):
+            parameters.index("[*:1]", start=1)
+        with pytest.raises(TypeError, match="non-None values for stop"):
+            parameters.index("[*:1]", stop=-1)
+
     def test_index_duplicates(self):
         """Test ParameterList.index when multiple parameters have identical SMIRKS"""
         p1 = ParameterType(smirks="[*:1]")

--- a/openff/toolkit/_tests/test_utils_collections.py
+++ b/openff/toolkit/_tests/test_utils_collections.py
@@ -182,6 +182,10 @@ class TestValidatedDict(TestValidatedMixin):
             d.update((("moe", 2), ("larry", 3), ("curly", -4)))
         with pytest.raises(TypeError, match="value is not positive"):
             d.update({"moe": 2, "larry": 3, "curly": -4})
+        with pytest.raises(TypeError, match="exactly one positional"):
+            d.update({"moe": 2}, {"larry": 3}, {"curly": -4})
+        with pytest.raises(TypeError, match="not accept named"):
+            d.update({"moe": 2}, moe=2, larry=3, curly=-4)
 
     def test_converters(self):
         """Custom converters of ValidatedDict are called correctly."""

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -1488,7 +1488,7 @@ class ParameterList(list):
         # TODO: Check if other ParameterList contains the same ParameterTypes?
         super().extend(other)
 
-    def index(self, item):
+    def index(self, item, start=None, stop=None):
         """
         Get the numerical index of a ParameterType object or SMIRKS in this ParameterList.
         Raises ParameterLookupError if the item is not found.
@@ -1497,6 +1497,10 @@ class ParameterList(list):
         ----------
         item
             The parameter or SMIRKS to look up in this ParameterList
+        start
+            Unsupported, added to align method signature with list.index
+        stop
+            Unsupported, added to align method signature with list.index
 
         Returns
         -------
@@ -1508,6 +1512,10 @@ class ParameterList(list):
         ParameterLookupError if SMIRKS pattern is passed in but not found
 
         """
+        if start is not None:
+            raise TypeError("ParameterList.index does not support non-None values for start.")
+        if stop is not None:
+            raise TypeError("ParameterList.index does not support non-None values for stop.")
         if isinstance(item, ParameterType):
             return super().index(item)
         else:

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -1513,9 +1513,13 @@ class ParameterList(list):
 
         """
         if start is not None:
-            raise TypeError("ParameterList.index does not support non-None values for start.")
+            raise TypeError(
+                "ParameterList.index does not support non-None values for start."
+            )
         if stop is not None:
-            raise TypeError("ParameterList.index does not support non-None values for stop.")
+            raise TypeError(
+                "ParameterList.index does not support non-None values for stop."
+            )
         if isinstance(item, ParameterType):
             return super().index(item)
         else:

--- a/openff/toolkit/utils/collections.py
+++ b/openff/toolkit/utils/collections.py
@@ -205,9 +205,13 @@ class ValidatedDict(dict):
 
     def update(self, *args, **kwargs):
         if len(args) != 1:
-            raise TypeError(f"ValidatedDict.update expected exactly one positional argument, got {len(args)} instead.")
+            raise TypeError(
+                f"ValidatedDict.update expected exactly one positional argument, got {len(args)} instead."
+            )
         if len(kwargs) != 0:
-            raise TypeError(f"ValidatedDict.update does not accept named arguments, got {kwargs} instead.")
+            raise TypeError(
+                f"ValidatedDict.update does not accept named arguments, got {kwargs} instead."
+            )
         other = self._convert_and_validate(dict(args[0]))
         super().update(other)
 

--- a/openff/toolkit/utils/collections.py
+++ b/openff/toolkit/utils/collections.py
@@ -203,8 +203,12 @@ class ValidatedDict(dict):
         mapping = self._convert_and_validate(mapping)
         super().__init__(mapping)
 
-    def update(self, other):
-        other = self._convert_and_validate(dict(other))
+    def update(self, *args, **kwargs):
+        if len(args) != 1:
+            raise TypeError(f"ValidatedDict.update expected exactly one positional argument, got {len(args)} instead.")
+        if len(kwargs) != 0:
+            raise TypeError(f"ValidatedDict.update does not accept named arguments, got {kwargs} instead.")
+        other = self._convert_and_validate(dict(args[0]))
         super().update(other)
 
     def copy(self):


### PR DESCRIPTION
- [x] Update some method signatures that don't agree with inherited base class
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
