### PR TITLE
More gently fail if AmberTools provenance fails

### DIFF
--- a/devtools/conda-envs/conda.yaml
+++ b/devtools/conda-envs/conda.yaml
@@ -9,5 +9,6 @@ dependencies:
   - pytest=7.4
   - pytest-rerunfailures
   - pytest-timeout
+  - pytest-mock
   - nbval
   

--- a/devtools/conda-envs/conda_oe.yaml
+++ b/devtools/conda-envs/conda_oe.yaml
@@ -11,4 +11,5 @@ dependencies:
   - pytest=7.4
   - pytest-rerunfailures
   - pytest-timeout
+  - pytest-mock
   - nbval

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -31,6 +31,7 @@ dependencies:
   - pytest-xdist
   - pytest-rerunfailures
   - pytest-timeout
+  - pytest-mock
   - pyyaml
   - toml
   - bson

--- a/devtools/conda-envs/test_env_no_openeye.yaml
+++ b/devtools/conda-envs/test_env_no_openeye.yaml
@@ -28,6 +28,7 @@ dependencies:
   - pytest-xdist
   - pytest-rerunfailures
   - pytest-timeout
+  - pytest-mock
   - pyyaml
   - toml
   - bson

--- a/openff/toolkit/_tests/test_toolkits.py
+++ b/openff/toolkit/_tests/test_toolkits.py
@@ -3762,7 +3762,7 @@ class TestAmberToolsToolkitWrapper:
         assert with_oe == pytest.approx(without_oe, abs=1e-5)
 
     def test_ambertools_provenance(self):
-        version = AmberToolsToolkitWrapper.toolkit_version
+        version = AmberToolsToolkitWrapper().toolkit_version
 
         assert version not in (None, "None", "Unknown")
 
@@ -3779,7 +3779,7 @@ class TestAmberToolsToolkitWrapper:
             side_effect=exception_class(),
         )
 
-        version = AmberToolsToolkitWrapper.toolkit_version
+        version = AmberToolsToolkitWrapper().toolkit_version
 
         assert version == "Unknown"
 

--- a/openff/toolkit/_tests/test_toolkits.py
+++ b/openff/toolkit/_tests/test_toolkits.py
@@ -3783,6 +3783,16 @@ class TestAmberToolsToolkitWrapper:
 
         assert version == "Unknown"
 
+    def teest_ambertools_provenance_non_version(self, mocker):
+        mocker.patch(
+            "openff.utilities.provenance.get_ambertools_version",
+            return_value=None,
+        )
+
+        version = AmberToolsToolkitWrapper().toolkit_version
+
+        assert version == "Unknown"
+
 
 class TestBuiltInToolkitWrapper:
     """Test the BuiltInToolkitWrapper"""

--- a/openff/toolkit/_tests/test_toolkits.py
+++ b/openff/toolkit/_tests/test_toolkits.py
@@ -11,6 +11,7 @@ from tempfile import NamedTemporaryFile
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal
+from packaging.version import Version
 
 from openff.toolkit import Quantity, unit
 from openff.toolkit._tests.create_molecules import (
@@ -3759,6 +3760,28 @@ class TestAmberToolsToolkitWrapper:
         GLOBAL_TOOLKIT_REGISTRY.register_toolkit(OpenEyeToolkitWrapper)
 
         assert with_oe == pytest.approx(without_oe, abs=1e-5)
+
+    def test_ambertools_provenance(self):
+        version = AmberToolsToolkitWrapper.toolkit_version
+
+        assert version not in (None, "None", "Unknown")
+
+        # just make sure it can be parsed like a version number
+        Version(version)
+
+    @pytest.mark.parametrize(
+        "exception_class",
+        [TypeError, ImportError],
+    )
+    def test_ambertools_provenance_fallback(self, mocker, exception_class):
+        mocker.patch(
+            "openff.utilities.provenance.get_ambertools_version",
+            side_effect=exception_class(),
+        )
+
+        version = AmberToolsToolkitWrapper.toolkit_version
+
+        assert version == "Unknown"
 
 
 class TestBuiltInToolkitWrapper:

--- a/openff/toolkit/utils/ambertools_wrapper.py
+++ b/openff/toolkit/utils/ambertools_wrapper.py
@@ -74,9 +74,12 @@ class AmberToolsToolkitWrapper(base_wrapper.ToolkitWrapper):
 
     @functools.cached_property
     def _toolkit_version(self):
-        from openff.utilities.provenance import get_ambertools_version
+        try:
+           from openff.utilities.provenance import get_ambertools_version
 
-        return get_ambertools_version()
+           return get_ambertools_version()
+        except Exception:
+            return 'Unknown'
 
     @staticmethod
     def is_available() -> bool:

--- a/openff/toolkit/utils/ambertools_wrapper.py
+++ b/openff/toolkit/utils/ambertools_wrapper.py
@@ -85,6 +85,9 @@ class AmberToolsToolkitWrapper(base_wrapper.ToolkitWrapper):
         ):
             ambertools_version = "Unknown"
 
+        if ambertools_version is None:
+            ambertools_version = "Unknown"
+
         return ambertools_version
 
     @staticmethod

--- a/openff/toolkit/utils/ambertools_wrapper.py
+++ b/openff/toolkit/utils/ambertools_wrapper.py
@@ -74,12 +74,18 @@ class AmberToolsToolkitWrapper(base_wrapper.ToolkitWrapper):
 
     @functools.cached_property
     def _toolkit_version(self):
+        # See https://github.com/openforcefield/openff-bespokefit/pull/440
         try:
-           from openff.utilities.provenance import get_ambertools_version
+            from openff.utilities.provenance import get_ambertools_version
 
-           return get_ambertools_version()
-        except Exception:
-            return 'Unknown'
+            ambertools_version = get_ambertools_version()
+        except (
+            ImportError,  # any number of failures
+            TypeError,  # https://github.com/openforcefield/openff-utilities/issues/156
+        ):
+            ambertools_version = "Unknown"
+
+        return ambertools_version
 
     @staticmethod
     def is_available() -> bool:


### PR DESCRIPTION
See https://github.com/openforcefield/openff-bespokefit/issues/438#issuecomment-5320725045 for parallel context, though this is a standalone change