### PR TITLE
Update deployment testing envs

### DIFF
--- a/devtools/conda-envs/conda.yaml
+++ b/devtools/conda-envs/conda.yaml
@@ -4,9 +4,8 @@ channels:
 dependencies:
     # Base depends
   - openff-toolkit-examples
+  - ambertools
     # Tests
   - pytest=7.4
   - pytest-rerunfailures
   - nbval
-  # https://github.com/openforcefield/openff-toolkit/issues/2150
-  - xmltodict <=1.0.2

--- a/devtools/conda-envs/conda.yaml
+++ b/devtools/conda-envs/conda.yaml
@@ -9,3 +9,4 @@ dependencies:
   - pytest=7.4
   - pytest-rerunfailures
   - nbval
+  

--- a/devtools/conda-envs/conda_oe.yaml
+++ b/devtools/conda-envs/conda_oe.yaml
@@ -5,10 +5,9 @@ channels:
 dependencies:
     # Base depends
   - openff-toolkit-examples
+  - ambertools
     # Tests
   - openeye-toolkits
   - pytest=7.4
   - pytest-rerunfailures
   - nbval
-  # https://github.com/openforcefield/openff-toolkit/issues/2150
-  - xmltodict <=1.0.2


### PR DESCRIPTION
This gets us back to the "sporadically failing" state of deployment tests
- [x] Manually add ambertools to deployment testing envs now that it's not brought in by openmmforcefields
