### PR TITLE
Convert insertion code or chain id empty string to single character space in to_openeye

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -14,6 +14,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### Behavior changes
 
 ### Bugfixes
+- [PR #1971](https://github.com/openforcefield/openff-toolkit/pull/1971): Fixes bug where OpenEyeToolkitWrapper would write coordinate-less PDB atoms if insertion_code or chain_id was an empty string ([Issue #1967](https://github.com/openforcefield/openff-toolkit/issues/1967))     
 
 
 ### New features

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,6 +15,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Bugfixes
 
+
 ### New features
 
 ### Improved documentation and warnings

--- a/openff/toolkit/_tests/test_toolkits.py
+++ b/openff/toolkit/_tests/test_toolkits.py
@@ -1041,6 +1041,36 @@ class TestOpenEyeToolkitWrapper:
         assert water_from_pdb_split[1].split()[2].rstrip() == "O"
         assert water_from_pdb_split[2].split()[2].rstrip() == "H"
 
+    def test_write_pdb_blank_chain_id_insertion_code(self):
+        """
+        Ensure PDB files are written with coords by OE when chain ID or insertion code is blank string.
+        (reference: https://github.com/openforcefield/openff-toolkit/issues/1967).
+        """
+        from io import StringIO
+
+        toolkit = OpenEyeToolkitWrapper()
+        water = Molecule()
+        water.add_atom(1, 0, False)
+        water.add_atom(8, 0, False)
+        water.add_atom(1, 0, False)
+        water.add_bond(0, 1, 1, False)
+        water.add_bond(1, 2, 1, False)
+        water.add_conformer(
+            Quantity(
+                np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
+                unit.angstrom,
+            )
+        )
+        water.atoms[0].metadata["insertion_code"] = ""
+        water.atoms[1].metadata["chain_id"] = ""
+        with NamedTemporaryFile(suffix='.pdb') as of:
+            water.to_file(of.name, "pdb", toolkit_registry=toolkit)
+            roundtripped = toolkit.from_file(of.name, file_format='pdb')
+            np.testing.assert_allclose(
+                water.conformers[0].m_as(unit.angstrom),
+                roundtripped[0].conformers[0].m_as(unit.angstrom)
+            )
+
     def test_get_sdf_coordinates(self):
         """Test OpenEyeToolkitWrapper for importing a single set of coordinates from a sdf file"""
 

--- a/openff/toolkit/_tests/test_toolkits.py
+++ b/openff/toolkit/_tests/test_toolkits.py
@@ -1046,8 +1046,6 @@ class TestOpenEyeToolkitWrapper:
         Ensure PDB files are written with coords by OE when chain ID or insertion code is blank string.
         (reference: https://github.com/openforcefield/openff-toolkit/issues/1967).
         """
-        from io import StringIO
-
         toolkit = OpenEyeToolkitWrapper()
         water = Molecule()
         water.add_atom(1, 0, False)

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1664,12 +1664,22 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
                 res.SetResidueNumber(1)
 
             if "insertion_code" in off_atom.metadata:
-                res.SetInsertCode(off_atom.metadata["insertion_code"])
+                # Replace blank string with single character space to avoid OE PDB writing issue
+                # https://github.com/openforcefield/openff-toolkit/issues/1967
+                if off_atom.metadata["insertion_code"] == "":
+                    res.SetInsertCode(" ")
+                else:
+                    res.SetInsertCode(off_atom.metadata["insertion_code"])
             else:
                 res.SetInsertCode(" ")
 
             if "chain_id" in off_atom.metadata:
-                res.SetChainID(off_atom.metadata["chain_id"])
+                # Replace blank string with single character space to avoid OE PDB writing issue
+                # https://github.com/openforcefield/openff-toolkit/issues/1967
+                if off_atom.metadata["chain_id"] == "":
+                    res.SetChainID(" ")
+                else:
+                    res.SetChainID(off_atom.metadata["chain_id"])
             else:
                 res.SetChainID(" ")
 


### PR DESCRIPTION
- [x] Fix #1967 
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] [Lint](https://open-forcefield-toolkit.readthedocs.io/en/latest/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
