### PR TITLE
Improve DuplicateParameterError message for VirtualSite parameters (fixes #2157)

### DIFF
--- a/openff/toolkit/typing/engines/smirnoff/parameters.py
+++ b/openff/toolkit/typing/engines/smirnoff/parameters.py
@@ -2009,7 +2009,12 @@ class ParameterHandler(_ParameterAttributeHandler):
 
         if not allow_duplicate_smirks:
             if self._index_of_parameter(new_parameter) is not None:
-                msg = f"A parameter SMIRKS pattern {new_parameter.smirks} already exists."
+                # Build an informative message. For VirtualSite parameters, uniqueness
+                # is determined by (type, SMIRKS, name), so include the name if present.
+                param_id = f"SMIRKS pattern {new_parameter.smirks!r}"
+                if hasattr(new_parameter, "name") and new_parameter.name is not None:
+                    param_id += f" with name {new_parameter.name!r}"
+                msg = f"A parameter with {param_id} already exists."
                 raise DuplicateParameterError(msg)
 
         before_index, after_index = None, None


### PR DESCRIPTION
## Problem

Fixes #2157.

`ParameterHandler.add_parameter` raises a `DuplicateParameterError` with the message:

```
A parameter SMIRKS pattern '[#1:1]-[#8X2H2+0:2]-[#1:3]' already exists.
```

For most parameter handlers (bonds, angles, torsions), SMIRKS alone identifies
a duplicate. However, `VirtualSiteHandler._index_of_parameter` uses a **three-part
key** — `(type, smirks, name)` — so the same SMIRKS is allowed with different names.
When a duplicate **is** detected for a VirtualSite, the error message only mentions
SMIRKS and omits the `name` that also contributed to the match, leaving users
confused about what uniqueness constraint was violated.

## Fix

Include `name` in the error message when the parameter type has a `name` attribute:

```python
# Before
msg = f"A parameter SMIRKS pattern {new_parameter.smirks} already exists."

# After
param_id = f"SMIRKS pattern {new_parameter.smirks!r}"
if hasattr(new_parameter, "name") and new_parameter.name is not None:
    param_id += f" with name {new_parameter.name!r}"
msg = f"A parameter with {param_id} already exists."
```

For non-VirtualSite parameters, the message is equivalent to before (name is absent).
For VirtualSite parameters, the new message reads:

```
A parameter with SMIRKS pattern '[#1:1]-[#8X2H2+0:2]-[#1:3]' with name 'LP' already exists.
```
