### PR TITLE
Improve speed of quantity stringification

### DIFF
--- a/docs/releasehistory.md
+++ b/docs/releasehistory.md
@@ -13,6 +13,7 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 ### Behavior changes
 
 ### Bugfixes
+
 - [PR #2052](https://github.com/openforcefield/openff-toolkit/pull/2052): Fixes bug where `Topology.from_pdb` couldn't load NH4+ ([Issue #2051](https://github.com/openforcefield/openff-toolkit/issues/2051))
 
 ### Miscellaneous
@@ -22,7 +23,9 @@ Releases follow the `major.minor.micro` scheme recommended by [PEP440](https://w
 - [PR #2078](https://github.com/openforcefield/openff-toolkit/pull/2078): Updates molecule cookbook molecule.from_qcschema()
 
 ### New features
+
 - [PR #2066](https://github.com/openforcefield/openff-toolkit/pull/2066): Improves runtime in some situations by making AmberToolsToolkitWrapper perform lazy evaluation of AmberTools version. (@vamironov)
+- [PR #2090](https://github.com/openforcefield/openff-toolkit/pull/2090): Improves runtime of force field serialization via faster `Quantity` stringification.
 
 
 ### Improved documentation and warnings

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -163,7 +163,7 @@ def quantity_to_string(input_quantity: Quantity) -> str:
         The serialized quantity
 
     """
-    unitless_value: float | int | NDArray | list = input_quantity.m_as(input_quantity.units)
+    unitless_value: float | int | NDArray | list = input_quantity.m
     # The string representation of a numpy array doesn't have commas and breaks the
     # parser, thus we convert any arrays to list here
     if isinstance(unitless_value, np.ndarray):


### PR DESCRIPTION
Relates to #2065, split off from #2081

I see a ~20% speedup in stringifying some force fields

```python
In [1]: import openff.toolkit

In [2]: ff14sb = openff.toolkit.ForceField("ff14sb_off_impropers_0.0.4.offxml")
/Users/mattthompson/micromamba/envs/openff-toolkit-test/lib/python3.12/site-packages/openff/amber_ff_ports/amber_ff_ports.py:8: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import resource_filename
/Users/mattthompson/micromamba/envs/openff-toolkit-test/lib/python3.12/site-packages/openff/amber_ff_ports/amber_ff_ports.py:8: UserWarning: Module openff was already imported from None, but /Users/mattthompson/software/openff-toolkit is being added to sys.path
  from pkg_resources import resource_filename

In [3]: %timeit ff14sb._to_smirnoff_data()
388 ms ± 2.91 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
This is compared to 
```python
501 ms ± 24.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
upstream, on my machine

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
