### PR TITLE
Ignore `examples/` path when searching for coverage report

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -171,5 +171,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          disable-search: true
+          disable_search: true
           fail_ci_if_error: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -171,5 +171,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          exclude: examples/
+          disable-search: true
           fail_ci_if_error: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -171,4 +171,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
+          exclude: examples/
           fail_ci_if_error: true


### PR DESCRIPTION
Debugging https://github.com/codecov/codecov-action/issues/1568 - this unfortunately will work if the issue is **either** too many uploads from a single commit or the action trying to upload a broken notebook.