### PR TITLE
Declare minimum Python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
 files: ^openff|(^examples/((?!deprecated).)*$)|^docs|(^utilities/((?!deprecated).)*$)
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.8
+  rev: v0.12.11
   hooks:
     - id: ruff-format
     - id: ruff-check

--- a/openff/toolkit/_tests/utils.py
+++ b/openff/toolkit/_tests/utils.py
@@ -13,7 +13,6 @@ import pathlib
 import pprint
 import textwrap
 from contextlib import contextmanager
-from typing import Union
 
 import numpy as np
 import openmm
@@ -47,7 +46,7 @@ requires_openeye_mol2 = pytest.mark.skipif(
 )
 
 
-def _get_readme_path() -> Union[pathlib.Path, None]:
+def _get_readme_path() -> pathlib.Path | None:
     """
     Return a path to the README file or None if it cannot be assured to be the toolkit's README.
     """

--- a/openff/toolkit/topology/_mm_molecule.py
+++ b/openff/toolkit/topology/_mm_molecule.py
@@ -12,7 +12,7 @@ TypedMolecule TODOs
 
 import functools
 from collections.abc import Generator, Iterable
-from typing import TYPE_CHECKING, NoReturn, Optional, Union
+from typing import TYPE_CHECKING, NoReturn, Union
 
 from openff.units.elements import MASSES, SYMBOLS
 
@@ -62,7 +62,7 @@ class _SimpleMolecule:
         self.bonds.append(bond)
 
     @property
-    def conformers(self) -> Optional[list["Quantity"]]:
+    def conformers(self) -> list["Quantity"] | None:
         return self._conformers
 
     def add_conformer(self, conformer):
@@ -457,7 +457,7 @@ class _SimpleMolecule:
         mol1: Union["FrozenMolecule", "_SimpleMolecule", "nx.Graph"],
         mol2: Union["FrozenMolecule", "_SimpleMolecule", "nx.Graph"],
         return_atom_map: bool = False,
-    ) -> tuple[bool, Optional[dict[int, int]]]:
+    ) -> tuple[bool, dict[int, int] | None]:
         import networkx
 
         _cls = _SimpleMolecule
@@ -540,8 +540,8 @@ class _SimpleAtom:
     def __init__(
         self,
         atomic_number: int,
-        molecule: Optional[_SimpleMolecule] = None,
-        metadata: Optional[AtomMetadataDict] = None,
+        molecule: _SimpleMolecule | None = None,
+        metadata: AtomMetadataDict | None = None,
         name: str = "",
         **kwargs,
     ):
@@ -609,8 +609,8 @@ class _SimpleAtom:
     def molecule_atom_index(self) -> int:
         return self.molecule.atoms.index(self)
 
-    def to_dict(self) -> dict[str, Union[dict, str, int]]:
-        atom_dict: dict[str, Union[dict, str, int]] = dict()
+    def to_dict(self) -> dict[str, dict | str | int]:
+        atom_dict: dict[str, dict | str | int] = dict()
         atom_dict["metadata"] = dict(self.metadata)
         atom_dict["atomic_number"] = self._atomic_number
         atom_dict["name"] = self._name

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -4158,7 +4158,7 @@ class FrozenMolecule(Serializable):
                 f"(supported formats: {supported_formats})"
             )
 
-        if isinstance(file_path, str, pathlib.Path):
+        if isinstance(file_path, str | pathlib.Path):
             toolkit.to_file(self, file_path, file_format)
         else:
             toolkit.to_file_obj(self, file_path, file_format)

--- a/openff/toolkit/topology/topology.py
+++ b/openff/toolkit/topology/topology.py
@@ -21,15 +21,14 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Literal,
-    Optional,
     TextIO,
+    TypeAlias,
     Union,
 )
 
 import numpy as np
 from numpy.typing import NDArray
 from openff.units import Unit
-from typing_extensions import TypeAlias
 
 from openff.toolkit import Quantity, unit
 from openff.toolkit.topology import Molecule
@@ -172,7 +171,7 @@ class ValenceDict(_TransformedDict):
     def index_of(
         cls,
         key: Iterable[int],
-        possible: Optional[Iterable[Iterable[int]]] = None,
+        possible: Iterable[Iterable[int]] | None = None,
     ) -> int:
         """
         Generates a canonical ordering of the equivalent permutations of ``key`` (equivalent rearrangements of indices)
@@ -426,7 +425,7 @@ class Topology(Serializable):
 
     """
 
