### PR TITLE
Catch MissingOptionalDependencyError when nglview is not installed

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -16,6 +16,8 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Bugfixes
 
+- [PR #2039](https://github.com/openforcefield/openff-toolkit/pull/2039): Prevent an error displaying a `Molecule` in IPython when `nglview` is not installed.
+
 ### New features
 
 - [PR #1996](https://github.com/openforcefield/openff-toolkit/pull/1996): Adds `ForceField.combine`.

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -5766,7 +5766,7 @@ class Molecule(FrozenMolecule):
 
         try:
             return display(self.visualize(backend="nglview"))
-        except (ImportError, ValueError):
+        except (MissingOptionalDependencyError, ValueError):
             pass
 
         try:


### PR DESCRIPTION
Fixes #1157.  Test `test_molecule.py::TestMoleculeVisualization::test_ipython_repr_no_nglview` already present and was failing (now passes, although this wouldn't have been caught by CI before; see https://github.com/openforcefield/openff-toolkit/pull/1158#issue-1085008138).

- [x] Tag issue being addressed
- [ ] ~~Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)~~
- [ ] ~~Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable~~
- [x] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
