### PR TITLE
Constrain NumPy < 2.3 in tests

### DIFF
--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python
   - versioningit
   - packaging
-  - numpy
+  - numpy <2.3
   - networkx
   - cachetools
   - cached-property

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python
   - versioningit
   - packaging
-  - numpy
+  - numpy <2.3
   - networkx
   - cachetools
   - cached-property

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python
   - versioningit
   - packaging
-  - numpy
+  - numpy <2.3
   - networkx
   - cachetools
   - cached-property

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -6,7 +6,7 @@ dependencies:
   - python
   - versioningit
   - packaging
-  - numpy
+  - numpy <2.3
   - networkx
   - cachetools
   - cached-property

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python
   - versioningit
   - packaging
-  - numpy
+  - numpy <2.3
   - networkx
   - cachetools
   - cached-property


### PR DESCRIPTION
ParmEd does not work with the newest NumPy release, each of which we need in tests

Since this causes CI to fail for reasons we cannot control, I aim to merge this without review.

Since we don't depend on ParmEd for our own features, I don't plan to update the packaging of our packages.