### PR TITLE
update citation instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ The toolkit currently covers two main areas we have committed to stably maintain
 
 For instructions on how to cite OpenFF tools or force fields, see our [website](https://openforcefield.org/science/how-to-cite/)
 
-Please cite the OpenFF Toolkit using the Zenodo record of the [latest release](https://zenodo.org/records/13886754/latest) or the version that was used. 
-
 ## Installation
 
 Detailed installation instructions can be found [here](https://open-forcefield-toolkit.readthedocs.io/en/stable/installation.html).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The toolkit currently covers two main areas we have committed to stably maintain
 
 ## How to cite
 
+For instructions on how to cite OpenFF tools or force fields, see our [website](https://openforcefield.org/science/how-to-cite/)
+
 Please cite the OpenFF Toolkit using the Zenodo record of the [latest release](https://zenodo.org/records/13886754/latest) or the version that was used. 
 
 ## Installation


### PR DESCRIPTION
As discussed in https://github.com/openforcefield/openforcefield.org/issues/513, the readme for this repo should point to the [How To Cite](https://openforcefield.org/science/how-to-cite/) page on our website.