### PR TITLE
Drop use of `importlib_metadata`

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -15,6 +15,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### Bugfixes
 - [PR #2052](https://github.com/openforcefield/openff-toolkit/pull/2052): Fixes bug where `Topology.from_pdb` couldn't load NH4+ ([Issue #2051](https://github.com/openforcefield/openff-toolkit/issues/2051))
 
+### Miscellaneous
+
+- [PR #2XXX](https://github.com/openforcefield/openff-toolkit/pull/2XXX): Removes internal use of `importlib_metadata` where `importlib.metadata` is appropriate.
 
 ### New features
 

--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -17,7 +17,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 
 ### Miscellaneous
 
-- [PR #2XXX](https://github.com/openforcefield/openff-toolkit/pull/2XXX): Removes internal use of `importlib_metadata` where `importlib.metadata` is appropriate.
+- [PR #2054](https://github.com/openforcefield/openff-toolkit/pull/2054): Removes internal use of `importlib_metadata` where `importlib.metadata` is appropriate.
 
 ### New features
 

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -13,6 +13,7 @@ Parameter assignment tools for the SMIRNOFF (SMIRKS Native Open Force Field) for
 import logging
 import os
 import pathlib
+from importlib.metadata import entry_points
 from typing import IO, TYPE_CHECKING, Any, Optional, Union
 
 from packaging.version import Version
@@ -85,7 +86,6 @@ def _get_installed_offxml_dir_paths() -> list[str]:
     """
     global _installed_offxml_dir_paths
     if len(_installed_offxml_dir_paths) == 0:
-        from importlib_metadata import entry_points
 
         # Find all registered entry points that should return a list of
         # paths to directories where to search for offxml files.

--- a/openff/toolkit/typing/engines/smirnoff/plugins.py
+++ b/openff/toolkit/typing/engines/smirnoff/plugins.py
@@ -23,6 +23,7 @@ inherits from ``ParameterHandler`` named ``CustomHandler``.
 """
 
 import logging
+from importlib.metadata import entry_points
 
 from openff.toolkit.typing.engines.smirnoff.parameters import ParameterHandler
 
@@ -45,7 +46,6 @@ def _load_handler_plugins(handler_name: str, expected_type: type) -> list[type]:
         handler plugins the expected class type is ``ParameterIOHandler``. Any
         classes not matching the expected type will be skipped.
     """
-    from importlib_metadata import entry_points
 
     if handler_name not in SUPPORTED_PLUGIN_NAMES:
         raise NotImplementedError(


### PR DESCRIPTION
`importlib-metadata` is a third-party package which backports features of `importlib.metadata` (which is in the standard library) to older Python versions. We were using it as a bridge while it was "provisional" but that ship has long passed.


This change is likely 3.10+ based on my reading of the docs, but I haven't pinned it down completely: https://docs.python.org/3/library/importlib.metadata.html

This was *not* declared as a dependency in test environments - it probably should have been - but is a requirement in packaging. This change would allow that to be dropped from the conda recipe.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
