### PR TITLE
Ensure to_file() writes files ending with newline (fixes #1761)

### DIFF
--- a/openff/toolkit/typing/engines/smirnoff/io.py
+++ b/openff/toolkit/typing/engines/smirnoff/io.py
@@ -166,6 +166,9 @@ class XMLParameterIOHandler(ParameterIOHandler):
 
         """
         xml_string = self.to_string(smirnoff_data)
+        # Ensure POSIX compliance: files must end with a newline (fixes #1761)
+        if not xml_string.endswith("\n"):
+            xml_string += "\n"
         with open(file_path, "w") as of:
             of.write(xml_string)
 


### PR DESCRIPTION
## Problem

Fixes #1761.

`ForceField.to_file()` writes OFFXML files without a trailing newline character,
violating the POSIX requirement that text files end with `\n`. This causes common
tools like `cat` to concatenate files without a separator:

```bash
$ cat x.offxml x.offxml
<?xml version="1.0" ...><SMIRNOFF ...></SMIRNOFF><?xml version="1.0" ...
#                                                  ^^^^ no separator!
```

## Fix

In `SMIRNOFFXML.to_file()`, append `\n` if the XML string does not already end
with one, before writing to disk:

```python
if not xml_string.endswith("\n"):
    xml_string += "\n"
```

This is the minimal, non-breaking fix. The change affects only the file output;
`to_string()` is unchanged so downstream string processing is unaffected.
