### PR TITLE
Test without `typing_extensions` explicitly declared

### DIFF
--- a/devtools/conda-envs/openeye-examples.yaml
+++ b/devtools/conda-envs/openeye-examples.yaml
@@ -20,7 +20,6 @@ dependencies:
   - openff-interchange-base >=0.5
   - openff-nagl-base >=0.4.0
   - openff-nagl-models >=0.3.0
-  - typing_extensions
   - nglview
     # Toolkit-specific
   - openeye-toolkits

--- a/devtools/conda-envs/openeye.yaml
+++ b/devtools/conda-envs/openeye.yaml
@@ -20,7 +20,6 @@ dependencies:
   - openff-interchange-base >=0.5
   - openff-nagl-base =0.4.0
   - openff-nagl-models >=0.3.0
-  - typing_extensions
     # Toolkit-specific
   - openeye-toolkits
     # Test-only/optional/dev/typing
@@ -39,7 +38,6 @@ dependencies:
   - qcengine
   - mdtraj
   - nglview
-  - typing_extensions
   - pip:
     - mypy ==2
     - types-setuptools

--- a/devtools/conda-envs/rdkit-examples.yaml
+++ b/devtools/conda-envs/rdkit-examples.yaml
@@ -19,7 +19,6 @@ dependencies:
   - openff-interchange-base >=0.5
   - openff-nagl-base >=0.4.0
   - openff-nagl-models >=0.3.0
-  - typing_extensions
   - nglview
     # Toolkit-specific
   - ambertools

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -19,7 +19,6 @@ dependencies:
   - openff-interchange-base >=0.5
   - openff-nagl-base >=0.4.0
   - openff-nagl-models >=0.3.0
-  - typing_extensions
     # Toolkit-specific
   - ambertools >=22
     # https://github.com/rdkit/rdkit/issues/7221 and https://github.com/rdkit/rdkit/issues/7583

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -20,7 +20,6 @@ dependencies:
   - openff-interchange-base >=0.5
   - openff-nagl-base >=0.4.0
   - openff-nagl-models >=0.3.0
-  - typing_extensions
     # Toolkit-specific
   - ambertools >=22
     # rdkit 2024.03.6 and 2024.09.1 packages fail when run natively on osx-arm64 macs


### PR DESCRIPTION
See https://github.com/conda-forge/openff-toolkit-feedstock/issues/126

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [ ] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