-    _constrained_atom_pairs: dict[tuple[int, int], Union[Quantity, bool]]
+    _constrained_atom_pairs: dict[tuple[int, int], Quantity | bool]
 
     def __init__(self, other=None):
         """
@@ -502,7 +501,7 @@ class Topology(Serializable):
         return combined
 
     @property
-    def unique_molecules(self) -> Iterator[Union[Molecule, _SimpleMolecule]]:
+    def unique_molecules(self) -> Iterator[Molecule | _SimpleMolecule]:
         """
         Get a list of chemically unique molecules in this Topology.
 
@@ -537,7 +536,7 @@ class Topology(Serializable):
             The Topology created from the specified molecule(s)
         """
         # Ensure that we are working with an iterable
-        if isinstance(molecules, (FrozenMolecule, _SimpleMolecule)):
+        if isinstance(molecules, FrozenMolecule | _SimpleMolecule):
             molecules = [molecules]
 
         # Create Topology and populate it with specified molecules
@@ -673,7 +672,7 @@ class Topology(Serializable):
             )
 
     @property
-    def constrained_atom_pairs(self) -> dict[tuple[int, int], Union[Quantity, bool]]:
+    def constrained_atom_pairs(self) -> dict[tuple[int, int], Quantity | bool]:
         """Returns the constrained atom pairs of the Topology
 
         Returns
@@ -701,7 +700,7 @@ class Topology(Serializable):
         # invalidate themselves during appropriate events.
         yield from self._molecules
 
-    def molecule(self, index: int) -> Union[Molecule, _SimpleMolecule]:
+    def molecule(self, index: int) -> Molecule | _SimpleMolecule:
         """
         Returns the molecule with a given index in this Topology.
 
@@ -1216,7 +1215,7 @@ class Topology(Serializable):
 
         return_dict: dict[
             str,
-            Union[None, str, bytes, bool, tuple, list[dict], dict[tuple[int, int], str]],
+            None | str | bytes | bool | tuple | list[dict] | dict[tuple[int, int], str],
         ] = dict()
 
         return_dict["aromaticity_model"] = self._aromaticity_model
@@ -1330,7 +1329,7 @@ class Topology(Serializable):
     def from_openmm(
         cls,
         openmm_topology: "openmm.app.Topology",
-        unique_molecules: Optional[Iterable[FrozenMolecule]] = None,
+        unique_molecules: Iterable[FrozenMolecule] | None = None,
         positions: Union[None, Quantity, "OMMQuantity"] = None,
     ) -> "Topology":
         """
@@ -1523,7 +1522,7 @@ class Topology(Serializable):
         # TODO: How can we preserve metadata from the openMM topology when creating the OFF topology?
         return topology
 
-    def _ensure_unique_atom_names(self, ensure_unique_atom_names: Union[str, bool]):
+    def _ensure_unique_atom_names(self, ensure_unique_atom_names: str | bool):
         """See `Topology.to_openmm`"""
         if not ensure_unique_atom_names:
             return
@@ -1539,11 +1538,11 @@ class Topology(Serializable):
     @requires_package("openmm")
     def from_pdb(
         cls,
-        file_path: Union[str, Path, TextIO],
-        unique_molecules: Optional[Iterable[Molecule]] = None,
+        file_path: str | Path | TextIO,
+        unique_molecules: Iterable[Molecule] | None = None,
         toolkit_registry=GLOBAL_TOOLKIT_REGISTRY,
-        _custom_substructures: Optional[dict[str, list[str]]] = None,
-        _additional_substructures: Optional[Iterable[Molecule]] = None,
+        _custom_substructures: dict[str, list[str]] | None = None,
+        _additional_substructures: Iterable[Molecule] | None = None,
     ):
         """
         Loads supported or user-specified molecules from a PDB file.
@@ -1686,7 +1685,7 @@ class Topology(Serializable):
         import openmm.unit as openmm_unit
         from openmm.app import PDBFile
 
-        if isinstance(file_path, (str, io.TextIOBase)):
+        if isinstance(file_path, str | io.TextIOBase):
             pass
         elif isinstance(file_path, Path):
             file_path = file_path.as_posix()
@@ -1772,7 +1771,7 @@ class Topology(Serializable):
     @requires_package("openmm")
     def to_openmm(
         self,
-        ensure_unique_atom_names: Union[str, bool] = "residues",
+        ensure_unique_atom_names: str | bool = "residues",
     ) -> "openmm.app.Topology":
         """
         Create an OpenMM Topology object.
