### PR TITLE
Support large molecule InChi with RDKit

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -19,7 +19,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### New features
 
 - [PR #1996](https://github.com/openforcefield/openff-toolkit/pull/1996): Adds `ForceField.combine`.
-- [PR #20XX](https://github.com/openforcefield/openff-toolkit/pull/20XX): Adds support for InChI with large molecules when using RDKit.
+- [PR #2040](https://github.com/openforcefield/openff-toolkit/pull/2040): Adds support for InChI with large molecules when using RDKit.
 
 ### Improved documentation and warnings
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -19,6 +19,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### New features
 
 - [PR #1996](https://github.com/openforcefield/openff-toolkit/pull/1996): Adds `ForceField.combine`.
+- [PR #20XX](https://github.com/openforcefield/openff-toolkit/pull/20XX): Adds support for InChI with large molecules when using RDKit.
 
 ### Improved documentation and warnings
 

--- a/openff/toolkit/_tests/test_toolkits.py
+++ b/openff/toolkit/_tests/test_toolkits.py
@@ -2404,6 +2404,14 @@ class TestRDKitToolkitWrapper:
                 method,
             )(toolkit_registry=RDKitToolkitWrapper())
 
+    @pytest.mark.parametrize("method", ["to_inchi", "to_inchikey"])
+    def test_large_molecule(self, method):
+        getattr(
+            Molecule.from_smiles(342 * "C"),
+            method,
+        )(toolkit_registry=RDKitToolkitWrapper())
+
+
     def test_smiles_charged(self):
         """Test RDKitWrapper functions for reading/writing charged SMILES"""
         toolkit_wrapper = RDKitToolkitWrapper()

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1774,6 +1774,10 @@ class FrozenMolecule(Serializable):
         InChI is a standardised representation that does not capture tautomers unless specified using the fixed
         hydrogen layer.
 
+        If RDKit is used, the /LargeMolecules switch will be used.
+
+        If OEChem is used, an error will be raised if the molecule is large (1024+ atoms).
+
         For information on InChi see here https://iupac.org/who-we-are/divisions/division-details/inchi/
 
         Parameters
@@ -1820,6 +1824,10 @@ class FrozenMolecule(Serializable):
         Create an InChIKey for the molecule using the requested toolkit backend.
         InChIKey is a standardised representation that does not capture tautomers unless specified
         using the fixed hydrogen layer.
+
+        If RDKit is used, the /LargeMolecules switch will be used.
+
+        If OEChem is used, an error will be raised if the molecule is large (1024+ atoms).
 
         For information on InChi see here https://iupac.org/who-we-are/divisions/division-details/inchi/
 

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -1917,6 +1917,8 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         else:
             inchi = oechem.OEMolToSTDInChI(oemol)
 
+        # TODO: Add support for /LargeMolecules switch when OpenEye allows it
+        #       (underlying InChI tool does)
         if len(inchi) == 0:
             raise EmptyInChiError(
                 "OEChem failed to generate an InChI for the molecule."

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -2772,6 +2772,8 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         InChI is a standardised representation that does not capture tautomers
         unless specified using the fixed hydrogen layer.
 
+        The /LargeMolecules option is used.
+
         For information on InChi see here https://iupac.org/who-we-are/divisions/division-details/inchi/
 
         Parameters
@@ -2797,10 +2799,13 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         from rdkit import Chem
 
         rdmol = self.to_rdkit(molecule)
+
+        options = "/LargeMolecules"
+
         if fixed_hydrogens:
-            inchi = Chem.MolToInchi(rdmol, options="-FixedH")
-        else:
-            inchi = Chem.MolToInchi(rdmol)
+            options += " /FixedH"
+
+        inchi = Chem.MolToInchi(rdmol, options)
 
         if len(inchi) == 0:
             raise EmptyInChiError("RDKit failed to generate an InChI for the molecule.")
@@ -2812,6 +2817,8 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         Create an InChIKey for the molecule using the RDKit Toolkit.
         InChIKey is a standardised representation that does not capture tautomers
         unless specified using the fixed hydrogen layer.
+
+        The /LargeMolecules option is used.
 
         For information on InChi see here https://iupac.org/who-we-are/divisions/division-details/inchi/
 
@@ -2838,15 +2845,16 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         from rdkit import Chem
 
         rdmol = self.to_rdkit(molecule)
+
+        options = "/LargeMolecules"
+
         if fixed_hydrogens:
-            inchi_key = Chem.MolToInchiKey(rdmol, options="-FixedH")
-        else:
-            inchi_key = Chem.MolToInchiKey(rdmol)
+            options += " /FixedH"
+
+        inchi_key = Chem.MolToInchiKey(rdmol, options)
 
         if len(inchi_key) == 0:
-            raise EmptyInChiError(
-                "RDKit failed to generate an InChI key for the molecule."
-            )
+            raise EmptyInChiError("RDKit failed to generate an InChI key for the molecule.")
 
         return inchi_key
 


### PR DESCRIPTION
Partial fix for #1977 since OEChem insists on not allowing the user to pass the argument through to InChI's tool

Arguably the `/LargeMolecules` option should be opt-in, but that's an API addition with no obvious upside.

This would change, but not break, how NAGL uses InChI to key its lookup table (https://github.com/openforcefield/openff-nagl/pull/165/). Currently, it makes an attempt to gracefully handle `EmptyInChiError`; when RDKit is that case shouldn't be needed any more.

This still appears to be relatively fast for a large molecule, not accounting for the time it takes to instantiate `RDKitToolkitWrapper`, delegate out, etc.:

```python
In [6]: molecule = Molecule.from_smiles(1000 * "C")

In [7]: %timeit molecule.to_inchi(toolkit_registry=RDKitToolkitWrapper())
39.7 ms ± 1.54 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Simple demo:

```python
from openff.toolkit import Molecule
from openff.toolkit.utils.rdkit_wrapper import RDKitToolkitWrapper, EmptyInChiError

try:
    Molecule.from_smiles(342 * "C").to_inchi(toolkit_registry=RDKitToolkitWrapper())
except EmptyInChiError as error:
    print(error)
else:
    print("InChI fine ... ")

try:
    Molecule.from_smiles(342 * "C").to_inchikey(toolkit_registry=RDKitToolkitWrapper())
except EmptyInChiError as error:
    print(error)
else:
    print("InChI key fine ... ")
```
Out:
```console
$ git checkout upstream/main && python large_molecule_inchi.py
HEAD is now at 4cc57064 re-ignore external examples in conda tests (#2038)
[13:51:05] ERROR: Too many atoms [did you forget 'LargeMolecules' switch?]

RDKit failed to generate an InChI for the molecule.
[13:51:05] Invalid InChI prefix in generating InChI Key
RDKit failed to generate an InChI key for the molecule.
(openff-toolkit-test) [openff-toolkit]
$ git checkout rdkit-large-molecule-inchi && python large_molecule_inchi.py
Previous HEAD position was 4cc57064 re-ignore external examples in conda tests (#2038)
Switched to branch 'rdkit-large-molecule-inchi'
InChI fine ...
InChI key fine ...
```

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
