### PR TITLE
Add `Molecule.clear_conformers`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -25,6 +25,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### New features
 - [PR #1990](https://github.com/openforcefield/openff-toolkit/pull/1990): Adds support for Pint 0.24 and `openff-units` 0.3.x.
+- [PR #2015](https://github.com/openforcefield/openff-toolkit/pull/2015): Adds `Molecule.clear_conformers`.
 
 ### Improved documentation and warnings
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -6,9 +6,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 * `minor` increments add features but do not break API compatibility
 * `micro` increments represent bugfix releases or improvements in documentation
 
-## Current development
-
-### API-breaking changes
+## 0.16.8
 
 ### Behavior changes
 - [PR #1963](https://github.com/openforcefield/openff-toolkit/pull/1963): Always use `getattr` in lazy loading machinery.

--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -2682,7 +2682,7 @@ class TestMolecule:
         # simpler molecules don't always like to have many (> 1) conformers
         # https://greglandrum.github.io/rdkit-blog/posts/2023-02-04-working-with-conformers.html
         molecule = Molecule.from_smiles(
-            "COc1ccc2[n-]c([S@@+]([O-])Cc3ncc(C)c(OC)c3C)nc2c1"
+            "CCCCCCNCNCNCCCCN"
         )
         molecule.generate_conformers(n_conformers=10)
 

--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -2678,6 +2678,32 @@ class TestMolecule:
         with pytest.raises(IncompatibleUnitError):
             molecule.add_conformer(conf_unitless)
 
+    def test_clear_conformers(self):
+        # simpler molecules don't always like to have many (> 1) conformers
+        # https://greglandrum.github.io/rdkit-blog/posts/2023-02-04-working-with-conformers.html
+        molecule = Molecule.from_smiles(
+            "COc1ccc2[n-]c([S@@+]([O-])Cc3ncc(C)c(OC)c3C)nc2c1"
+        )
+        molecule.generate_conformers(n_conformers=10)
+
+        assert molecule.n_conformers > 0
+
+        molecule.clear_conformers()
+
+        assert molecule.n_conformers == 0
+
+    def test_clear_conformers_none(self):
+        """
+        Ensure nothing weird happens when calling clear_conformers() on a molecule that already has no conformers.
+        """
+        molecule = create_ethanol()
+
+        assert molecule.n_conformers == 0
+
+        molecule.clear_conformers()
+
+        assert molecule.n_conformers == 0
+
     @pytest.mark.parametrize("molecule", mini_drug_bank())
     def test_add_atoms_and_bonds(self, molecule):
         """Test the creation of a molecule from the addition of atoms and bonds"""

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5438,6 +5438,14 @@ class Molecule(FrozenMolecule):
 
         return self._add_conformer(coordinates)
 
+    def clear_conformers(self):
+        """
+        Delete all conformers of this molecule, if any exist.
+
+        """
+        self._conformers = None
+
+
     @overload
     def visualize(
         self,


### PR DESCRIPTION
Implements one solution for #1841, the other option being updating the attribute to only ever be a list

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
