### PR TITLE
Add `Topology.add_molecules`

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -32,6 +32,7 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - pytest-rerunfailures
+  - pytest-timeout
   - pyyaml
   - toml
   - bson

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -16,6 +16,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### New features
 
+- [PR #1920](https://github.com/openforcefield/openff-toolkit/pull/1920): Allows `Topology.add_molecule` to take a list of molecule, which is faster when adding many molecules.
+
 ### Improved documentation and warnings
 
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -16,7 +16,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### New features
 
-- [PR #1920](https://github.com/openforcefield/openff-toolkit/pull/1920): Allows `Topology.add_molecule` to take a list of molecule, which is faster when adding many molecules.
+- [PR #1920](https://github.com/openforcefield/openff-toolkit/pull/1920): Adds `Topology.add_molecules`, which takes a list of `Molecule`s is faster when adding many molecules.
 
 ### Improved documentation and warnings
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -16,7 +16,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### New features
 
-- [PR #1920](https://github.com/openforcefield/openff-toolkit/pull/1920): Adds `Topology.add_molecules`, which takes a list of `Molecule`s is faster when adding many molecules.
+- [PR #1920](https://github.com/openforcefield/openff-toolkit/pull/1920): Adds `Topology.add_molecules`, which takes a list of `Molecule`s and is faster when adding many molecules.
 
 ### Improved documentation and warnings
 

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -144,21 +144,6 @@ class TestTopology:
         assert not topology.is_periodic
         assert len(topology.constrained_atom_pairs.items()) == 0
 
-    @pytest.mark.timeout(8)
-    def test_from_molecule_multiple(self):
-        """
-        Test that add_molecule on a list of many molecules is quick.
-
-        See issue #1916
-        """
-        water = create_water()
-
-        topology = Topology()
-
-        topology.add_molecule(10_000 * [water])
-
-        assert topology.n_molecules == 10_000
-
     def test_from_molecule_bad_argument(self):
         with pytest.raises(
             ValueError,
@@ -168,6 +153,28 @@ class TestTopology:
             topology = Topology()
 
             topology.add_molecule(create_water().to_topology())
+
+    @pytest.mark.timeout(8)
+    def test_from_molecules(self):
+        water = create_water()
+
+        topology = Topology()
+
+        indices = topology.add_molecules(10_000 * [water])
+
+        assert topology.n_molecules == 10_000
+
+        assert indices == [*range(10_000)]
+
+    def test_from_molecule_nonlist(self):
+        topology = Topology()
+
+        with pytest.raises(
+            ValueError,
+            match="Invalid type.*set.*molecules",
+        ):
+
+            topology.add_molecules({create_water(), create_ammonia()})
 
     def test_reinitialization_box_vectors(self):
         topology = Topology()

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -144,7 +144,7 @@ class TestTopology:
         assert not topology.is_periodic
         assert len(topology.constrained_atom_pairs.items()) == 0
 
-    @pytest.mark.timeout(5)
+    @pytest.mark.timeout(8)
     def test_from_molecule_multiple(self):
         """
         Test that add_molecule on a list of many molecules is quick.

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -164,7 +164,7 @@ class TestTopology:
 
         assert topology.n_molecules == 10_000
 
-        assert indices == [*range(10_000)]
+        assert indices == [*range(1, 10_001)]
 
     def test_from_molecule_nonlist(self):
         topology = Topology()

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -154,8 +154,8 @@ class TestTopology:
 
             topology.add_molecule(create_water().to_topology())
 
-    @pytest.mark.timeout(8)
-    def test_from_molecules(self):
+    @pytest.mark.timeout(10)
+    def test_add_molecules(self):
         water = create_water()
 
         topology = Topology()
@@ -175,6 +175,13 @@ class TestTopology:
         ):
 
             topology.add_molecules({create_water(), create_ammonia()})
+
+        with pytest.raises(
+            ValueError,
+            match="Invalid type.*str.*molecules",
+        ):
+
+            topology.add_molecules("CC.CCO")
 
     def test_reinitialization_box_vectors(self):
         topology = Topology()

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -144,6 +144,31 @@ class TestTopology:
         assert not topology.is_periodic
         assert len(topology.constrained_atom_pairs.items()) == 0
 
+    @pytest.mark.timeout(5)
+    def test_from_molecule_multiple(self):
+        """
+        Test that add_molecule on a list of many molecules is quick.
+
+        See issue #1916
+        """
+        water = create_water()
+
+        topology = Topology()
+
+        topology.add_molecule(10_000 * [water])
+
+        assert topology.n_molecules == 10_000
+
+    def test_from_molecule_bad_argument(self):
+        with pytest.raises(
+            ValueError,
+            match="Invalid type.*Topology",
+        ):
+
+            topology = Topology()
+
+            topology.add_molecule(create_water().to_topology())
+
     def test_reinitialization_box_vectors(self):
         topology = Topology()
         assert Topology(topology).box_vectors is None

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -2401,11 +2401,9 @@ class Topology(Serializable):
         """
         if isinstance(molecule, (Molecule, _SimpleMolecule)):
 
-            idx = self._add_molecule_keep_cache(molecule)
-
-            self._invalidate_cached_properties()
-
-            return idx
+            # Route everything through add_molecules for simplicity; the overhead of
+            # making a list and grabbing the first element should be negligible
+            return self.add_molecules([molecule])[0]
 
         else:
 

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -27,7 +27,6 @@ from typing import (
     Optional,
     TextIO,
     Union,
-    overload,
 )
 
 import numpy as np
@@ -2391,29 +2390,16 @@ class Topology(Serializable):
                 return molecule.bond(bond_molecule_index)
             this_molecule_start_index += molecule.n_bonds
 
-    @overload
-    def add_molecule(self, molecule: MoleculeLike) -> int: ...
-
-    @overload
-    def add_molecule(self, molecule: list[MoleculeLike]) -> list[int]: ...
-
     def add_molecule(
         self,
-        molecule: MoleculeLike | list[MoleculeLike],
-    ) -> int | list[int]:
-        """Add a molecule or multiple molecules to the topology."""
-        if isinstance(molecule, list):
+        molecule: MoleculeLike,
+    ) -> int:
+        """
+        Add a molecule to the topology.
 
-            indices = [
-                self._add_molecule_keep_cache(iter_molecule)
-                for iter_molecule in molecule
-            ]
-
-            self._invalidate_cached_properties()
-
-            return indices
-
-        elif isinstance(molecule, (Molecule, _SimpleMolecule)):
+        To add multiple molecules, particularly many times, use `add_molecules` for better performance.
+        """
+        if isinstance(molecule, (Molecule, _SimpleMolecule)):
 
             idx = self._add_molecule_keep_cache(molecule)
 
@@ -2424,6 +2410,32 @@ class Topology(Serializable):
         else:
 
             raise ValueError(f"Invalid type {type(molecule)} for Topology.add_molecule")
+
+    def add_molecules(
+        self,
+        molecules: list[MoleculeLike],
+    ) -> list[int]:
+        """
+        Add molecules to the topology.
+
+        To add a single molecule to the topology, use `add_molecule`.
+        """
+
+        if isinstance(molecules, list):
+
+            indices = [
+                self._add_molecule_keep_cache(molecule) for molecule in molecules
+            ]
+
+            self._invalidate_cached_properties()
+
+            return indices
+
+        else:
+
+            raise ValueError(
+                f"Invalid type {type(molecules)} for Topology.add_molecules"
+            )
 
     def _add_molecule_keep_cache(self, molecule: MoleculeLike) -> int:
         self._molecules.append(deepcopy(molecule))

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -276,19 +276,19 @@ def convert_all_strings_to_quantity(
 
 
 @overload
-def convert_all_quantities_to_string(  # noqa: E704
+def convert_all_quantities_to_string(
     smirnoff_data: list[Quantity],
 ) -> list[str]: ...
 
 
 @overload
-def convert_all_quantities_to_string(  # noqa: E704
+def convert_all_quantities_to_string(
     smirnoff_data: dict,
 ) -> Union[list[str], dict[str, Any]]: ...
 
 
 @overload
-def convert_all_quantities_to_string(  # noqa: E704
+def convert_all_quantities_to_string(
     smirnoff_data: "Quantity",
 ) -> Union[str, list[str], dict[str, Any]]: ...
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ exclude_lines =
 
 [flake8]
 max-line-length = 119
-ignore = E203,W605,W503
+ignore = E203,W605,W503,E704
 exclude =
     openff/toolkit/_tests/_stale_tests.py
 per-file-ignores =


### PR DESCRIPTION
Resolves #1916; modifying the reproduction to leverage this change (`topology.add_molecule(n_solvent * [water])`) indicates timing differences are within noise

(Timings are at 2ed0083cf801bb9948bca4f541a80572a0d51730, see edit history for others)
```
#n,add_molecules,from_molecules
100,0.004326343536376953,0.004456996917724609
200,0.008298158645629883,0.008605003356933594
300,0.01304483413696289,0.012480974197387695
400,0.016698837280273438,0.039669036865234375
500,0.02105402946472168,0.020509958267211914
600,0.023821115493774414,0.02369093894958496
700,0.054055213928222656,0.028130054473876953
800,0.03286099433898926,0.05617833137512207
900,0.03642416000366211,0.036705732345581055
1000,0.06891608238220215,0.04215121269226074
1100,0.07125687599182129,0.04464316368103027
1200,0.04902386665344238,0.07808613777160645
1300,0.052931785583496094,0.08499383926391602
1400,0.08034300804138184,0.05517315864562988
1500,0.08928894996643066,0.059242963790893555
1600,0.0911250114440918,0.09041094779968262
1700,0.06853795051574707,0.09943413734436035
1800,0.0976266860961914,0.07319378852844238
1900,0.11597585678100586,0.10258984565734863
2000,0.10834097862243652,0.0783381462097168
2100,0.11317706108093262,0.10875320434570312
2200,0.11331892013549805,0.11619782447814941
2300,0.1267378330230713,0.12550926208496094
2400,0.15245485305786133,0.12961506843566895
2500,0.1312239170074463,0.12987184524536133
2600,0.13352394104003906,0.1362438201904297
2700,0.13997626304626465,0.1558849811553955
2800,0.1441199779510498,0.14195513725280762
2900,0.14261388778686523,0.1425330638885498
3000,0.1729898452758789,0.1553659439086914
3100,0.16576695442199707,0.15640711784362793
3200,0.17840981483459473,0.16184210777282715
3300,0.18575620651245117,0.16659212112426758
3400,0.1914048194885254,0.16928482055664062
3500,0.1950390338897705,0.17164182662963867
3600,0.17933392524719238,0.2037489414215088
3700,0.1815779209136963,0.20410919189453125
3800,0.19510793685913086,0.21448493003845215
3900,0.20508909225463867,0.2175590991973877
4000,0.20284199714660645,0.30047607421875
4100,0.24508309364318848,0.21770095825195312
4200,0.22712087631225586,0.23752117156982422
4300,0.27291321754455566,0.23709893226623535
4400,0.24172306060791016,0.24338698387145996
4500,0.22370076179504395,0.3592557907104492
4600,0.25223612785339355,0.29245591163635254
4700,0.3019530773162842,0.2697610855102539
4800,0.30089807510375977,0.2619192600250244
4900,0.28049492835998535,0.2615830898284912
5000,0.2817862033843994,0.3020761013031006
```
- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
