### PR TITLE
Add __delete__ to ParameterAttribute to complete descriptor protocol (fixes #1680)

### DIFF
--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -374,6 +374,26 @@ class ParameterAttribute:
         value = self._convert_and_validate(instance, value)
         setattr(instance, self._name, value)
 
+    def __delete__(self, instance):
+        """Reset this attribute to its default, or remove it if already at default.
+
+        After deletion, accessing the attribute will return its default value (if
+        one was specified) or raise ``AttributeError`` for required attributes.
+        This completes the Python descriptor protocol alongside ``__get__`` and
+        ``__set__`` (fixes #1680).
+        """
+        try:
+            delattr(instance, self._name)
+        except AttributeError:
+            # The attribute was never explicitly set. If there is no default,
+            # raise AttributeError consistent with __get__ behavior.
+            if self.default is ParameterAttribute.UNDEFINED:
+                raise AttributeError(
+                    f"'{type(instance).__name__}' object attribute"
+                    f" '{self.name}' has not been set"
+                ) from None
+            # Otherwise the attribute is already at its default — succeed silently.
+
     def converter(self, converter):
         """Create a new ParameterAttribute with an associated converter.
 

--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -389,8 +389,7 @@ class ParameterAttribute:
             # raise AttributeError consistent with __get__ behavior.
             if self.default is ParameterAttribute.UNDEFINED:
                 raise AttributeError(
-                    f"'{type(instance).__name__}' object attribute"
-                    f" '{self.name}' has not been set"
+                    f"'{type(instance).__name__}' object attribute '{self.name}' has not been set"
                 ) from None
             # Otherwise the attribute is already at its default — succeed silently.
 


### PR DESCRIPTION
## Problem

Fixes #1680.

`ParameterAttribute` implements `__get__` and `__set__` as a Python
[descriptor](https://docs.python.org/3/howto/descriptor.html), but does not
implement `__delete__`. This causes `del` to fail:

```python
handler = BondHandler(version=0.4)
del handler.fractional_bondorder_method
# AttributeError: __delete__
```

## Fix

Add `__delete__` to complete the descriptor protocol:

```python
def __delete__(self, instance):
    try:
        delattr(instance, self._name)   # remove instance._attr_name
    except AttributeError:
        if self.default is ParameterAttribute.UNDEFINED:
            raise AttributeError(...)   # required attr, never set
        # optional attr already at default — succeed silently
```

After deletion, `__get__` naturally returns the `default` (if any) or raises
`AttributeError` for UNDEFINED required attributes — consistent with Python's
standard attribute deletion semantics.

## Verification

```python
handler = BondHandler(version=0.4)

# Delete an optional attribute (has a default)
del handler.fractional_bondorder_method
# → no error; subsequent access returns the default

# Delete a required attribute (UNDEFINED)
del handler.length  # if length has no default
# → AttributeError: '...' object attribute 'length' has not been set
```