@@ -1936,11 +1935,11 @@ class Topology(Serializable):
     @requires_package("openmm")
     def to_file(
         self,
-        file: Union[Path, str, TextIO],
-        positions: Optional[Union["OMMQuantity", Quantity, NDArray]] = None,
+        file: Path | str | TextIO,
+        positions: Union["OMMQuantity", Quantity, NDArray] | None = None,
         file_format: Literal["PDB"] = "PDB",
         keep_ids: bool = False,
-        ensure_unique_atom_names: Union[str, bool] = "residues",
+        ensure_unique_atom_names: str | bool = "residues",
     ):
         """
         Save coordinates and topology to a PDB file.
@@ -2020,8 +2019,8 @@ class Topology(Serializable):
             openmm_top = self.to_openmm(ensure_unique_atom_names=ensure_unique_atom_names)
 
             # Write PDB file
-            ctx_manager: Union[nullcontext[TextIO], TextIO]  # MyPy needs some help here
-            if isinstance(file, (str, Path)):
+            ctx_manager: nullcontext[TextIO] | TextIO  # MyPy needs some help here
+            if isinstance(file, str | Path):
                 ctx_manager = open(file, "w")
             else:
                 ctx_manager = nullcontext(file)
@@ -2036,7 +2035,7 @@ class Topology(Serializable):
         else:
             raise NotImplementedError("Topology.to_file supports only PDB")
 
-    def get_positions(self) -> Optional[Quantity]:
+    def get_positions(self) -> Quantity | None:
         """
         Copy the positions of the topology into a new array.
 
@@ -2123,7 +2122,7 @@ class Topology(Serializable):
     def from_mdtraj(
         cls,
         mdtraj_topology: "mdtraj.Topology",
-        unique_molecules: Optional[Iterable[MoleculeLike]] = None,
+        unique_molecules: Iterable[MoleculeLike] | None = None,
         positions: Union[None, "OMMQuantity", Quantity] = None,
     ):
         """
@@ -2342,7 +2341,7 @@ class Topology(Serializable):
 
         To add multiple molecules, particularly many times, use `add_molecules` for better performance.
         """
-        if isinstance(molecule, (Molecule, _SimpleMolecule)):
+        if isinstance(molecule, Molecule | _SimpleMolecule):
             # Route everything through add_molecules for simplicity; the overhead of
             # making a list and grabbing the first element should be negligible
             return self.add_molecules([molecule])[0]

--- a/openff/toolkit/typing/engines/smirnoff/forcefield.py
+++ b/openff/toolkit/typing/engines/smirnoff/forcefield.py
@@ -15,7 +15,7 @@ import logging
 import os
 import pathlib
 from importlib.metadata import entry_points
-from typing import IO, TYPE_CHECKING, Any, Optional, Union
+from typing import IO, TYPE_CHECKING, Any, Union
 
 from packaging.version import Version
 
@@ -222,8 +222,8 @@ class ForceField:
         self,
         *sources,
         aromaticity_model: str = DEFAULT_AROMATICITY_MODEL,
-        parameter_handler_classes: Optional[list[type[ParameterHandler]]] = None,
-        parameter_io_handler_classes: Optional[list[type[ParameterIOHandler]]] = None,
+        parameter_handler_classes: list[type[ParameterHandler]] | None = None,
+        parameter_io_handler_classes: list[type[ParameterIOHandler]] | None = None,
         disable_version_check: bool = False,
         allow_cosmetic_attributes: bool = False,
         load_plugins: bool = False,
@@ -355,8 +355,8 @@ class ForceField:
         # ParameterIO classes to be used for each file type
         self._parameter_io_handlers: dict[str, ParameterIOHandler] = dict()
         # It'd be much more convenient for these to only be str, and just default to the empty string
-        self._author: Optional[str] = None
-        self._date: Optional[str] = None
+        self._author: str | None = None
+        self._date: str | None = None
 
     def _check_smirnoff_version_compatibility(self, version: str):
         """
@@ -460,7 +460,7 @@ class ForceField:
             self._date += " AND " + date
 
     @property
-    def author(self) -> Optional[str]:
+    def author(self) -> str | None:
         """Returns the author data for this ForceField object. If not defined in any loaded files, this will be None.
 
         Returns
@@ -471,7 +471,7 @@ class ForceField:
         return self._author
 
     @author.setter
