### PR TITLE
Update mixture simulation example

### DIFF
--- a/examples/SMIRNOFF_simulation/README.md
+++ b/examples/SMIRNOFF_simulation/README.md
@@ -1,3 +1,3 @@
-## Simulate a system parametrized with the Open Force Field Toolkit
+## Simulate a system parametrized with the OpenFF Toolkit
 
-The notebook `run_simulation.ipynb` shows how to use the Open Force Field Toolkit to create a parametrized `System` object that can be used to run a molecular dynamic simulation with OpenMM.
+The notebook `run_simulation.ipynb` shows how to use the OpenFF Toolkit to create a parametrized `openmm.System` object that can be used to run a molecular dynamic simulation with OpenMM.

--- a/examples/SMIRNOFF_simulation/run_simulation.ipynb
+++ b/examples/SMIRNOFF_simulation/run_simulation.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Mixture simulation with Sage: Ethanol and cyclohexane\n",
     "\n",
-    "This example shows how to use the Open Force Field Toolkit to create a parametrized `System` object that can be used to run a molecular dynamic simulation with OpenMM. If you want to run MD with a different engine, see the example in `examples/conversion_amber_gromacs/`."
+    "This example shows how to use the OpenFF Toolkit to create a parametrized `openmm.System` object that can be used to run a molecular dynamic simulation with OpenMM. If you want to run MD with a different engine, see the example in `examples/using_smirnoff_in_amber_or_gromacs/`."
    ]
   },
   {
@@ -94,33 +94,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now create the Open Force Field Toolkit `Topology` describing the system from an OpenMM `Topology` object. The OFF `Topology` include more information (supplied by the two `Molecule` objects) than the OpenMM `Topology` such as (optionally) partial charges and stereochemistry. In this example, partial charges are not explicitly given, and `ForceField` will assign AM1/BCC charges as specified by the \"Sage\" force field.\n",
+    "We now create the OpenFF `Topology` describing via loading the PDB file. The OpenFF `Topology` object includes more information (supplied by the two `Molecule` objects) than the OpenMM `Topology` such as (optionally) partial charges and stereochemistry. In this example, partial charges are not explicitly given, and `ForceField` will assign AM1-BCC charges as specified by the \"Sage\" force field.\n",
     "\n",
-    "Note that the Open Force Field Toolkit produces deterministic charges that do not depend on the input conformation of parameterized molecules. See the [FAQ](https://docs.openforcefield.org/projects/toolkit/en/stable/faq.html#the-partial-charges-generated-by-the-toolkit-dont-seem-to-depend-on-the-molecules-conformation-is-this-a-bug) for more information.\n",
-    "\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "    <b>Note on partial charges:</b> The full 1.0.0 release will implement support for the definition of semiempirical partial charge treatment directly into the SMIRNOFF force field file (for details, see https://openforcefield.github.io/standards/standards/smirnoff/#partial-charge-and-electrostatics-models). Moreover, it will be possible to import charges directly from sdf and mol2 files.\n",
-    "</div>"
+    "Note that the OpenFF Toolkit produces partial charges on the fly in a manner that does not depend on the molecules' stored conformers. See the [FAQ](https://docs.openforcefield.org/projects/toolkit/en/stable/faq.html#the-partial-charges-generated-by-the-toolkit-dont-seem-to-depend-on-the-molecules-conformation-is-this-a-bug) for more information."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b21376e03b3c481c9d943d2f427c082f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openff.toolkit import ForceField, Topology\n",
     "\n",
@@ -198,7 +181,7 @@
      "output_type": "stream",
      "text": [
       "Starting simulation\n",
-      "Elapsed time 1.19 seconds\n",
+      "Elapsed time 0.23 seconds\n",
       "Done!\n"
      ]
     }
@@ -236,16 +219,16 @@
      "output_type": "stream",
      "text": [
       "#\"Step\",\"Potential Energy (kJ/mole)\",\"Temperature (K)\",\"Density (g/mL)\"\n",
-      "100,74.374459717961,153.8639730810106,0.006671086812409914\n",
-      "200,67.18465564081257,225.04871999306042,0.006671086812409914\n",
-      "300,73.153268311711,216.02183682738016,0.006671086812409914\n",
-      "400,80.31836840936725,207.7937447329963,0.006671086812409914\n",
-      "500,80.12940356561725,188.36565243783872,0.006671086812409914\n",
-      "600,67.47083422967975,170.97481857480136,0.006671086812409914\n",
-      "700,84.53037402460163,191.9952731085917,0.006671086812409914\n",
-      "800,83.9705290538985,213.94618798329284,0.006671086812409914\n",
-      "900,101.1868376476485,248.17766215167603,0.006671086812409914\n",
-      "1000,82.79697558710163,252.8156596432481,0.006671086812409914\n"
+      "100,85.41116764057628,150.81213878105126,0.006671086812409914\n",
+      "200,66.39389745179764,273.6937808130675,0.006671086812409914\n",
+      "300,62.31512702662698,234.4267606166383,0.006671086812409914\n",
+      "400,77.0996799844896,215.26077039218976,0.006671086812409914\n",
+      "500,78.41016953472248,336.9803724317831,0.006671086812409914\n",
+      "600,97.52128887210242,272.5884641183809,0.006671086812409914\n",
+      "700,86.1867948326861,367.6193645908188,0.006671086812409914\n",
+      "800,81.5534011650478,371.79969881832847,0.006671086812409914\n",
+      "900,98.4014650214111,323.78319023653546,0.006671086812409914\n",
+      "1000,83.24642916802517,335.38104765850983,0.006671086812409914\n"
      ]
     }
    ],
@@ -264,7 +247,7 @@
  "metadata": {
   "category": "parametrization_evaluation",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "openff-toolkit-test",
    "language": "python",
    "name": "python3"
   },
@@ -278,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.11.14"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Closes #2099

- [x] No longer says OpenMM is used for loading topologies
- [x] Drops claims about deterministic AM1-BCC charges
- [x] Drops claims about loading charges from SDF/mol2 in 1.0 and/or something about semiempirical charges
- [x] Try to make the difference between OpenFF and OpenMM toolkit `Topology` objects
- [x] Consolidate `Open Force Field Toolkit` -> `OpenFF Toolkit`
- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
