### PR TITLE
Drop testing on Python 3.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         rdkit: [true, false]
         openeye: [true, false]
         exclude:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         openeye: ["true", "false"]
 
     env:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10"]
+        python-version: ["3.11"]
         rdkit: [true, false]
         openeye: [true, false]
         exclude:

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-12, ubuntu-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
 
     env:
       CI_OS: ${{ matrix.os }}

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -13,6 +13,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### Behavior changes
 
 - [PR #2026](https://github.com/openforcefield/openff-toolkit/pull/2026): Makes `Molecule.__repr__` more succinct for large molecules.
+- [PR #2041](https://github.com/openforcefield/openff-toolkit/pull/2041): Drop testing on Python 3.10
 
 ### Bugfixes
 


### PR DESCRIPTION
Bumps minimum Python version in tests to 3.11 following NEP 29.

Where 3.10 was one of many versions used in a matrix, it is removed.
Where 3.10 was the only version used in a workflow, 3.11 is used instead. This could have produced failures but nothing is coming back. (I did not look through logs for warnings.)

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [x] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