-    def author(self, author: Optional[str]):
+    def author(self, author: str | None):
         """Set the author data for this ForceField object. If not defined in any loaded files, this will be None.
 
         Parameters
@@ -482,7 +482,7 @@ class ForceField:
         self._author = author
 
     @property
-    def date(self) -> Optional[str]:
+    def date(self) -> str | None:
         """Returns the date data for this ForceField object. If not defined in any loaded files, this will be None.
 
         Returns
@@ -493,7 +493,7 @@ class ForceField:
         return self._date
 
     @date.setter
-    def date(self, date: Optional[str]):
+    def date(self, date: str | None):
         """Set the author data for this ForceField object. If not defined in any loaded files, this will be None.
 
         Parameters
@@ -626,7 +626,7 @@ class ForceField:
     def get_parameter_handler(
         self,
         tagname: str,
-        handler_kwargs: Optional[dict] = None,
+        handler_kwargs: dict | None = None,
         allow_cosmetic_attributes: bool = False,
     ) -> ParameterHandler:
         """Retrieve the parameter handlers associated with the provided tagname.
@@ -732,7 +732,7 @@ class ForceField:
 
     def deregister_parameter_handler(
         self,
-        handler: Union[str, ParameterHandler],
+        handler: str | ParameterHandler,
     ):
         """
         Deregister a parameter handler specified by tag name, class, or instance.
@@ -806,7 +806,7 @@ class ForceField:
             A nested dict representing this ForceField as a SMIRNOFF data object.
 
         """
-        l1_dict: dict[str, Union[str, dict]] = dict()
+        l1_dict: dict[str, str | dict] = dict()
 
         # Assume we will write out SMIRNOFF data in compliance with the max supported spec version
         l1_dict["version"] = str(self._MAX_SUPPORTED_SMIRNOFF_VERSION)
@@ -954,7 +954,7 @@ class ForceField:
             )
             handler._add_parameters(parameter_list_dict, allow_cosmetic_attributes=allow_cosmetic_attributes)
 
-    def parse_smirnoff_from_source(self, source: Union[str, IO]) -> dict:
+    def parse_smirnoff_from_source(self, source: str | IO) -> dict:
         """
         Reads a SMIRNOFF data structure from a source, which can be one of many types.
 
@@ -1046,7 +1046,7 @@ class ForceField:
 
     def to_string(
         self,
-        io_format: Union[str, ParameterIOHandler] = "XML",
+        io_format: str | ParameterIOHandler = "XML",
         discard_cosmetic_attributes: bool = False,
     ) -> str:
         """
@@ -1079,7 +1079,7 @@ class ForceField:
     def to_file(
         self,
         filename: str,
-        io_format: Optional[Union[str, ParameterIOHandler]] = None,
+        io_format: str | ParameterIOHandler | None = None,
         discard_cosmetic_attributes: bool = False,
     ) -> None:
         """
@@ -1140,9 +1140,9 @@ class ForceField:
         self,
         topology: "Topology",
         *,
-        toolkit_registry: Optional[Union["ToolkitRegistry", "ToolkitWrapper"]] = None,
-        charge_from_molecules: Optional[list["Molecule"]] = None,
-        partial_bond_orders_from_molecules: Optional[list["Molecule"]] = None,
+        toolkit_registry: Union["ToolkitRegistry", "ToolkitWrapper"] | None = None,
+        charge_from_molecules: list["Molecule"] | None = None,
+        partial_bond_orders_from_molecules: list["Molecule"] | None = None,
         allow_nonintegral_charges: bool = False,
     ) -> "openmm.System":
         """Create an OpenMM System from this ForceField and a Topology.
@@ -1185,9 +1185,9 @@ class ForceField:
     def create_interchange(
         self,
         topology: "Topology",
-        toolkit_registry: Optional[Union["ToolkitRegistry", "ToolkitWrapper"]] = None,
-        charge_from_molecules: Optional[list["Molecule"]] = None,
-        partial_bond_orders_from_molecules: Optional[list["Molecule"]] = None,
+        toolkit_registry: Union["ToolkitRegistry", "ToolkitWrapper"] | None = None,
+        charge_from_molecules: list["Molecule"] | None = None,
+        partial_bond_orders_from_molecules: list["Molecule"] | None = None,
         allow_nonintegral_charges: bool = False,
     ) -> "Interchange":
         """
@@ -1396,7 +1396,7 @@ class ForceField:
             unit.elementary_charge,
         )
 
-    def __getitem__(self, val: Union[str, ParameterHandler]) -> ParameterHandler:
+    def __getitem__(self, val: str | ParameterHandler) -> ParameterHandler:
         """
         Syntax sugar for lookikng up a ParameterHandler. Note that only
         string-based lookups are currently supported.

