### PR TITLE
[DNM] Add QCElemental py314 branch to env

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -47,3 +47,5 @@ dependencies:
   - nbval
   # No idea why this is necessary, see https://github.com/openforcefield/openff-toolkit/pull/1821
   - nomkl
+  - pip:
+    - git+https://github.com/loriab/QCElemental.git@py314


### PR DESCRIPTION
Added QCElemental package from GitHub to pip dependencies: git+https://github.com/loriab/QCElemental.git@py314

IGNORE THIS: I just need CI and I can't run it manually for some reason
