### PR TITLE
Allow NAGL model paths to be `pathlib.Path | str`

### DIFF
--- a/openff/toolkit/_tests/test_nagl.py
+++ b/openff/toolkit/_tests/test_nagl.py
@@ -5,6 +5,7 @@ import numpy
 import pytest
 from openff.utilities import has_package, skip_if_missing
 
+from openff.nagl_models import get_models_by_type
 from openff.nagl_models._dynamic_fetch import BadFileSuffixError
 from openff.toolkit import Molecule, unit
 from openff.toolkit._tests.create_molecules import (
@@ -67,7 +68,7 @@ class TestNAGLToolkitWrapper:
             case str:
                 nagl_model = str(nagl_model)
 
-        assert isinstance(nagl_model, input_type)
+        assert isinstance(nagl_model, input_type), (nagl_model, input_type)
 
         molecule = molecule_function()
 
@@ -95,6 +96,22 @@ class TestNAGLToolkitWrapper:
             nagl_charges,
             atol=0.07,
         )
+
+    def assign_am1bcc_from_get_model(self):
+        ethanol = create_ethanol()
+        ethanol.assign_partial_charges(
+            partial_charge_method=get_models_by_type("am1bcc")[-1],
+        )
+
+        NAGLToolkitWrapper().assign_partial_charges(
+            ethanol,
+            partial_charge_method=get_models_by_type("am1bcc")[-1],
+        )
+
+    @pytest.mark.parametrize("partial_charge_method", get_models_by_type("am1bcc"))
+    def assign_from_molecule_with_helper(self, partial_charge_method):
+        ethanol = create_ethanol()
+        ethanol.assign_partial_charges(partial_charge_method)
 
     def test_atom_order_dependence(self):
         """Regression test against atom order dependence."""

--- a/openff/toolkit/_tests/test_nagl.py
+++ b/openff/toolkit/_tests/test_nagl.py
@@ -54,9 +54,21 @@ class TestNAGLToolkitWrapper:
     )
     @pytest.mark.parametrize(
         "nagl_model",
-        [pathlib.Path(file).name for file in list_available_nagl_models()],
+        list_available_nagl_models(),
     )
-    def test_assign_partial_charges_basic(self, molecule_function, nagl_model):
+    @pytest.mark.parametrize(
+        "input_type",
+        [str, pathlib.Path],
+    )
+    def test_assign_partial_charges_basic(self, molecule_function, nagl_model, input_type):
+        match input_type:
+            case pathlib.Path:
+                nagl_model = pathlib.Path(nagl_model)
+            case str:
+                nagl_model = str(nagl_model)
+
+        assert isinstance(nagl_model, input_type)
+
         molecule = molecule_function()
 
         molecule.assign_partial_charges(

--- a/openff/toolkit/_tests/test_nagl.py
+++ b/openff/toolkit/_tests/test_nagl.py
@@ -97,7 +97,7 @@ class TestNAGLToolkitWrapper:
             atol=0.07,
         )
 
-    def assign_am1bcc_from_get_model(self):
+    def test_assign_am1bcc_from_full_path(self):
         ethanol = create_ethanol()
         ethanol.assign_partial_charges(
             partial_charge_method=get_models_by_type("am1bcc")[-1],

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -2550,7 +2550,7 @@ class FrozenMolecule(Serializable):
 
     def assign_partial_charges(
         self,
-        partial_charge_method: str,
+        partial_charge_method: str | pathlib.Path,
         strict_n_conformers: bool = False,
         use_conformers: Optional[Iterable[Quantity]] = None,
         toolkit_registry: TKR = GLOBAL_TOOLKIT_REGISTRY,
@@ -2651,8 +2651,9 @@ class FrozenMolecule(Serializable):
         openff.toolkit.utils.toolkits.AmberToolsToolkitWrapper.assign_partial_charges
         openff.toolkit.utils.toolkits.BuiltInToolkitWrapper.assign_partial_charges
         """
+        # https://github.com/openforcefield/openff-nagl-models/issues/69
         if isinstance(partial_charge_method, pathlib.Path):
-            partial_charge_method = partial_charge_method.as_posix()
+            partial_charge_method = partial_charge_method.name
 
         # Raise a warning when users try to apply these charge methods to "large" molecules
         WARN_LARGE_MOLECULES: set[str] = {

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -2651,6 +2651,8 @@ class FrozenMolecule(Serializable):
         openff.toolkit.utils.toolkits.AmberToolsToolkitWrapper.assign_partial_charges
         openff.toolkit.utils.toolkits.BuiltInToolkitWrapper.assign_partial_charges
         """
+        if isinstance(partial_charge_method, pathlib.Path):
+            partial_charge_method = partial_charge_method.as_posix()
 
         # Raise a warning when users try to apply these charge methods to "large" molecules
         WARN_LARGE_MOLECULES: set[str] = {

--- a/openff/toolkit/utils/nagl_wrapper.py
+++ b/openff/toolkit/utils/nagl_wrapper.py
@@ -61,7 +61,7 @@ class NAGLToolkitWrapper(ToolkitWrapper):
     def assign_partial_charges(
         self,
         molecule: "Molecule",
-        partial_charge_method: str,
+        partial_charge_method: pathlib.Path | str,
         use_conformers: Optional[list["Quantity"]] = None,
         strict_n_conformers: bool = False,
         normalize_partial_charges: bool = True,
@@ -114,7 +114,8 @@ class NAGLToolkitWrapper(ToolkitWrapper):
         from openff.nagl import GNNModel
         from openff.nagl_models._dynamic_fetch import HashComparisonFailedException, get_model
 
-        assert type(partial_charge_method) is str, "partial_charge_method must be a string"
+        if isinstance(partial_charge_method, pathlib.Path):
+            partial_charge_method = partial_charge_method.as_posix()
 
         if partial_charge_method == "" or partial_charge_method == "None":
             raise FileNotFoundError(


### PR DESCRIPTION
The `partial_charge_method` is meant to be a string, but some helper functions from `openff.nagl_models` return `list[pathlib.Path]`. This change sanitizes inputs in order to support both

- [x] Tag issue being addressed
- [x] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
