### PR TITLE
Improve `Molecule.remap` docstring

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -4854,7 +4854,7 @@ class FrozenMolecule(Serializable):
             )
 
     def remap(
-        self,
+        self: FM,
         mapping_dict: dict[int, int],
         current_to_new: bool = True,
         partial: bool = False,

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -4858,9 +4858,9 @@ class FrozenMolecule(Serializable):
         mapping_dict: dict[int, int],
         current_to_new: bool = True,
         partial: bool = False,
-    ):
+    ) -> FM:
         """
-        Reorder the atoms in the molecule according to the given mapping dict.
+        Return a copy of this molecule with the atoms reordered according to the given mapping dict.
 
         The mapping dict must be a dictionary mapping atom indices to atom
         indices. Each atom index must be an integer in the half-open interval
@@ -4876,10 +4876,10 @@ class FrozenMolecule(Serializable):
         ``current_to_new`` argument.
 
         The keys of the ``self.properties["atom_map"]`` property are updated for
-        the new ordering. Other values of the properties dictionary are
+        the new ordering. Other values of the ``.properties`` dictionary are
         transferred unchanged.
 
-        .. warning :: This API is experimental and subject to change.
+        Partial charges and conformers are remapped according to the mapping dict.
 
         Parameters
         ----------


### PR DESCRIPTION
When working with `Molecule.remap` today, I came across a few behaviors which weren't documented and I had to discover through trial-and-error.

* This method returns a new object; I thought it modified in-place
* Conformers are updated - I don't need to shuffle them myself
* Same with partial charges
* This API doesn't seem particularly experimental, or at least not more unstable than I'd expect from a 0.x package (#2082)

I can move this into an issue but it's minor and, I hope, self-explanatory.

- [ ] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [x] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
