### PR TITLE
Do not cast residue ids/numbers in `Topology.from_openmm`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -12,6 +12,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Behavior changes
 
+- [PR #1954](https://github.com/openforcefield/openff-toolkit/pull/1954): `Topology.from_openmm` no longer casts residue numbers to int.
+
 ### Bugfixes
 
 ### New features

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -754,8 +754,6 @@ class TestTopology:
                 roundtrip = roundtrip_atom.metadata["residue_number"]
                 assert original == roundtrip
             else:
-                # OpenFF lets residue numbers be str or int, but this is str in OpenMM's
-                # representation, so faithful round-trip is not practical
                 assert roundtrip_atom.metadata["residue_number"] == "0"
 
             if "insertion_code" in orig_atom.metadata:

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -754,7 +754,9 @@ class TestTopology:
                 roundtrip = roundtrip_atom.metadata["residue_number"]
                 assert original == roundtrip
             else:
-                assert roundtrip_atom.metadata["residue_number"] == 0
+                # OpenFF lets residue numbers be str or int, but this is str in OpenMM's
+                # representation, so faithful round-trip is not practical
+                assert roundtrip_atom.metadata["residue_number"] == "0"
 
             if "insertion_code" in orig_atom.metadata:
                 original = orig_atom.metadata["insertion_code"]

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -770,6 +770,20 @@ class TestTopology:
             else:
                 assert roundtrip_atom.metadata["chain_id"] == "X"
 
+    def test_from_to_openmm_hierarchy_metadata(self):
+        """Reproduce issue #1953"""
+        import openmm.app
+
+        openmm_topology = openmm.app.PDBFile(get_data_file_path("proteins/MainChain_ALA_ALA.pdb")).topology
+        openff_molecule = Topology.from_pdb(get_data_file_path("proteins/MainChain_ALA_ALA.pdb")).molecule(0)
+
+        roundtripped = Topology.from_openmm(
+            openmm_topology,
+            unique_molecules=[openff_molecule],
+        ).to_openmm()
+
+        assert {type(residue.id) for residue in roundtripped.residues()} == {str}, "type mistmatch in residue id in OpenMM residues"
+
     @requires_rdkit
     def test_from_pdb(self):
         with pytest.raises(UnassignedChemistryInPDBError) as exc_info:

--- a/openff/toolkit/_tests/test_topology.py
+++ b/openff/toolkit/_tests/test_topology.py
@@ -772,6 +772,7 @@ class TestTopology:
             else:
                 assert roundtrip_atom.metadata["chain_id"] == "X"
 
+    @requires_rdkit
     def test_from_to_openmm_hierarchy_metadata(self):
         """Reproduce issue #1953"""
         import openmm.app

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -1521,9 +1521,7 @@ class Topology(Serializable):
                 off_atom.metadata["residue_name"] = omm_mol_G.nodes[omm_atom_idx][
                     "residue_name"
                 ]
-                off_atom.metadata["residue_number"] = int(
-                    omm_mol_G.nodes[omm_atom_idx]["residue_id"]
-                )
+                off_atom.metadata["residue_number"] = omm_mol_G.nodes[omm_atom_idx]["residue_id"]
                 off_atom.metadata["insertion_code"] = omm_mol_G.nodes[omm_atom_idx][
                     "insertion_code"
                 ]


### PR DESCRIPTION
Fixes #1953

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
