### PR TITLE
Update `Atom.stereochemistry` docstring

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -440,18 +440,17 @@ class Atom(Particle):
 
     @stereochemistry.setter
     def stereochemistry(self, value: Literal["CW", "CCW", None]):
-        """Set the atoms stereochemistry
+        """
+        Set the stereochemistry of this atom.
+
         Parameters
         ----------
         value
-            The stereochemistry around this atom, allowed values are "CW", "CCW", or None,
+            The stereochemistry around this atom, suggested values are "CW", "CCW", or None,
         """
-
-        # if (value != 'CW') and (value != 'CCW') and not(value is None):
-        #    raise Exception(
-        #       "Atom stereochemistry setter expected 'CW', 'CCW', or None. ""
-        #       "Received {} (type {})".format(value, type(value))"
-        # )
+        # there should be some input validation, if we can agree on what possible values this might take.
+        # currently (July 2025) toolkit wrappers only deal with "CW", "CCW", or None.
+        # for more, see https://github.com/openforcefield/openff-toolkit/issues/2084
         self._stereochemistry = value
 
     @property


### PR DESCRIPTION
Interacts with #2084 but does **not** close it

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
