### PR TITLE
[WIP] Re-ignore external examples in conda tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -128,4 +128,4 @@ jobs:
 
       - name: Run example notebooks
         run: |
-          python -m pytest -r fE -v -x --tb=short --nbval-lax --ignore=examples/deprecated examples
+          python -m pytest -r fE -v -x --tb=short --nbval-lax --ignore=examples/deprecated --ignore=examples/external examples


### PR DESCRIPTION
- [x] Fixes #2036 

This will be auto-fixed when we cut a release, but I don't want to rush that just for the sake of CI, especially since there's a new feature and a behavior change in on main.

Testing with manual dispatches, ex https://github.com/openforcefield/openff-toolkit/actions/runs/13976249748 