### PR TITLE
Drop `cached-property`

### DIFF
--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -10,7 +10,6 @@ dependencies:
   - numpy
   - networkx
   - cachetools
-  - cached-property
   - xmltodict
   - python-constraint
   - openmm >=7.6

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -10,7 +10,6 @@ dependencies:
   - numpy
   - networkx
   - cachetools
-  - cached-property
   - xmltodict
   - python-constraint
   - openmm >=7.6

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -9,7 +9,6 @@ dependencies:
   - numpy
   - networkx
   - cachetools
-  - cached-property
   - xmltodict
   - python-constraint
   - openmm >=7.6

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -9,7 +9,6 @@ dependencies:
   - numpy
   - networkx
   - cachetools
-  - cached-property
   - xmltodict
   - python-constraint
   - openmm >=7.6

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,7 +10,6 @@ dependencies:
   - numpy
   - networkx
   - cachetools
-  - cached-property
   - xmltodict
   - python-constraint
   - openmm >=7.6

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -24,7 +24,6 @@ dependencies:
     - packaging
     - openff-units
     - openff-utilities
-    - cached_property
     - cachetools
     - python-constraint
     - mdtraj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ module = [
     "qcelemental",
     "nglview",
     "nglview.base_adaptor",
-    "cached_property",
     "constraint",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
This is in the standard library with Python 3.8, but also not actually used anywhere in the code

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