--- a/openff/toolkit/typing/engines/smirnoff/io.py
+++ b/openff/toolkit/typing/engines/smirnoff/io.py
@@ -13,7 +13,6 @@ __all__ = [
 ]
 import logging
 from collections.abc import Iterable
-from typing import Optional
 
 import xmltodict
 
@@ -188,7 +187,7 @@ class XMLParameterIOHandler(ParameterIOHandler):
 
         def prepend_all_keys(
             d: dict,
-            char: Optional[str] = "@",
+            char: str | None = "@",
             ignore_keys: Iterable[str] = frozenset(),
         ):
             """

--- a/openff/toolkit/utils/ambertools_wrapper.py
+++ b/openff/toolkit/utils/ambertools_wrapper.py
@@ -9,7 +9,7 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from shutil import which
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -102,8 +102,8 @@ class AmberToolsToolkitWrapper(base_wrapper.ToolkitWrapper):
     def assign_partial_charges(
         self,
         molecule: "Molecule",
-        partial_charge_method: Optional[str] = None,
-        use_conformers: Optional[list[Quantity]] = None,
+        partial_charge_method: str | None = None,
+        use_conformers: list[Quantity] | None = None,
         strict_n_conformers: bool = False,
         normalize_partial_charges: bool = True,
         _cls=None,
@@ -384,8 +384,8 @@ class AmberToolsToolkitWrapper(base_wrapper.ToolkitWrapper):
     def assign_fractional_bond_orders(
         self,
         molecule: "Molecule",
-        bond_order_model: Optional[str] = None,
-        use_conformers: Optional[list[str]] = None,
+        bond_order_model: str | None = None,
+        use_conformers: list[str] | None = None,
         _cls=None,
     ):
         """

