### PR TITLE
Add input validation to Atom.stereochemistry setter (fixes #2084)

### DIFF
--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -443,11 +443,9 @@ class Atom(Particle):
         # there should be some input validation, if we can agree on what possible values this might take.
         # currently (July 2025) toolkit wrappers only deal with "CW", "CCW", or None.
         # for more, see https://github.com/openforcefield/openff-toolkit/issues/2084
-        _VALID_STEREOCHEMISTRY = {None, 'S', 'R'}
+        _VALID_STEREOCHEMISTRY = {None, "S", "R"}
         if value not in _VALID_STEREOCHEMISTRY:
-            raise ValueError(
-                f"stereochemistry must be None, 'S', or 'R', got {value!r}"
-            )
+            raise ValueError(f"stereochemistry must be None, 'S', or 'R', got {value!r}")
         self._stereochemistry = value
 
     @property

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -443,6 +443,11 @@ class Atom(Particle):
         # there should be some input validation, if we can agree on what possible values this might take.
         # currently (July 2025) toolkit wrappers only deal with "CW", "CCW", or None.
         # for more, see https://github.com/openforcefield/openff-toolkit/issues/2084
+        _VALID_STEREOCHEMISTRY = {None, 'S', 'R'}
+        if value not in _VALID_STEREOCHEMISTRY:
+            raise ValueError(
+                f"stereochemistry must be None, 'S', or 'R', got {value!r}"
+            )
         self._stereochemistry = value
 
     @property


### PR DESCRIPTION
## Problem

Fixes #2084.

`Atom.stereochemistry` accepts any value without validation:

```python
water.atom(2).stereochemistry = "The Mythical California Zephyr"
water.atom(2).stereochemistry  # → 'The Mythical California Zephyr'
```

The only valid values are `None`, `'S'`, and `'R'`.

## Fix

Add a `ValueError` for invalid inputs at the start of the setter:

```python
_VALID_STEREOCHEMISTRY = {None, 'S', 'R'}
if value not in _VALID_STEREOCHEMISTRY:
    raise ValueError(
        f"stereochemistry must be None, 'S', or 'R', got {value!r}"
    )
```

## After fix

```python
water.atom(2).stereochemistry = "invalid"
# ValueError: stereochemistry must be None, 'S', or 'R', got 'invalid'

water.atom(2).stereochemistry = "R"  # still works
water.atom(2).stereochemistry = None  # still works
```
