### PR TITLE
Run CI on `macos-latest`, not `macos-12`

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.10"]
         rdkit: [true, false]
         openeye: [true, false]
@@ -38,7 +38,7 @@ jobs:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       PACKAGE: openff
       PYTEST_ARGS: -r fE -v -x --tb=short -nauto
-      NB_ARGS: --nbval-lax --dist loadscope --ignore=examples/deprecated
+      NB_ARGS: --nbval-lax --dist loadscope --ignore=examples/deprecated --ignore=examples/external
 
     steps:
       - uses: actions/checkout@v4
@@ -65,10 +65,6 @@ jobs:
           environment-file: devtools/conda-envs/${{env.ENVFILE}}-examples.yaml
           create-args: >-
             python=${{ matrix.python-version }}
-          # default - will pull down 2.0 which we don't want!
-          # micromamba-version: latest
-          # pin to latest 1.x release
-          micromamba-version: "1.5.10-0"
 
       - name: Additional info about the build
         run: |
@@ -96,18 +92,9 @@ jobs:
           # so don't remove it.
           if [ ! -z "${{ env.PACKAGES_TO_REMOVE }}" ]; then
             for cpkg in ${{ env.PACKAGES_TO_REMOVE }}; do
-              if [[ $(conda list | grep $cpkg) ]]; then micromamba remove --force $cpkg --yes ; fi
+              if [[ $(micromamba list | grep $cpkg) ]]; then micromamba remove --force $cpkg --yes ; fi
             done
           fi
-
-      - name: Reinstall ParmEd
-        if: ${{ matrix.rdkit == false }}
-        run: |
-          micromamba remove --force parmed --yes
-          # See #1531, #1532, eventually this should work with 4 or 3 and 4
-          micromamba install "parmed =3" -c conda-forge -yq
-          # Needed for other examples to run, but were removed incidentally alongside AmberTools
-          micromamba install h5py -c conda-forge -yq
 
       - name: Check installed toolkits
         run: |
@@ -125,8 +112,9 @@ jobs:
           fi
       - name: Environment Information
         run: |
-          conda info
-          conda list
+          micromamba info
+          micromamba list
+          pip list
 
       - name: Run example scripts
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       OE_LICENSE: ${{ github.workspace }}/oe_license.txt
       PACKAGE: openff
-      PYTEST_ARGS: -r fE -v -x --tb=short -nauto
+      PYTEST_ARGS: -r fE -v -x --tb=short -nauto --durations=10
       NB_ARGS: --nbval-lax --dist loadscope --ignore=examples/deprecated --ignore=examples/external
 
     steps:

--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -38,7 +38,6 @@ dependencies:
   - qcportal >=0.50
   - qcengine
   - mdtraj
-  - parmed =3
   - nbval
   - pdbfixer
   - openmmforcefields >=0.11.2

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -26,9 +26,9 @@ dependencies:
     # Toolkit-specific
   # AmberTools 23 brings in ParmEd 4, which doesn't yet work with examples
   # https://github.com/openforcefield/openff-toolkit/issues/1532
-  - ambertools =22.4
+  - ambertools
     # https://github.com/rdkit/rdkit/issues/7221 and https://github.com/rdkit/rdkit/issues/7583
-  - rdkit !=2024.03.6,!=2024.03.5
+  - rdkit =2024
     # Test-only/optional/dev/typing/examples
   - pytest
   - pytest-xdist


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10721

Example impact: https://github.com/openforcefield/openff-toolkit/actions/runs/12167392775/job/33935854048?pr=1972


```
$ grep -r macos-1 . | wc -l
       0