### PR TITLE
fix: ensure to_file() output ends with trailing newline

### DIFF
--- a/openff/toolkit/typing/engines/smirnoff/io.py
+++ b/openff/toolkit/typing/engines/smirnoff/io.py
@@ -167,7 +167,7 @@ class XMLParameterIOHandler(ParameterIOHandler):
         """
         xml_string = self.to_string(smirnoff_data)
         with open(file_path, "w") as of:
-            of.write(xml_string)
+            of.write(xml_string + "\n")
 
     def to_string(self, smirnoff_data: dict) -> str:
         """


### PR DESCRIPTION
POSIX-conformant text files should end with a newline character.
Without it, concatenating two OFFXML files with `cat` squishes the
closing tag of the first file with the opening tag of the second.

Add a trailing newline to the XML output written by `to_file()`.

Fixes: #1761