--- a/openff/toolkit/utils/base_wrapper.py
+++ b/openff/toolkit/utils/base_wrapper.py
@@ -5,7 +5,7 @@ Base class for toolkit wrappers. Defines the public API and some shared methods
 __all__ = ("ToolkitWrapper",)
 
 from functools import wraps
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from openff.toolkit.utils.constants import DEFAULT_AROMATICITY_MODEL
 from openff.toolkit.utils.exceptions import (
@@ -44,10 +44,10 @@ class ToolkitWrapper:
 
     """
 
-    _is_available: Optional[bool] = None  # True if toolkit is available
-    _toolkit_version: Optional[str] = None
-    _toolkit_name: Optional[str] = None  # Name of the toolkit
-    _toolkit_installation_instructions: Optional[str] = None  # Installation instructions for the toolkit
+    _is_available: bool | None = None  # True if toolkit is available
+    _toolkit_version: str | None = None
+    _toolkit_name: str | None = None  # Name of the toolkit
+    _toolkit_installation_instructions: str | None = None  # Installation instructions for the toolkit
     _supported_charge_methods: dict[str, _ChargeSettings] = dict()
     _toolkit_file_read_formats: list[str] = list()
     _toolkit_file_write_formats: list[str] = list()
@@ -193,9 +193,9 @@ class ToolkitWrapper:
     def _check_n_conformers(
         self,
         molecule: "Molecule",
-        partial_charge_method: Optional[str] = None,
-        min_confs: Optional[int] = None,
-        max_confs: Optional[int] = None,
+        partial_charge_method: str | None = None,
+        min_confs: int | None = None,
+        max_confs: int | None = None,
         strict_n_conformers: bool = False,
     ):
         """

--- a/openff/toolkit/utils/builtin_wrapper.py
+++ b/openff/toolkit/utils/builtin_wrapper.py
@@ -4,7 +4,7 @@ Built-in ToolkitWrapper for very basic functionality. Intended for testing and n
 
 __all__ = ("BuiltInToolkitWrapper",)
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from openff.toolkit import Quantity, unit
 from openff.toolkit.utils import base_wrapper
@@ -40,11 +40,11 @@ class BuiltInToolkitWrapper(base_wrapper.ToolkitWrapper):
     def assign_partial_charges(
         self,
         molecule: "FrozenMolecule",
-        partial_charge_method: Optional[str] = None,
-        use_conformers: Optional[Quantity] = None,
+        partial_charge_method: str | None = None,
+        use_conformers: Quantity | None = None,
         strict_n_conformers: bool = False,
         normalize_partial_charges: bool = True,
-        _cls: Optional[type] = None,
+        _cls: type | None = None,
     ):
         """
 

--- a/openff/toolkit/utils/exceptions.py
+++ b/openff/toolkit/utils/exceptions.py
@@ -421,12 +421,12 @@ class UnassignedChemistryInPDBError(OpenFFToolkitException, ValueError):
 
     def __init__(
         self,
-        msg: Optional[str] = None,
-        substructure_library: Optional[dict[str, list[tuple]]] = None,
+        msg: str | None = None,
+        substructure_library: dict[str, list[tuple]] | None = None,
         omm_top: Optional["OpenMMTopology"] = None,
-        unassigned_bonds: Optional[list[tuple[int, int]]] = None,
-        unassigned_atoms: Optional[list[int]] = None,
-        matches: Optional[defaultdict[int, list[str]]] = None,
+        unassigned_bonds: list[tuple[int, int]] | None = None,
+        unassigned_atoms: list[int] | None = None,
+        matches: defaultdict[int, list[str]] | None = None,
     ):
         if omm_top is not None:
             self.omm_top = omm_top

--- a/openff/toolkit/utils/nagl_wrapper.py
+++ b/openff/toolkit/utils/nagl_wrapper.py
@@ -1,7 +1,7 @@
 import importlib
 import pathlib
 import warnings
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from openff.toolkit import Quantity, unit
 from openff.toolkit.utils.base_wrapper import ToolkitWrapper
@@ -62,12 +62,12 @@ class NAGLToolkitWrapper(ToolkitWrapper):
         self,
         molecule: "Molecule",
         partial_charge_method: str,
-        use_conformers: Optional[list["Quantity"]] = None,
+        use_conformers: list["Quantity"] | None = None,
         strict_n_conformers: bool = False,
         normalize_partial_charges: bool = True,
-        doi: Optional[str] = None,
-        file_hash: Optional[str] = None,
-        _cls: Optional[type["FrozenMolecule"]] = None,
+        doi: str | None = None,
+        file_hash: str | None = None,
+        _cls: type["FrozenMolecule"] | None = None,
     ):
         """
         Compute partial charges with NAGL and store in ``self.partial_charges``

--- a/openff/toolkit/utils/openeye_wrapper.py
+++ b/openff/toolkit/utils/openeye_wrapper.py
@@ -19,12 +19,11 @@ import tempfile
 import warnings
 from collections import defaultdict
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import numpy as np
 from cachetools import LRUCache, cached
 from openff.units.elements import SYMBOLS
-from typing_extensions import TypeAlias
 
 from openff.toolkit import Quantity, unit
 from openff.toolkit.utils.base_wrapper import (
@@ -103,10 +102,10 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
     )
     # This could belong to ToolkitWrapper, although it seems strange
     # to carry that data for open-source toolkits
-    _is_licensed: Optional[bool] = None
+    _is_licensed: bool | None = None
     # Only for OpenEye is there potentially a difference between
     # being available and installed
-    _is_installed: Optional[bool] = None
+    _is_installed: bool | None = None
     _license_functions: dict[str, str] = {
         "oechem": "OEChemIsLicensed",
         "oequacpac": "OEQuacPacIsLicensed",
@@ -458,7 +457,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
 
     def from_file(
         self,
-        file_path: Union[str, pathlib.Path],
+        file_path: str | pathlib.Path,
         file_format: str,
         allow_undefined_stereo: bool = False,
         _cls=None,
@@ -596,7 +595,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
     def to_file(
         self,
         molecule: "Molecule",
-        file_path: Union[str, pathlib.Path],
+        file_path: str | pathlib.Path,
         file_format: str,
     ):
         """
@@ -709,7 +708,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         self,
         oemolistream,
         allow_undefined_stereo: bool,
-        file_path: Optional[str] = None,
+        file_path: str | None = None,
         _cls=None,
     ):
         """
@@ -2094,7 +2093,7 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
         self,
         molecule: "Molecule",
         n_conformers: int = 1,
-        rms_cutoff: Optional[Quantity] = None,
+        rms_cutoff: Quantity | None = None,
         clear_existing: bool = True,
         make_carboxylic_acids_cis: bool = False,
     ):
@@ -2262,8 +2261,8 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
     def assign_partial_charges(
         self,
         molecule: "Molecule",
-        partial_charge_method: Optional[str] = None,
-        use_conformers: Optional[list[Quantity]] = None,
+        partial_charge_method: str | None = None,
+        use_conformers: list[Quantity] | None = None,
         strict_n_conformers: bool = False,
         normalize_partial_charges: bool = True,
         _cls=None,
@@ -2434,8 +2433,8 @@ class OpenEyeToolkitWrapper(ToolkitWrapper):
     def assign_fractional_bond_orders(
         self,
         molecule: "Molecule",
-        bond_order_model: Optional[str] = None,
-        use_conformers: Optional[list[Quantity]] = None,
+        bond_order_model: str | None = None,
+        use_conformers: list[Quantity] | None = None,
         _cls=None,
     ):
         """

--- a/openff/toolkit/utils/rdkit_wrapper.py
+++ b/openff/toolkit/utils/rdkit_wrapper.py
@@ -14,7 +14,7 @@ import pathlib
 import tempfile
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from cachetools import LRUCache, cached
@@ -289,7 +289,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         pdbfile,
         substructure_dictionary,
         coords_angstrom,
-        _custom_substructures: Optional[dict[str, list[str]]] = None,
+        _custom_substructures: dict[str, list[str]] | None = None,
     ):
         import json
 
@@ -1538,7 +1538,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         self,
         molecule: "Molecule",
         n_conformers: int = 1,
-        rms_cutoff: Optional[Quantity] = None,
+        rms_cutoff: Quantity | None = None,
         clear_existing: bool = True,
         _cls=None,
         make_carboxylic_acids_cis: bool = False,
@@ -1616,8 +1616,8 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
     def assign_partial_charges(
         self,
         molecule: "Molecule",
-        partial_charge_method: Optional[str] = None,
-        use_conformers: Optional[list[Quantity]] = None,
+        partial_charge_method: str | None = None,
+        use_conformers: list[Quantity] | None = None,
         strict_n_conformers: bool = False,
         normalize_partial_charges: bool = True,
         _cls=None,
@@ -1695,7 +1695,7 @@ class RDKitToolkitWrapper(base_wrapper.ToolkitWrapper):
         cls,
         molecule: "Molecule",
         conformer: Quantity,
-    ) -> tuple[bool, Optional[str]]:
+    ) -> tuple[bool, str | None]:
         """A function which checks if a particular conformer is known to be problematic
         when computing ELF partial charges.
 

--- a/openff/toolkit/utils/serialization.py
+++ b/openff/toolkit/utils/serialization.py
@@ -432,9 +432,9 @@ def _contains_bytes(val) -> bool:
         return False
     elif isinstance(val, bytes):
         return True
-    elif isinstance(val, (int, float, str, bool)):
+    elif isinstance(val, int | float | str | bool):
         return False
-    elif isinstance(val, (list, tuple)):
+    elif isinstance(val, list | tuple):
         return any([_contains_bytes(x) for x in val])
     elif isinstance(val, dict):
         return any([_contains_bytes(x) for x in val.values()])
@@ -455,7 +455,7 @@ def _prep_numpy_data_for_json(data: dict) -> dict:
             data[key] = _prep_numpy_data_for_json(val)
         if isinstance(val, bytes):
             data[key] = np.frombuffer(val, dtype=big_endian_float).tolist()
-        if isinstance(val, (list, tuple)):
+        if isinstance(val, list | tuple):
             for i, element in enumerate(val):
                 if isinstance(element, bytes):
                     # Handles case of list[np.array], like Molecule.conformers

--- a/openff/toolkit/utils/toolkit_registry.py
+++ b/openff/toolkit/utils/toolkit_registry.py
@@ -4,8 +4,8 @@ __all__ = ("ToolkitRegistry", "toolkit_registry_manager")
 
 import inspect
 import logging
+from collections.abc import Callable
 from contextlib import contextmanager
-from typing import Callable, Optional, Union
 
 from openff.toolkit.utils.ambertools_wrapper import AmberToolsToolkitWrapper
 from openff.toolkit.utils.base_wrapper import ToolkitWrapper
@@ -79,7 +79,7 @@ class ToolkitRegistry:
 
     def __init__(
         self,
-        toolkit_precedence: Optional[list[type[ToolkitWrapper]]] = None,
+        toolkit_precedence: list[type[ToolkitWrapper]] | None = None,
         exception_if_unavailable: bool = True,
         _register_imported_toolkit_wrappers: bool = False,
     ):
@@ -165,7 +165,7 @@ class ToolkitRegistry:
         self,
         method_name: str,
         *args,
-        raise_exception_types: Optional[list[type[Exception]]] = None,
+        raise_exception_types: list[type[Exception]] | None = None,
         **kwargs,
     ):
         """
@@ -284,7 +284,7 @@ class ToolkitRegistry:
 
     def register_toolkit(
         self,
-        toolkit_wrapper: Union[ToolkitWrapper, type[ToolkitWrapper]],
+        toolkit_wrapper: ToolkitWrapper | type[ToolkitWrapper],
         exception_if_unavailable: bool = True,
     ):
         """
@@ -458,7 +458,7 @@ class ToolkitRegistry:
 # Copied from https://github.com/openforcefield/openff-fragmenter/blob/4a290b866a8ed43eabcbd3231c62b01f0c6d7df6
 # /openff/fragmenter/utils.py#L97-L123
 @contextmanager
-def toolkit_registry_manager(toolkit_registry: Union[ToolkitRegistry, ToolkitWrapper]):
+def toolkit_registry_manager(toolkit_registry: ToolkitRegistry | ToolkitWrapper):
     """
     A context manager that temporarily changes the :py:data:`GLOBAL_TOOLKIT_REGISTRY`.
 

--- a/openff/toolkit/utils/utils.py
+++ b/openff/toolkit/utils/utils.py
@@ -27,7 +27,7 @@ import contextlib
 import functools
 import logging
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 import numpy as np
 import pint
@@ -192,7 +192,7 @@ def string_to_unit(unit_string) -> Unit:
 
 
 @functools.lru_cache
-def string_to_quantity(quantity_string: str) -> Union[int, float, Quantity]:
+def string_to_quantity(quantity_string: str) -> int | float | Quantity:
     """Attempt to parse a string into a ``Quantity``.
 
     Note that strings representing dimensionless floats or ints are returned as floats or ints, not
@@ -215,7 +215,7 @@ def string_to_quantity(quantity_string: str) -> Union[int, float, Quantity]:
 
     # TODO: Should intentionally unitless array-likes be Quantity objects
     #       or their raw representation?
-    if quantity.units == _DIMENSIONLESS and isinstance(quantity.m, (int, float)):
+    if quantity.units == _DIMENSIONLESS and isinstance(quantity.m, int | float):
         return quantity.m
     else:
         return quantity
@@ -299,12 +299,12 @@ def convert_all_quantities_to_string(
 @overload
 def convert_all_quantities_to_string(
     smirnoff_data: "Quantity",
-) -> Union[str, list[str], dict[str, Any]]: ...
+) -> str | list[str] | dict[str, Any]: ...
 
 
 def convert_all_quantities_to_string(
-    smirnoff_data: Union[dict, str, Quantity, list],
-) -> Union[str, dict[str, Any], list[str]]:
+    smirnoff_data: dict | str | Quantity | list,
+) -> str | dict[str, Any] | list[str]:
     """
     Traverses a SMIRNOFF data structure, attempting to convert all
     quantities into strings.
@@ -414,7 +414,7 @@ def serialize_numpy(np_array) -> tuple[bytes, tuple[int]]:
 
 
 def deserialize_numpy(
-    serialized_np: Union[bytes, list],
+    serialized_np: bytes | list,
     shape: tuple[int, ...],
 ) -> NDArray:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers=[
     'Programming Language :: Python :: 3',
 ]
 readme = "README.md"
+requires-python = ">=3.11"
 dynamic = ["version"]
 
 [tool.setuptools.packages]


### PR DESCRIPTION
The metadata of the Python project did not declare what Python version(s) are supported, at least the lower bound. This adds a one-liner into `pyproject.toml` to do just that. This will make Python-centric tooling and packaging more useful since this is where this information is supposed to live.

Some tooling is aware of this and, as a consequence, made some automated changes. I see mostly
* `Optional[Foo]` becomes `Foo | None`
  * https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional/
* `Union[Foo, Bar]` becomes `Foo | Bar`
* `isinstance(mylist, (list, tuple))` becomes `isinstance(mylist, list | tuple)`
  * https://docs.astral.sh/ruff/rules/non-pep604-isinstance/
* Some imports from `typing_extensions` are in the standard library from the minimum supported Python
  * https://docs.astral.sh/ruff/rules/deprecated-import/

I don't love all of these changes, but they're automatic and consistent.