### PR TITLE
Return NotImplemented from FrozenMolecule.__eq__ for non-Molecule comparisons (fixes #1517)

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -1387,6 +1387,8 @@ class FrozenMolecule(Serializable):
         """
         # updated to use the new isomorphic checking method, with full matching
         # TODO the doc string did not match the previous function what matching should this method do?
+        if not isinstance(other, FrozenMolecule):
+            return NotImplemented
         return Molecule.are_isomorphic(self, other, return_atom_map=False)[0]
 
     def __deepcopy__(self, memo):


### PR DESCRIPTION
## Problem

Fixes #1517.

`list.index()` raises `TypeError` when called on a Python list of `Molecule`
objects because `FrozenMolecule.__eq__` does not handle comparison with
non-Molecule types:

```python
molecules = Molecule.from_file("ligands.sdf")   # returns List[Molecule]
molecules.index("some_name")
# TypeError from FrozenMolecule.__eq__ when comparing Molecule to str
```

When Python evaluates `molecule == "some_name"`, it calls `Molecule.__eq__("some_name")`,
which tries to do isomorphism checking on a string and raises `TypeError`.

## Fix

Return `NotImplemented` for non-`FrozenMolecule` types at the start of `__eq__`.
Python will then fall through to the reflected operation (`"some_name".__eq__(molecule)`),
which returns `False`, so `list.index()` behaves as expected:

```python
def __eq__(self, other):
    if not isinstance(other, FrozenMolecule):
        return NotImplemented  # ← new
    ...  # existing isomorphism checking
```

This follows standard Python `__eq__` best practice for typed classes.

## Behavior after fix

```python
mol = Molecule.from_smiles("CC")
mol == "some_string"    # False (via NotImplemented → reflected eq)
mol == 42               # False
[mol].index("CC")       # ValueError: 'CC' is not in list  (correct)
[mol, mol].index(mol)   # 0 (still works for Molecule vs Molecule)
```
