### PR TITLE
Fix some Pydantic V2 deprecations in tests

### DIFF
--- a/devtools/conda-envs/examples.yaml
+++ b/devtools/conda-envs/examples.yaml
@@ -31,6 +31,7 @@ dependencies:
   - toml
   - bson
   - msgpack-python
+  - pydantic =2
   - qcelemental
   - qcportal >=0.50
   - qcengine

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -35,7 +35,7 @@ dependencies:
   - toml
   - bson
   - msgpack-python
-  - pydantic
+  - pydantic =2
   - qcelemental
   - qcportal >=0.50
   - qcengine

--- a/devtools/conda-envs/test_env_no_openeye.yaml
+++ b/devtools/conda-envs/test_env_no_openeye.yaml
@@ -32,7 +32,7 @@ dependencies:
   - toml
   - bson
   - msgpack-python
-  - pydantic
+  - pydantic =2
   - qcelemental
   - qcportal >=0.50
   - qcengine

--- a/examples/QCArchive_interface/QCarchive_interface.ipynb
+++ b/examples/QCArchive_interface/QCarchive_interface.ipynb
@@ -562,7 +562,7 @@
     }
    ],
    "source": [
-    "entry.dict()"
+    "entry.model_dump()"
    ]
   },
   {
@@ -590,7 +590,7 @@
     "molecule_from_entry = Molecule.from_qcschema(entry)\n",
     "\n",
     "# we could have also used the dictionary representation of the object\n",
-    "molecule_from_dict = Molecule.from_qcschema(entry.dict())\n",
+    "molecule_from_dict = Molecule.from_qcschema(entry.model_dump())\n",
     "\n",
     "assert molecule_from_entry == molecule_from_dict\n",
     "\n",

--- a/openff/toolkit/_tests/test_molecule.py
+++ b/openff/toolkit/_tests/test_molecule.py
@@ -3296,7 +3296,7 @@ class TestQCArchiveInterface:
             "Molecule roundtrip to/from_qcschema failed",
         )
 
-        mol_dict = off_qcschema.dict()
+        mol_dict = off_qcschema.model_dump()
         del mol_dict["extras"]["canonical_isomeric_explicit_hydrogen_mapped_smiles"]
         del mol_dict["identifiers"]["canonical_isomeric_explicit_hydrogen_mapped_smiles"]
         with pytest.raises(MissingCMILESError):

--- a/openff/toolkit/topology/molecule.py
+++ b/openff/toolkit/topology/molecule.py
@@ -4705,7 +4705,7 @@ class FrozenMolecule(Serializable):
         # Process input as dict; convert if necessary
         if not isinstance(qca_object, dict):
             try:
-                qca_object = qca_object.dict()
+                qca_object = qca_object.model_dump()
             except AttributeError:
                 raise AttributeError(
                     f"The input object (type {type(qca_object)=} "


### PR DESCRIPTION
Fixes #2233

I couldn't find any other usages such as `.json()`. When I run tests locally, no Pydantic-related deprecation warnings are thrown

This forces the toolkit to use the V2 package at installation time, but that's already required to use Interchange 0.4.0 (released November 2024) or newer

- [x] Tag issue being addressed
- [ ] Add [tests](https://github.com/openforcefield/openff-toolkit/tree/main/openff/toolkit/_tests)
- [ ] Update docstrings/[documentation](https://github.com/openforcefield/openff-toolkit/tree/main/docs), if applicable
- [x] [Lint](https://docs.openforcefield.org/projects/toolkit/en/stable/users/developing.html#style-guide) codebase
- [ ] Update [changelog](https://github.com/openforcefield/openff-toolkit/blob/main/docs/releasehistory.md)
